### PR TITLE
Adding custom post types / custom fields 

### DIFF
--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -163,6 +163,11 @@ require get_template_directory() . '/inc/post-types/cd-of-the-week.php';
 require get_template_directory() . '/inc/post-types/artist.php';
 
 /**
- * Add Artist Post Type
+ * Add Song Post Type
  */
 require get_template_directory() . '/inc/post-types/song.php';
+
+/**
+ * Add On Demand Post Type
+ */
+require get_template_directory() . '/inc/post-types/on-demand.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -161,3 +161,8 @@ require get_template_directory() . '/inc/post-types/cd-of-the-week.php';
  * Add Artist Post Type
  */
 require get_template_directory() . '/inc/post-types/artist.php';
+
+/**
+ * Add Artist Post Type
+ */
+require get_template_directory() . '/inc/post-types/song.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -178,6 +178,11 @@ require get_template_directory() . '/inc/post-types/on-demand.php';
 require get_template_directory() . '/inc/post-types/schedule.php';
 
 /**
+ * Add Custom Deejay fields to Users
+ */
+require get_template_directory() . '/inc/post-types/deejay.php';
+
+/**
  * Remove Comments
  */
 require get_template_directory() . '/inc/remove-comments.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -176,3 +176,8 @@ require get_template_directory() . '/inc/post-types/on-demand.php';
  * Add Schedule Post Type
  */
 require get_template_directory() . '/inc/post-types/schedule.php';
+
+/**
+ * Remove Comments
+ */
+require get_template_directory() . '/inc/remove-comments.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -186,3 +186,8 @@ require get_template_directory() . '/inc/remove-comments.php';
  * Customize Admin Menu Order
  */
 require get_template_directory() . '/inc/customize-admin-menu-order.php';
+
+/**
+ * Rename Default Post Types
+ */
+require get_template_directory() . '/inc/rename-default-post-types.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -171,3 +171,8 @@ require get_template_directory() . '/inc/post-types/song.php';
  * Add On Demand Post Type
  */
 require get_template_directory() . '/inc/post-types/on-demand.php';
+
+/**
+ * Add Schedule Post Type
+ */
+require get_template_directory() . '/inc/post-types/schedule.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -7,7 +7,7 @@
  * @package ynotradio
  */
 
-if ( ! function_exists( 'ynotradio_setup' ) ) :
+if (!function_exists('ynotradio_setup')):
 /**
  * Sets up theme defaults and registers support for various WordPress features.
  *
@@ -15,58 +15,59 @@ if ( ! function_exists( 'ynotradio_setup' ) ) :
  * runs before the init hook. The init hook is too late for some features, such
  * as indicating support for post thumbnails.
  */
