### PR TITLE
[Bugfix] resolve missing confirmation data in control panel

### DIFF
--- a/src/functions/ads_fns.php
+++ b/src/functions/ads_fns.php
@@ -6,8 +6,8 @@ function add_ad($name, $start_date, $end_date, $pic_url, $web_url, $priority) {
   $web_url = mysqli_real_escape_string(open_db(), $web_url);
 
   $insert = "INSERT INTO ads VALUES (id, '".$name ."', '".$start_date. "', '". $end_date ."', '". $pic_url ."', '". $web_url ."', '". $priority ."', 'n')";
-
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);
 
   if (!$result) {
     echo $insert ."<br>";
@@ -17,7 +17,7 @@ function add_ad($name, $start_date, $end_date, $pic_url, $web_url, $priority) {
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Ad for ". $name. " has been saved</h3>".
        "<hr width=75%>";
-  display_ad(get_ad(mysqli_insert_id(open_db())));
+  display_ad(get_ad(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/cdotw_fns.php
+++ b/src/functions/cdotw_fns.php
@@ -11,18 +11,23 @@ function add_cdotw($artist, $title, $label, $review, $cd_pic_url, $band, $review
   $date = mysqli_real_escape_string(open_db(), $date);	
 
   $insert = "INSERT INTO cdotw VALUES (id, '".$artist ."', '".$title ."', '".$label ."', '".$review ."', '".$cd_pic_url ."', '".$band ."', '".$reviewer ."', '".$date ."', 'no')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);
+
 
   if (!$result) {
     echo $insert ."<br>";
     die('Error Inserting into Database.');
   }
 
-  echo "<div class=\"center\"><h1>Success!</h1>".
+    echo "<div class=\"center\"><h1>Success!</h1>".
     "<h3>New review for <span class=\"success\">". $artist. " - ". $title. "</span> has been saved</h3>".
     "<hr width=75%>";
-    display_cdotw(get_cdotw(mysqli_insert_id(open_db())));
+    display_cdotw(get_cdotw(mysqli_insert_id($link)));
     echo "</div>";
+  
+
+
 }
 
 function cdotw($id){

--- a/src/functions/concert_fns.php
+++ b/src/functions/concert_fns.php
@@ -13,7 +13,8 @@ function add_concert($date, $artist, $band_pic_url, $band_url, $venue, $ticketin
     $featured = "No";
 
   $insert = "INSERT INTO concerts VALUES (id, '".$date ."', '".$artist. "', '".$band_pic_url. "', '".$band_url. "', '". $venue ."', '". $ticketinfo ."', '". $ticketurl ."', '". $featured ."', 'n')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);
 
   if (!$result) {
     echo $insert ."<br>";
@@ -23,7 +24,7 @@ function add_concert($date, $artist, $band_pic_url, $band_url, $venue, $ticketin
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Concert with ". $artist. " at ". $venue ." has been saved</h3>".
        "<hr width=75%>";
-  display_concert(get_concert(mysqli_insert_id(open_db())));
+  display_concert(get_concert(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/custom_text_fns.php
+++ b/src/functions/custom_text_fns.php
@@ -4,7 +4,8 @@ function add_custom_text($title, $html) {
   $permalink = create_permalink($title);
 
   $insert = "INSERT INTO custom_texts VALUES (id, '".$title ."', '".$permalink. "', '".$html. "', 'active')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -14,7 +15,7 @@ function add_custom_text($title, $html) {
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Custom Text has been saved</h3>".
        "<hr width=75%>";
-  display_custom_text(get_custom_text(mysqli_insert_id(open_db())));
+  display_custom_text(get_custom_text(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/deejay_fns.php
+++ b/src/functions/deejay_fns.php
@@ -27,7 +27,8 @@ function add_deejay($name, $show, $email, $external_connect_text, $external_conn
   $pic = mysqli_real_escape_string(open_db(), $pic);
 
   $insert = "INSERT INTO deejays VALUES (id, '".$name ."', '".$show. "', '".$email. "', '".$external_connect_text. "', '". $external_connect_url ."', '". $pic ."', '1', 'no')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -37,7 +38,7 @@ function add_deejay($name, $show, $email, $external_connect_text, $external_conn
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Deejay, ". $name. ", has been saved</h3>".
        "<hr width=75%>";
-  display_deejay(get_deejay(mysqli_insert_id(open_db())));
+  display_deejay(get_deejay(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/image_fns.php
+++ b/src/functions/image_fns.php
@@ -2,7 +2,8 @@
 
 function add_image($file_name) {
   $insert = "INSERT INTO images VALUES (id, '".$file_name ."')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";

--- a/src/functions/mrm_fns.php
+++ b/src/functions/mrm_fns.php
@@ -10,7 +10,8 @@ function add_mrm_band($name, $url, $pic_url, $placement, $seed, $abbr, $sponsor)
   $sponsor = mysqli_real_escape_string(open_db(), $sponsor);
 
   $insert = "INSERT INTO mrm_bands VALUES (id, '".$name ."', '".$url. "', '".$pic_url. "', '".$placement. "', '".$seed. "', '".$abbr. "','".$sponsor. "')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -20,7 +21,7 @@ function add_mrm_band($name, $url, $pic_url, $placement, $seed, $abbr, $sponsor)
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New MRM band, ". $name. ", has been saved</h3>".
        "<hr width=75%>";
-  display_mrm_band(get_mrm_band(mysqli_insert_id(open_db())));
+  display_mrm_band(get_mrm_band(mysqli_insert_id($link)));
   echo "</div>";
 }
 
@@ -820,7 +821,8 @@ function record_ip($match_id, $voted_band) {
 
   if (has_voted($match_id) == false) {
     $insert = "INSERT INTO mrm_votes VALUES (id, '".$match_id ."', '".$voter_ip. "', '".$voted_band. "')";
-    $result = mysqli_query(open_db(), $insert);
+    $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
     if (!$result) {
       echo $insert ."<br>";

--- a/src/functions/music_fns.php
+++ b/src/functions/music_fns.php
@@ -7,7 +7,8 @@ function add_music($date, $artist, $song, $url) {
   $url = mysqli_real_escape_string(open_db(), $url);
 
   $insert = "INSERT INTO music VALUES (id, '".$artist. "', '". $song ."', '". $url ."', '". $date ."', 'n')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -17,7 +18,7 @@ function add_music($date, $artist, $song, $url) {
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Music, ". $artist. " - ". $song. ", has been saved</h3>".
        "<hr width=75%>";
-  display_music(get_music(mysqli_insert_id(open_db())));
+  display_music(get_music(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/on_demand_fns.php
+++ b/src/functions/on_demand_fns.php
@@ -9,7 +9,8 @@ function add_on_demand($date, $image, $headline, $note, $songs, $audio_id) {
   $audio_id = mysqli_real_escape_string(open_db(), $audio_id);
 
   $insert = "INSERT INTO ondemand VALUES (id, '".$date ."', '".$image ."', '".$headline. "', '".$note. "', '".$songs. "', '".$audio_id. "', 'opendrive', 'no')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";

--- a/src/functions/on_demand_fns.php
+++ b/src/functions/on_demand_fns.php
@@ -20,7 +20,7 @@ function add_on_demand($date, $image, $headline, $note, $songs, $audio_id) {
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New On Demand, ". $headline. ", has been saved</h3>".
        "<hr width=75%>";
-  display_on_demand(get_on_demand(mysqli_insert_id()));
+  display_on_demand(get_on_demand(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/schedule_fns.php
+++ b/src/functions/schedule_fns.php
@@ -10,7 +10,8 @@ function add_schedule($host, $date , $start_time, $end_time, $note) {
   if (($timestamp = strtotime($date)) !== false) {
     $day_insert = date("l", $timestamp);
     $insert = "INSERT INTO schedule VALUES (id, '".$date. "', '".$day_insert. "', '". $start_time ."', '". $end_time ."', '". $host ."', '". $note ."', 'n')";
-    $result = mysqli_query(open_db(), $insert);
+    $link = open_db();
+  $result = mysqli_query($link, $insert);;
   } else {
     echo 'invalid timestamp!';
   }
@@ -23,14 +24,15 @@ function add_schedule($host, $date , $start_time, $end_time, $note) {
   echo "<div class=\"center\"><h1>Success!</h1>".
     "<h3>New Schedule for ". $host ." on " .$date . " has been saved</h3>".
     "<hr width=75%>";
-    display_schedule(get_schedule(mysqli_insert_id(open_db())));
+    display_schedule(get_schedule(mysqli_insert_id($link)));
     echo "</div>";
 }
 
 function copy_day($new_date, $original_date){
   $insert = "INSERT INTO schedule (date, day, start_time, end_time, host, note, deleted) (SELECT \"".$new_date."\", day, start_time, end_time, host, note, deleted FROM schedule WHERE date = \"".$original_date. "\")";
 
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";

--- a/src/functions/story_fns.php
+++ b/src/functions/story_fns.php
@@ -5,7 +5,8 @@ function add_story($headline, $story, $start_date, $end_date, $pic, $pic_url, $p
   $story = mysqli_real_escape_string(open_db(), $story);
 
   $insert = "INSERT INTO stories VALUES (id, '".$start_date ."', '".$end_date. "', '". $headline ."', '". $story ."', '". $pic ."', '". $pic_url ."', '". $priority ."', 'n')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -15,7 +16,7 @@ function add_story($headline, $story, $start_date, $end_date, $pic, $pic_url, $p
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Story about ". $headline. ", has been saved</h3>".
        "<hr width=75%>";
-  display_story(get_story(mysqli_insert_id(open_db())));
+  display_story(get_story(mysqli_insert_id($link)));
   echo "</div>";
 }
 

--- a/src/functions/top11_fns.php
+++ b/src/functions/top11_fns.php
@@ -12,7 +12,8 @@ function add_contestant($firstname, $lastname, $email, $phone, $contest, $newsle
     $newsletter = mysqli_real_escape_string(open_db(), $newsletter);
 
     $insert = "INSERT INTO top11contest VALUES (id, '".$firstname ."', '".$lastname. "', '".$email. "', '".$phone. "', '".$contest. "', '".$newsletter. "', 'yes')";
-    $result = mysqli_query(open_db(), $insert);
+    $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert;
@@ -23,7 +24,8 @@ function add_contestant($firstname, $lastname, $email, $phone, $contest, $newsle
 function add_ip($ip) {
   $ip = mysqli_real_escape_string(open_db(), $ip);
   $insert = "INSERT INTO ip_address VALUES (id, '".$ip ."', 'n')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -46,7 +48,8 @@ function add_top11_song($artist, $song) {
   $song = mysqli_real_escape_string(open_db(), $song);
 
   $insert = "INSERT INTO top11songs VALUES (id, '".$artist ."', '".$song. "', 0, 'n')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -56,7 +59,7 @@ function add_top11_song($artist, $song) {
   echo "<div class=\"center\"><h1>Success!</h1>".
     "<h3>The new Top 11 song has been saved</h3>".
     "<hr width=75%>";
-  display_top11_song(get_top11_song(mysqli_insert_id(open_db())));
+  display_top11_song(get_top11_song(mysqli_insert_id($link)));
   echo "</div>";
 }
 
@@ -486,7 +489,8 @@ function view_write_ins() {
 
 function write_in($write_in) {
   $insert = "INSERT INTO write_in VALUES (id, '".$write_in ."', 'no')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";

--- a/src/functions/year_end_poll_fns.php
+++ b/src/functions/year_end_poll_fns.php
@@ -10,7 +10,8 @@ function add_contestant($name, $email, $phone, $hometown, $contest, $newsletter,
   $ip = addslashes($ip);
 
 	$insert = "INSERT INTO year_end_contestants VALUES (id, '".$name. "', '".$email. "', '".$phone. "', '".$hometown. "', '".$contest. "', '".$newsletter. "', '".$ip. "')";
-	$result = mysqli_query(open_db(), $insert);
+	$link = open_db();
+  $result = mysqli_query($link, $insert);;
 
 	return ($result) ? true : false;
 }
@@ -19,7 +20,8 @@ function add_manual_vote_for($ip, $poll_form, $manual_vote) {
   $manual_vote = mysqli_real_escape_string(open_db(), $manual_vote);
 
   $insert = "INSERT INTO year_end_write_ins (ip_address, poll, write_in) VALUES (\"". $ip ."\", \"" . $poll_form . "\", \"" . $manual_vote . "\")";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -31,7 +33,8 @@ function add_manual_vote_for($ip, $poll_form, $manual_vote) {
 
 function add_ip($ip, $poll) {
   $insert = "INSERT INTO year_end_ips VALUES (id, '".$ip ."', '" . $poll . "')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 	
   if (!$result) {
 	  echo $insert ."<br>";
@@ -43,7 +46,8 @@ function add_song_votes_for($ip, $votes, $write_in_value) {
   $last_value = ( $write_in_value != '') ? $write_in_value : $votes[19];
 
   $insert = "INSERT INTO year_end_song_votes VALUES (NULL, '".$ip."', '".$votes[0]."', '".$votes[1]."', '".$votes[2]."', '".$votes[3]."', '".$votes[4]."', '".$votes[5]."', '".$votes[6]."', '".$votes[7]."', '".$votes[8]."', '".$votes[9]."', '".$votes[10]."', '".$votes[11]."', '".$votes[12]."', '".$votes[13]."', '".$votes[14]."', '".$votes[15]."', '".$votes[16]."', '".$votes[17]."', '".$votes[18]."', '".$last_value."')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";

--- a/src/functions/year_end_staff_pick_fns.php
+++ b/src/functions/year_end_staff_pick_fns.php
@@ -4,7 +4,8 @@ function add_year_end_staff_pick($order, $html) {
   $order = mysqli_real_escape_string(open_db(), $order);
 
   $insert = "INSERT INTO year_end_staff_picks VALUES (id, '".$order ."', '".$html."', 'n')";
-  $result = mysqli_query(open_db(), $insert);
+  $link = open_db();
+  $result = mysqli_query($link, $insert);;
 
   if (!$result) {
     echo $insert ."<br>";
@@ -14,7 +15,7 @@ function add_year_end_staff_pick($order, $html) {
   echo "<div class=\"center\"><h1>Success!</h1>".
        "<h3>New Year End Staff Pick has been saved</h3>".
        "<hr width=75%>";
-        display_year_end_staff_pick(get_year_end_staff_pick(mysqli_insert_id(open_db())));
+        display_year_end_staff_pick(get_year_end_staff_pick(mysqli_insert_id($link)));
   echo "</div>";
 }
 


### PR DESCRIPTION
Message from Josh alerted me to a problem with the control panel after the PHP 7 upgrade (#6):

> I've been having some weirdness on the back end of the site since the PHP upgrade.  When I make updates, it doesn't show the confirmation properly.  Here's a screenshot showing an example.  See how the fields are all blank. 

Image of the problem:

![image](https://user-images.githubusercontent.com/1401894/74662383-d1b4f480-5167-11ea-8d9f-f40195b346de.png)

What appeared to be happening was the mysql connection not being shared between the insert operation and the insert_id  operation. This fixes that problem.