-function ynotradio_setup() {
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed in the /languages/ directory.
-	 * If you're building a theme based on ynotradio, use a find and replace
-	 * to change 'ynotradio' to the name of your theme in all the template files.
-	 */
-	load_theme_textdomain( 'ynotradio', get_template_directory() . '/languages' );
+    function ynotradio_setup()
+{
+        /*
+         * Make theme available for translation.
+         * Translations can be filed in the /languages/ directory.
+         * If you're building a theme based on ynotradio, use a find and replace
+         * to change 'ynotradio' to the name of your theme in all the template files.
+         */
+        load_theme_textdomain('ynotradio', get_template_directory() . '/languages');
 
-	// Add default posts and comments RSS feed links to head.
-	add_theme_support( 'automatic-feed-links' );
+        // Add default posts and comments RSS feed links to head.
+        add_theme_support('automatic-feed-links');
 
-	/*
-	 * Let WordPress manage the document title.
-	 * By adding theme support, we declare that this theme does not use a
-	 * hard-coded <title> tag in the document head, and expect WordPress to
-	 * provide it for us.
-	 */
-	add_theme_support( 'title-tag' );
+        /*
+         * Let WordPress manage the document title.
+         * By adding theme support, we declare that this theme does not use a
+         * hard-coded <title> tag in the document head, and expect WordPress to
+         * provide it for us.
+         */
+        add_theme_support('title-tag');
 
-	/*
-	 * Enable support for Post Thumbnails on posts and pages.
-	 *
-	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-	 */
-	add_theme_support( 'post-thumbnails' );
+        /*
+         * Enable support for Post Thumbnails on posts and pages.
+         *
+         * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+         */
+        add_theme_support('post-thumbnails');
 
-	// This theme uses wp_nav_menu() in one location.
-	register_nav_menus( array(
-		'primary' => esc_html__( 'Primary', 'ynotradio' ),
-	) );
+        // This theme uses wp_nav_menu() in one location.
+        register_nav_menus(array(
+            'primary' => esc_html__('Primary', 'ynotradio'),
+        ));
 
-	/*
-	 * Switch default core markup for search form, comment form, and comments
-	 * to output valid HTML5.
-	 */
-	add_theme_support( 'html5', array(
-		'search-form',
-		'comment-form',
-		'comment-list',
-		'gallery',
-		'caption',
-	) );
+        /*
+         * Switch default core markup for search form, comment form, and comments
+         * to output valid HTML5.
+         */
+        add_theme_support('html5', array(
+            'search-form',
+            'comment-form',
+            'comment-list',
+            'gallery',
+            'caption',
+        ));
 
-	// Set up the WordPress core custom background feature.
-	add_theme_support( 'custom-background', apply_filters( 'ynotradio_custom_background_args', array(
-		'default-color' => 'ffffff',
-		'default-image' => '',
-	) ) );
-}
+        // Set up the WordPress core custom background feature.
+        add_theme_support('custom-background', apply_filters('ynotradio_custom_background_args', array(
+            'default-color' => 'ffffff',
+            'default-image' => '',
+        )));
+    }
 endif;
-add_action( 'after_setup_theme', 'ynotradio_setup' );
+add_action('after_setup_theme', 'ynotradio_setup');
 
 /**
  * Set the content width in pixels, based on the theme's design and stylesheet.
@@ -75,47 +76,50 @@ add_action( 'after_setup_theme', 'ynotradio_setup' );
  *
  * @global int $content_width
  */
-function ynotradio_content_width() {
-	$GLOBALS['content_width'] = apply_filters( 'ynotradio_content_width', 640 );
+function ynotradio_content_width()
+{
+    $GLOBALS['content_width'] = apply_filters('ynotradio_content_width', 640);
 }
-add_action( 'after_setup_theme', 'ynotradio_content_width', 0 );
+add_action('after_setup_theme', 'ynotradio_content_width', 0);
 
 /**
  * Register widget area.
  *
  * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
  */
-function ynotradio_widgets_init() {
-	register_sidebar( array(
-		'name'          => esc_html__( 'Sidebar', 'ynotradio' ),
-		'id'            => 'sidebar-1',
-		'description'   => esc_html__( 'Add widgets here.', 'ynotradio' ),
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
+function ynotradio_widgets_init()
+{
+    register_sidebar(array(
+        'name' => esc_html__('Sidebar', 'ynotradio'),
+        'id' => 'sidebar-1',
+        'description' => esc_html__('Add widgets here.', 'ynotradio'),
+        'before_widget' => '<section id="%1$s" class="widget %2$s">',
+        'after_widget' => '</section>',
+        'before_title' => '<h2 class="widget-title">',
+        'after_title' => '</h2>',
+    ));
 }
-add_action( 'widgets_init', 'ynotradio_widgets_init' );
+add_action('widgets_init', 'ynotradio_widgets_init');
 
 /**
  * Enqueue scripts and styles.
  */
-function ynotradio_scripts() {
-	wp_enqueue_style( 'ynotradio-style', get_stylesheet_uri() );
+function ynotradio_scripts()
+{
+    wp_enqueue_style('ynotradio-style', get_stylesheet_uri());
 
-	wp_enqueue_script( 'ynotradio-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151215', true );
+    wp_enqueue_script('ynotradio-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151215', true);
 
-	wp_enqueue_script( 'ynotradio-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );
+    wp_enqueue_script('ynotradio-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true);
 
-	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-		wp_enqueue_script( 'comment-reply' );
-	}
+    if (is_singular() && comments_open() && get_option('thread_comments')) {
+        wp_enqueue_script('comment-reply');
+    }
 }
-add_action( 'wp_enqueue_scripts', 'ynotradio_scripts' );
+add_action('wp_enqueue_scripts', 'ynotradio_scripts');
 
 if (isset($_REQUEST['migrate']) && current_user_can('install_themes')) {
-	include_once 'migrations/migration.php';
+    include_once 'migrations/migration.php';
 }
 
 /**
@@ -153,3 +157,7 @@ require get_template_directory() . '/inc/carbon-fields-setup.php';
  */
 require get_template_directory() . '/inc/post-types/cd-of-the-week.php';
 
+/**
+ * Add Artist Post Type
+ */
+require get_template_directory() . '/inc/post-types/artist.php';

--- a/src/theme/functions.php
+++ b/src/theme/functions.php
@@ -181,3 +181,8 @@ require get_template_directory() . '/inc/post-types/schedule.php';
  * Remove Comments
  */
 require get_template_directory() . '/inc/remove-comments.php';
+
+/**
+ * Customize Admin Menu Order
+ */
+require get_template_directory() . '/inc/customize-admin-menu-order.php';

--- a/src/theme/inc/customize-admin-menu-order.php
+++ b/src/theme/inc/customize-admin-menu-order.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Activates the 'menu_order' filter and then hooks into 'menu_order'
+ */
+add_filter('custom_menu_order', function () {return true;});
+add_filter('menu_order', 'my_new_admin_menu_order');
+/**
+ * Filters WordPress' default menu order
+ */
+function my_new_admin_menu_order($menu_order)
+{
+    // define your new desired menu positions here
+    // for example, move 'upload.php' to position #9 and built-in pages to position #1
+    $new_positions = array(
+        'edit.php?post_type=page' => 2,
+        'edit.php?post_type=cd_of_the_week' => 8,
+        'users.php' => 10,
+        'separator2' => 11,
+    );
+    // helper function to move an element inside an array
+    function move_element(&$array, $a, $b)
+    {
+        $out = array_splice($array, $a, 1);
+        array_splice($array, $b, 0, $out);
+    }
+    // traverse through the new positions and move
+    // the items if found in the original menu_positions
+    foreach ($new_positions as $value => $new_index) {
+        if ($current_index = array_search($value, $menu_order)) {
+            move_element($menu_order, $current_index, $new_index);
+        }
+    }
+    return $menu_order;
+};

--- a/src/theme/inc/post-types/artist.php
+++ b/src/theme/inc/post-types/artist.php
@@ -55,3 +55,13 @@ function crb_register__artist()
 }
 
 add_action('carbon_fields_register_fields', 'crb_register__artist');
+
+function custom_enter_title__artist($input)
+{
+    if ('artist' === get_post_type()) {
+        return __('Enter artist or band name', 'ynotradio_text');
+    }
+
+    return $input;
+}
+add_filter('enter_title_here', 'custom_enter_title__artist');

--- a/src/theme/inc/post-types/artist.php
+++ b/src/theme/inc/post-types/artist.php
@@ -34,7 +34,7 @@ function crb_register__artist()
     Container::make('post_meta', 'Social Links')
         ->where('post_type', '=', 'artist')
         ->add_fields(array(
-            Field::make('complex', 'crb_social_urls', 'Social Links')
+            Field::make('complex', 'crb_artist__social_urls', 'Social Links')
                 ->add_fields(array(
                     Field::make('text', 'label', 'Label')
                         ->set_width(50) // condense layout so field takes only 50% of the available width

--- a/src/theme/inc/post-types/artist.php
+++ b/src/theme/inc/post-types/artist.php
@@ -13,7 +13,45 @@ function create_post_type__artist()
         'has_archive' => true,
         'rewrite' => array('slug' => 'artist'),
         'menu_icon' => 'dashicons-art',
+        'supports' => array('title'),
     ));
 }
 
 add_action('init', 'create_post_type__artist');
+
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
+function crb_register__artist()
+{
+    Container::make('post_meta', 'Artist Information')
+        ->where('post_type', '=', 'artist')
+        ->add_fields(array(
+            Field::make('text', 'crb_artist__url', 'URL'),
+            Field::make('text', 'crb_artist__picture', 'Picture (Imported)'),
+        ));
+
+    Container::make('post_meta', 'Social Links')
+        ->where('post_type', '=', 'artist')
+        ->add_fields(array(
+            Field::make('complex', 'crb_social_urls', 'Social Links')
+                ->add_fields(array(
+                    Field::make('text', 'label', 'Label')
+                        ->set_width(50) // condense layout so field takes only 50% of the available width
+                        ->set_required(),
+                    Field::make('text', 'url', 'URL')
+                        ->set_width(50)
+                        ->set_required(),
+                )
+                ),
+        ));
+    Container::make('post_meta', 'Modern Rock Madness')
+        ->where('post_type', '=', 'artist')
+        ->add_fields(array(
+            Field::make('text', 'crb_artist__abbreviation', 'Abbreviation')
+                ->set_width(10),
+        ));
+
+}
+
+add_action('carbon_fields_register_fields', 'crb_register__artist');

--- a/src/theme/inc/post-types/artist.php
+++ b/src/theme/inc/post-types/artist.php
@@ -1,0 +1,19 @@
+<?php
+
+function create_post_type__artist()
+{
+
+    register_post_type('artist', array(
+        'labels' => array(
+            'name' => __('Artists'),
+            'singular_name' => __('Artist'),
+            'add_new_item' => __('Add Artist'),
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'rewrite' => array('slug' => 'artist'),
+        'menu_icon' => 'dashicons-art',
+    ));
+}
+
+add_action('init', 'create_post_type__artist');

--- a/src/theme/inc/post-types/cd-of-the-week.php
+++ b/src/theme/inc/post-types/cd-of-the-week.php
@@ -52,3 +52,13 @@ function crb_register__cd_of_the_week()
 }
 
 add_action('carbon_fields_register_fields', 'crb_register__cd_of_the_week');
+
+function custom_enter_title__cdotw($input)
+{
+    if ('cd_of_the_week' === get_post_type()) {
+        return __('Enter CD name', 'ynotradio_text');
+    }
+
+    return $input;
+}
+add_filter('enter_title_here', 'custom_enter_title__cdotw');

--- a/src/theme/inc/post-types/cd-of-the-week.php
+++ b/src/theme/inc/post-types/cd-of-the-week.php
@@ -6,20 +6,19 @@ function create_post_type__cd_of_the_week()
 {
     register_post_type('cd_of_the_week',
         array(
-            'labels'      => array(
-                'name'          => __('CD of the Week'),
+            'labels' => array(
+                'name' => __('CD of the Week'),
                 'singular_name' => __('CD of the Week'),
-                'add_new_item'  => __('Add New CD of the Week'),
+                'add_new_item' => __('Add New CD of the Week'),
             ),
-            'public'      => true,
+            'public' => true,
             'has_archive' => true,
-            'rewrite'     => array('slug' => 'cd-of-the-week'),
-            'menu_icon'   => 'dashicons-album',
+            'rewrite' => array('slug' => 'cd-of-the-week'),
+            'menu_icon' => 'dashicons-album',
         )
     );
 
     //remove_post_type_support( 'cd_of_the_week', 'editor');
-
 
 }
 add_action('init', 'create_post_type__cd_of_the_week');
@@ -41,11 +40,11 @@ function crb_register__cd_of_the_week()
     Container::make('post_meta', 'CD Artwork')
         ->where('post_type', '=', 'cd_of_the_week')
         ->add_fields(array(
-        	Field::make( 'image', 'cdotw_pic_img', "Upload CD Image" ),
-        	Field::make( 'text', 'cdotw_pic_url', "Link External Image" ),
+            Field::make('image', 'cdotw_pic_img', "Upload CD Image"),
+            Field::make('text', 'cdotw_pic_url', "Link External Image"),
         ))
-        ->set_context( 'side' )
-        ->set_priority( 'low' );
+        ->set_context('side')
+        ->set_priority('low');
 }
 
 add_action('carbon_fields_register_fields', 'crb_register__cd_of_the_week');

--- a/src/theme/inc/post-types/cd-of-the-week.php
+++ b/src/theme/inc/post-types/cd-of-the-week.php
@@ -15,10 +15,9 @@ function create_post_type__cd_of_the_week()
             'has_archive' => true,
             'rewrite' => array('slug' => 'cd-of-the-week'),
             'menu_icon' => 'dashicons-album',
+            'supports' => array('title', 'author', 'editor'),
         )
     );
-
-    //remove_post_type_support( 'cd_of_the_week', 'editor');
 
 }
 add_action('init', 'create_post_type__cd_of_the_week');
@@ -38,8 +37,8 @@ function crb_register__cd_of_the_week()
                         'post_type' => 'artist',
                     ))),
             Field::make('text', 'crb_cdotw__label', "Record Label"),
-            Field::make('text', 'crb_cdotw__reviewer', "Reviewer's Name"),
-            Field::make('hidden', 'crb_cdotw__legacy_id'),
+            Field::make('text', 'crb_cdotw__reviewer', "Reviewer's Name (Imported)"),
+            Field::make('hidden', 'crb_cdotw__legacy_id', 'ID (Imported)'),
         ));
 
     Container::make('post_meta', 'CD Artwork')

--- a/src/theme/inc/post-types/cd-of-the-week.php
+++ b/src/theme/inc/post-types/cd-of-the-week.php
@@ -29,12 +29,17 @@ function crb_register__cd_of_the_week()
     Container::make('post_meta', 'CD Information')
         ->where('post_type', '=', 'cd_of_the_week')
         ->add_fields(array(
-            Field::make('date', 'cdotw_date', 'Week of:'),
-            Field::make('text', 'cdotw_artist', 'Artist'),
-            Field::make('text', 'cdotw_artist_url', 'Artist Website'),
-            Field::make('text', 'cdotw_label', "Record Label"),
-            Field::make('text', 'cdotw_reviewer', "Reviewer's Name"),
-            Field::make('hidden', 'cdotw_legacy_id'),
+            Field::make('date', 'crb_cdotw__date', 'Week of:'),
+            Field::make('association', 'crb_cdotw__artist', 'Artist')
+                ->set_min(1)
+                ->set_types(array(
+                    array(
+                        'type' => 'post',
+                        'post_type' => 'artist',
+                    ))),
+            Field::make('text', 'crb_cdotw__label', "Record Label"),
+            Field::make('text', 'crb_cdotw__reviewer', "Reviewer's Name"),
+            Field::make('hidden', 'crb_cdotw__legacy_id'),
         ));
 
     Container::make('post_meta', 'CD Artwork')

--- a/src/theme/inc/post-types/deejay.php
+++ b/src/theme/inc/post-types/deejay.php
@@ -9,9 +9,21 @@ function crb_register__deejay_users()
     Container::make('user_meta', 'Public Profile Information')
         ->add_fields(array(
             Field::make('text', 'crb_deejay__show_name', 'Show'),
-            Field::make('text', 'crb_deejay__social_text', 'Social Text'),
-            Field::make('text', 'crb_deejay__social_url', 'Social URL'),
             Field::make('text', 'crb_deejay__picture', 'Picture (Imported)'),
+        ));
+
+    Container::make('user_meta', 'Social Links')
+        ->add_fields(array(
+            Field::make('complex', 'crb_deejay__social_urls', 'Social Links')
+                ->add_fields(array(
+                    Field::make('text', 'label', 'Label')
+                        ->set_width(50) // condense layout so field takes only 50% of the available width
+                        ->set_required(),
+                    Field::make('text', 'url', 'URL')
+                        ->set_width(50)
+                        ->set_required(),
+                )
+                ),
         ));
 }
 

--- a/src/theme/inc/post-types/deejay.php
+++ b/src/theme/inc/post-types/deejay.php
@@ -1,0 +1,18 @@
+<?php
+
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
+function crb_register__deejay_users()
+{
+
+    Container::make('user_meta', 'Public Profile Information')
+        ->add_fields(array(
+            Field::make('text', 'crb_deejay__show_name', 'Show'),
+            Field::make('text', 'crb_deejay__social_text', 'Social Text'),
+            Field::make('text', 'crb_deejay__social_url', 'Social URL'),
+            Field::make('text', 'crb_deejay__picture', 'Picture (Imported)'),
+        ));
+}
+
+add_action('carbon_fields_register_fields', 'crb_register__deejay_users');

--- a/src/theme/inc/post-types/deejay.php
+++ b/src/theme/inc/post-types/deejay.php
@@ -10,6 +10,7 @@ function crb_register__deejay_users()
         ->add_fields(array(
             Field::make('text', 'crb_deejay__show_name', 'Show'),
             Field::make('text', 'crb_deejay__picture', 'Picture (Imported)'),
+            Field::make('hidden', 'crb_deejay__legacy_id'),
         ));
 
     Container::make('user_meta', 'Social Links')

--- a/src/theme/inc/post-types/on-demand.php
+++ b/src/theme/inc/post-types/on-demand.php
@@ -1,0 +1,19 @@
+<?php
+
+function create_post_type__on_demand()
+{
+
+    register_post_type('on-demand', array(
+        'labels' => array(
+            'name' => __('On Demand Sessions'),
+            'singular_name' => __('On Demand Session'),
+            'add_new_item' => __('Add On Demand Session'),
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'rewrite' => array('slug' => 'on-demand'),
+        'menu_icon' => 'dashicons-microphone',
+    ));
+}
+
+add_action('init', 'create_post_type__on_demand');

--- a/src/theme/inc/post-types/on-demand.php
+++ b/src/theme/inc/post-types/on-demand.php
@@ -22,6 +22,12 @@ add_action('init', 'create_post_type__on_demand');
 
 function crb_register__on_demand()
 {
+    Container::make('post_meta', 'Audio')
+        ->where('post_type', '=', 'on-demand')
+        ->add_fields(array(
+
+            Field::make('text', 'crb_on_demand__audio_id', "Audio ID"),
+        ));
     Container::make('post_meta', 'Artist')
         ->where('post_type', '=', 'on-demand')
         ->add_fields(array(
@@ -33,15 +39,11 @@ function crb_register__on_demand()
                         'post_type' => 'artist',
                     ))),
         ));
-    Container::make('post_meta', 'Audio')
-        ->where('post_type', '=', 'on-demand')
-        ->add_fields(array(
 
-            Field::make('text', 'crb_on_demand__audio_id', "Audio ID"),
-        ));
     Container::make('post_meta', 'Details')
         ->where('post_type', '=', 'on-demand')
         ->add_fields(array(
+            Field::make('date', 'crb_on_demand__recorded_date', 'Recorded on:'),
 
             Field::make('text', 'crb_on_demand__songs', "Songs"),
             Field::make('text', 'crb_on_demand__image_url', "Image (Imported)"),

--- a/src/theme/inc/post-types/on-demand.php
+++ b/src/theme/inc/post-types/on-demand.php
@@ -1,4 +1,6 @@
 <?php
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
 
 function create_post_type__on_demand()
 {
@@ -17,3 +19,35 @@ function create_post_type__on_demand()
 }
 
 add_action('init', 'create_post_type__on_demand');
+
+function crb_register__on_demand()
+{
+    Container::make('post_meta', 'Artist')
+        ->where('post_type', '=', 'on-demand')
+        ->add_fields(array(
+            Field::make('association', 'crb_on_demand__artist', 'Artists')
+                ->set_min(0)
+                ->set_types(array(
+                    array(
+                        'type' => 'post',
+                        'post_type' => 'artist',
+                    ))),
+        ));
+    Container::make('post_meta', 'Audio')
+        ->where('post_type', '=', 'on-demand')
+        ->add_fields(array(
+
+            Field::make('text', 'crb_on_demand__audio_id', "Audio ID"),
+        ));
+    Container::make('post_meta', 'Details')
+        ->where('post_type', '=', 'on-demand')
+        ->add_fields(array(
+
+            Field::make('text', 'crb_on_demand__songs', "Songs"),
+            Field::make('text', 'crb_on_demand__image_url', "Image (Imported)"),
+            Field::make('hidden', 'crb_on_demand__legacy_id', 'ID (Imported)'),
+
+        ));
+
+}
+add_action('carbon_fields_register_fields', 'crb_register__on_demand');

--- a/src/theme/inc/post-types/schedule.php
+++ b/src/theme/inc/post-types/schedule.php
@@ -1,0 +1,19 @@
+<?php
+
+function create_post_type__schedule()
+{
+
+    register_post_type('schedule', array(
+        'labels' => array(
+            'name' => __('Schedules'),
+            'singular_name' => __('Schedule'),
+            'add_new_item' => __('Add Schedule Entry'),
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'rewrite' => array('slug' => 'schedule'),
+        'menu_icon' => 'dashicons-format-chat',
+    ));
+}
+
+add_action('init', 'create_post_type__schedule');

--- a/src/theme/inc/post-types/schedule.php
+++ b/src/theme/inc/post-types/schedule.php
@@ -1,5 +1,8 @@
 <?php
 
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
 function create_post_type__schedule()
 {
 
@@ -13,7 +16,45 @@ function create_post_type__schedule()
         'has_archive' => true,
         'rewrite' => array('slug' => 'schedule'),
         'menu_icon' => 'dashicons-format-chat',
+        'supports' => array(null),
     ));
 }
 
 add_action('init', 'create_post_type__schedule');
+
+function crb_register__schedule()
+{
+    Container::make('post_meta', 'Date')
+        ->where('post_type', '=', 'schedule')
+        ->add_fields(array(
+            Field::make('date', 'crb_schedule__date', 'Date')
+                ->set_required(),
+
+        ));
+
+    Container::make('post_meta', 'Shows')
+        ->where('post_type', '=', 'schedule')
+        ->add_fields(array(
+            Field::make('complex', 'crb_schedule__shows', 'Shows')
+                ->add_fields(array(
+                    Field::make('text', 'show', 'Show Name'),
+                    Field::make('association', 'host', 'Host / Deejay')
+                        ->set_types(array(
+                            array(
+                                'type' => 'user',
+                            ))),
+                    Field::make('time', 'start_time', 'Start Time')
+                        ->set_width(50) // condense layout so field takes only 50% of the available width
+                        ->set_required(),
+                    Field::make('time', 'end_time', 'End Time')
+                        ->set_width(50) // condense layout so field takes only 50% of the available width
+                        ->set_required(),
+
+                    Field::make('rich_text', 'notes', 'Notes'),
+
+                )),
+
+        ));
+}
+
+add_action('carbon_fields_register_fields', 'crb_register__schedule');

--- a/src/theme/inc/post-types/song.php
+++ b/src/theme/inc/post-types/song.php
@@ -17,3 +17,13 @@ function create_post_type__song()
 }
 
 add_action('init', 'create_post_type__song');
+
+function custom_enter_title__song($input)
+{
+    if ('song' === get_post_type()) {
+        return __('Enter song title', 'ynotradio_text');
+    }
+
+    return $input;
+}
+add_filter('enter_title_here', 'custom_enter_title__song');

--- a/src/theme/inc/post-types/song.php
+++ b/src/theme/inc/post-types/song.php
@@ -1,0 +1,19 @@
+<?php
+
+function create_post_type__song()
+{
+
+    register_post_type('song', array(
+        'labels' => array(
+            'name' => __('Songs'),
+            'singular_name' => __('Song'),
+            'add_new_item' => __('Add Song'),
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'rewrite' => array('slug' => 'song'),
+        'menu_icon' => 'dashicons-media-audio',
+    ));
+}
+
+add_action('init', 'create_post_type__song');

--- a/src/theme/inc/post-types/song.php
+++ b/src/theme/inc/post-types/song.php
@@ -1,11 +1,14 @@
 <?php
 
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
 function create_post_type__song()
 {
 
     register_post_type('song', array(
         'labels' => array(
-            'name' => __('Songs'),
+            'name' => __('Songs (New Music)'),
             'singular_name' => __('Song'),
             'add_new_item' => __('Add Song'),
         ),
@@ -13,10 +16,31 @@ function create_post_type__song()
         'has_archive' => true,
         'rewrite' => array('slug' => 'song'),
         'menu_icon' => 'dashicons-media-audio',
+        'supports' => array('title'),
     ));
 }
 
 add_action('init', 'create_post_type__song');
+
+function crb_register__song()
+{
+    Container::make('post_meta', 'New Music Information')
+        ->where('post_type', '=', 'song')
+        ->add_fields(array(
+            Field::make('date', 'crb_song__date', 'Week of:'),
+            Field::make('association', 'crb_song__artist', 'Artist')
+                ->set_min(1)
+                ->set_types(array(
+                    array(
+                        'type' => 'post',
+                        'post_type' => 'artist',
+                    ))),
+            Field::make('text', 'crb_song__url', "Song URL"),
+            Field::make('hidden', 'crb_song__legacy_id', 'ID (Imported)'),
+        ));
+}
+
+add_action('carbon_fields_register_fields', 'crb_register__song');
 
 function custom_enter_title__song($input)
 {

--- a/src/theme/inc/remove-comments.php
+++ b/src/theme/inc/remove-comments.php
@@ -1,0 +1,24 @@
+<?php
+
+// Removes from admin menu
+add_action('admin_menu', 'my_remove_admin_menus');
+function my_remove_admin_menus()
+{
+    remove_menu_page('edit-comments.php');
+}
+
+// Removes from post and pages
+add_action('init', 'remove_comment_support', 100);
+
+function remove_comment_support()
+{
+    remove_post_type_support('post', 'comments');
+    remove_post_type_support('page', 'comments');
+}
+// Removes from admin bar
+function mytheme_admin_bar_render()
+{
+    global $wp_admin_bar;
+    $wp_admin_bar->remove_menu('comments');
+}
+add_action('wp_before_admin_bar_render', 'mytheme_admin_bar_render');

--- a/src/theme/inc/rename-default-post-types.php
+++ b/src/theme/inc/rename-default-post-types.php
@@ -1,0 +1,33 @@
+<?php
+
+function change_post_label()
+{
+    global $menu;
+    global $submenu;
+    $menu[5][0] = 'Stories';
+    $submenu['edit.php'][5][0] = 'Stories';
+    $submenu['edit.php'][10][0] = 'Add Story';
+    $submenu['edit.php'][16][0] = 'Story Tags';
+
+}
+
+add_action('admin_menu', 'change_post_label');
+
+function change_page_label()
+{
+    global $menu;
+    global $submenu;
+    $menu[20][0] = 'Pages (Custom Text)';
+
+}
+
+add_action('admin_menu', 'change_page_label');
+
+function change_users_label()
+{
+    global $menu;
+    global $submenu;
+    $menu[70][0] = 'Deejays / Users';
+}
+
+add_action('admin_menu', 'change_users_label');


### PR DESCRIPTION
This branch adds custom post types, custom fields, and other CMS tweaks for the following content types:

1. Artists (new)
1. Stories (renamed from "Posts")
1. Pages / Custom Text (renamed from "Pages")
1. CD of the Week
1. Deejays (extended core WordPress "users")
1. New Music / Songs
1. On Demand
1. Schedule

![image](https://user-images.githubusercontent.com/1401894/77995675-48faae00-72fa-11ea-8769-017df2ef2aae.png)

![image](https://user-images.githubusercontent.com/1401894/77995706-5152e900-72fa-11ea-9f5b-54bd1893886d.png)
![image](https://user-images.githubusercontent.com/1401894/77995722-56b03380-72fa-11ea-85c7-ed97ee12ee2b.png)
![image](https://user-images.githubusercontent.com/1401894/77995746-5e6fd800-72fa-11ea-9839-2bc86cedf4ab.png)
![image](https://user-images.githubusercontent.com/1401894/77995774-6596e600-72fa-11ea-9c9e-d0952a014833.png)
![image](https://user-images.githubusercontent.com/1401894/77995796-6e87b780-72fa-11ea-83be-0fbdd379259e.png)
