### PR TITLE
Add Auth0 login and weekly user vote tracking to Top 11

### DIFF
--- a/src/db/migrations/top11_user_votes.sql
+++ b/src/db/migrations/top11_user_votes.sql
@@ -1,0 +1,16 @@
+--
+-- Table structure for table `top11_user_votes`
+-- This table tracks which users have voted in each weekly Top 11 session
+--
+
+CREATE TABLE IF NOT EXISTS `top11_user_votes` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_email` varchar(255) NOT NULL,
+  `vote_week` date NOT NULL COMMENT 'The Monday of the voting week',
+  `voted_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `user_auth0_id` varchar(255) DEFAULT NULL COMMENT 'Auth0 user ID for additional security',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_user_week` (`user_email`, `vote_week`),
+  KEY `idx_vote_week` (`vote_week`),
+  KEY `idx_user_email` (`user_email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/models/Top11.php
+++ b/src/models/Top11.php
@@ -184,4 +184,29 @@ interface Top11
      * @return bool Whether the operation was successful
      */
     public function reset(): bool;
+
+    /**
+     * Check if a user has already voted this week
+     *
+     * @param string $userEmail The user's email address
+     * @param string|null $auth0Id Optional Auth0 user ID for additional security
+     * @return bool Whether the user has already voted this week
+     */
+    public function hasUserVotedThisWeek(string $userEmail, ?string $auth0Id = null): bool;
+
+    /**
+     * Record that a user has voted this week
+     *
+     * @param string $userEmail The user's email address
+     * @param string|null $auth0Id Optional Auth0 user ID for additional security
+     * @return bool Whether the operation was successful
+     */
+    public function recordUserVote(string $userEmail, ?string $auth0Id = null): bool;
+
+    /**
+     * Get the current voting week (Monday of the current week)
+     *
+     * @return string The Monday date of the current week (Y-m-d format)
+     */
+    public function getCurrentVotingWeek(): string;
 }

--- a/src/models/implementations/SqlTop11.php
+++ b/src/models/implementations/SqlTop11.php
@@ -362,6 +362,79 @@ class SqlTop11 implements Top11
         // Reset IP addresses
         $success = $success && $this->db->query("UPDATE ip_address SET deleted = 'yes'");
 
+        // Reset user votes for the current week
+        $currentWeek = $this->getCurrentVotingWeek();
+        $stmt = $this->db->prepare("DELETE FROM top11_user_votes WHERE vote_week = ?");
+        $stmt->bind_param("s", $currentWeek);
+        $success = $success && $stmt->execute();
+
         return $success;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasUserVotedThisWeek(string $userEmail, ?string $auth0Id = null): bool
+    {
+        try {
+            $currentWeek = $this->getCurrentVotingWeek();
+            
+            $query = "SELECT COUNT(*) as count FROM top11_user_votes WHERE user_email = ? AND vote_week = ?";
+            $stmt = $this->db->prepare($query);
+            
+            if (!$stmt) {
+                // Table likely doesn't exist yet, return false (user hasn't voted)
+                return false;
+            }
+            
+            $stmt->bind_param("ss", $userEmail, $currentWeek);
+            $stmt->execute();
+            
+            $result = $stmt->get_result();
+            $row = $result->fetch_assoc();
+            
+            return $row['count'] > 0;
+        } catch (\Exception $e) {
+            // If table doesn't exist or other error, assume user hasn't voted
+            error_log("Error checking user vote: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function recordUserVote(string $userEmail, ?string $auth0Id = null): bool
+    {
+        try {
+            $currentWeek = $this->getCurrentVotingWeek();
+            
+            $query = "INSERT INTO top11_user_votes (user_email, vote_week, user_auth0_id) VALUES (?, ?, ?)";
+            $stmt = $this->db->prepare($query);
+            
+            if (!$stmt) {
+                // Table likely doesn't exist yet, return false
+                error_log("Error preparing user vote record: " . $this->db->error);
+                return false;
+            }
+            
+            $stmt->bind_param("sss", $userEmail, $currentWeek, $auth0Id);
+            
+            return $stmt->execute();
+        } catch (\Exception $e) {
+            error_log("Error recording user vote: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentVotingWeek(): string
+    {
+        // Get the Monday of the current week
+        $currentDate = new \DateTime();
+        $currentDate->modify('this week');
+        return $currentDate->format('Y-m-d');
     }
 }

--- a/src/partials/_top11_save.php
+++ b/src/partials/_top11_save.php
@@ -9,10 +9,8 @@ if (!isset($top11Model)) {
 }
 
 // Process the form submission
-$firstname = isset($_POST['firstname']) ? $_POST['firstname'] : '';
-$lastname = isset($_POST['lastname']) ? $_POST['lastname'] : '';
-$email = isset($_POST['email']) ? $_POST['email'] : '';
-$phone = isset($_POST['phone']) ? $_POST['phone'] : '';
+$voter_email = isset($_POST['voter_email']) ? $_POST['voter_email'] : '';
+$auth0_id = isset($_POST['auth0_id']) ? $_POST['auth0_id'] : null;
 $contest = isset($_POST['contest']) ? $_POST['contest'] : 'no';
 $newsletter = isset($_POST['newsletter']) ? $_POST['newsletter'] : 'no';
 $top11_votes = isset($_POST['top11']) ? $_POST['top11'] : [];
@@ -20,6 +18,17 @@ $write_in = isset($_POST['write_in_value']) ? $_POST['write_in_value'] : '';
 
 // Validate the form
 $errors = [];
+
+// Check if user is authenticated
+if (empty($voter_email)) {
+    $errors[] = "You must be logged in to vote";
+}
+
+// Check if user has already voted this week
+if (!empty($voter_email) && $top11Model->hasUserVotedThisWeek($voter_email, $auth0_id)) {
+    $errors[] = "You have already voted this week. Each user can only vote once per week.";
+}
+
 // Only require song selection, make personal info optional
 if (empty($top11_votes) && empty($write_in)) {
     $errors[] = "Please select at least one song or write in your own";
@@ -38,11 +47,18 @@ if (!empty($errors)) {
     return;
 }
 
-// Save the contestant
+// Save the vote
 try {
-    // Only save contestant info if they provided at least a name and email
-    if (!empty($firstname) && !empty($email)) {
-        $top11Model->addContestant($firstname, $lastname, $email, $phone, $contest, $newsletter);
+    // Record that this user has voted this week (prevent duplicates)
+    $top11Model->recordUserVote($voter_email, $auth0_id);
+    
+    // Extract user information from email for contestant entry
+    $emailParts = explode('@', $voter_email);
+    $username = $emailParts[0];
+    
+    // Save contestant info using the authenticated email
+    if ($contest === 'yes' || $newsletter === 'yes') {
+        $top11Model->addContestant($username, '', $voter_email, '', $contest, $newsletter);
     }
     
     // Process votes
@@ -61,16 +77,19 @@ try {
     echo "<div class=\"alert alert-success\">";
     echo "<h3>Thank you for your vote!</h3>";
     echo "<p>Your Top 11 @ 11 vote has been received.</p>";
+    echo "<p>You are logged in as: <strong>" . htmlspecialchars($voter_email) . "</strong></p>";
     if ($contest === 'yes') {
         echo "<p>You have been entered into this week's contest.</p>";
     }
     if ($newsletter === 'yes') {
         echo "<p>You have been added to our newsletter list.</p>";
     }
+    echo "<p><a href=\"top11_social_logout.php\">Log out</a></p>";
     echo "</div>";
 } catch (\Exception $e) {
     echo "<div class=\"alert alert-error\">";
     echo "<h3>Error</h3>";
     echo "<p>There was an error processing your vote. Please try again later.</p>";
+    echo "<p>Error details: " . htmlspecialchars($e->getMessage()) . "</p>";
     echo "</div>";
 }

--- a/src/top11.php
+++ b/src/top11.php
@@ -3,9 +3,24 @@
 $page_file = "top11.php";
 $page_title = "Top 11 @ 11";
 
-require ("functions/main_fns.php");
-require_once ("models/Top11Factory.php");
-require ("partials/_header.php");
+require 'vendor/autoload.php';
+require 'partials/__env_loader.php';
+
+// Initialize Auth0 BEFORE any output
+$uri = $_SERVER["HTTP_HOST"];
+$protocol = isset($_SERVER["HTTPS"]) ? 'https' : 'http';
+
+$auth0 = new Auth0\SDK\Auth0([
+  'domain' => $_ENV['AUTH0_DOMAIN'],
+  'client_id' => $_ENV['AUTH0_CLIENT_ID'],
+  'client_secret' => $_ENV['AUTH0_CLIENT_SECRET'],
+  'redirect_uri' => $protocol . "://" . $uri . "/top11",
+  'scope' => 'openid email profile',
+]);
+
+require("functions/main_fns.php");
+require_once("models/Top11Factory.php");
+require("partials/_header.php");
 
 // Get the Top11 model
 $db = open_db();
@@ -16,82 +31,103 @@ $top11Model = \YNotRadio\Models\Top11Factory::create($db);
 <div class="row">
   <div class="nine columns content">
     <h1>Top 11 @ 11</h1>
-    <?php 
-      if ($_POST['action']) {
-        require ("partials/_top11_save.php");
-      } else {
-        // Display Top11 message
-        $message = $top11Model->getMessage();
-        echo "<div class=\"top11-message full_height\">
+    <?php
+    if ($_POST['action']) {
+      require("partials/_top11_save.php");
+    } else {
+      // Display Top11 message
+      $message = $top11Model->getMessage();
+      echo "<div class=\"top11-message full_height\">
           <img src=\"imgs/knob_11.jpg\" alt=\"Top 11\" /></td>
           <td id=\"top11message\">" . $message['message'] .
-          "</div>";
-        
-        // Show Top11 list
-        $top11Entries = $top11Model->getAll();
-        $titleEntry = null;
-        
-        foreach ($top11Entries as $entry) {
-            if ($entry['placement'] == 99) {
-                $titleEntry = $entry;
-                break;
-            }
-        }
-        
-        echo "<h2 class=\"center\">Top 11 @ 11 for ". $titleEntry['artist']. "</h2>\n";
-        echo "<table class='table table-striped table-bordered-horizontal table-condensed no-header table-center'>";
-        
-        foreach ($top11Entries as $entry) {
-            if ($entry['placement'] != 99 && $entry['placement'] != 98) {
-                echo "<tr>\n<td>" . $entry['placement'] . " </td>\n" .
-                    "<td>" . $entry['artist'] . "</td>\n" .
-                    "<td>" . $entry['song'] . "</td>\n" .
-                    "<td>" . $entry['note'] . "</td>\n" .
-                    "</tr>\n";
-            }
-        }
-        echo "</table>\n";
-        
-        // Check if voting is open
-        if ($top11Model->getStatus() == "open") {
-          // Display the voting form
-          $songs = $top11Model->getAllSongs();
-          echo "<h2 class=\"center\">Vote for Your Top 3 Y-Not Songs of the Week</h2>\n";
-          echo "<form action=".$page_file." method=\"post\" name=\"top11\" class=\"form-default\">
-            <fieldset>\n<div class=\"control-group\">\n<div class=\"controls\">\n";
-          
-          foreach ($songs as $song) {
-            echo "<label for=\"".$song['id']."\" class=\"half\"><input type=\"checkbox\" name=\"top11[]\" id=\"".$song['id']."\" value=\"".$song['id']."\">".
-              "<span class=\"top11_entry\"> " . $song['artist'] ." - ".$song['song'] ."\n</span>\n</label>\n";
-          }
-          
-          echo "</div></div>\n<div class=\"control-group\">\n<div class=\"controls\">\n";
-          echo "<input type=\"checkbox\" id=\"top11_write_in\"> <input type=\"text\" disabled=\"disabled\" class=\"input-xl\" id=\"write_in_value\" name=\"write_in_value\">\n".
-            "<div class=\"form-other\">Other (please specify)</div>\n</div>\n</div>\n";
-        
-          echo "<div class=\"control-group top-spacer_20 input-seperation\">\n".
-            "<label>First Name</label>\n<div class=\"controls\">\n<input type=\"text\" name=\"firstname\" class=\"input-l\"></div>\n".
-            "<label>Last Name</label>\n<div class=\"controls\">\n<input type=\"text\" name=\"lastname\" class=\"input-l\"/></div>\n".
-            "<label>E-mail</label>\n<div class=\"controls\"><input type=\"text\" name=\"email\" class=\"input-l\"/></div>\n".
-            "<label>Phone Number</label>\n<div class=\"controls\"><input type=\"text\" name=\"phone\" class=\"input-l\"/></div>\n".
-            "<label>Would you like to be entered into this week's contest?</label>\n".
-            "<div class=\"controls inline clearfix\"><label for=\"yes\"><input type=\"radio\" name=\"contest\" id=\"yes\" value=\"yes\" />Yes</label>".
-            "<label for=\"no\"><input type=\"radio\" name=\"contest\" id=\"no\" value=\"no\" />No</label></div>\n".
-            "<label>Would you like to receive Y-Not Radio's weekly Y-Mail newsletter?</label>\n".
-            "<div class=\"controls inline clearfix\"><label for=\"newsletter-yes\"><input type=\"radio\" name=\"newsletter\" id=\"newsletter-yes\" value=\"yes\" />Yes</label>".
-            "<label for=\"newsletter-no\"><input type=\"radio\" name=\"newsletter\" id=\"newsletter-no\" value=\"no\" />No</label>".
-            "<label for=\"newsletter-already\"><input type=\"radio\" name=\"newsletter\" id=\"newsletter-already\" value=\"already\" />I Already Receive It</label></div>\n".
-            "<div class=\"form-actions\"><button class=\"btn-info\" type=\"submit\">Cast Your Vote</button>\n" .
-            "<input type=\"hidden\" name=\"action\" value=\"write\"></div>".
-            "</form>\n</div>\n</fieldset>";
-        } else {
-          echo "<div class=\"information center\">Sorry but voting is currently closed.
-                <br>
-                Check back soon to vote for next week's Top 11 @ 11</div>";
+        "</div>";
+
+      // Show Top11 list
+      $top11Entries = $top11Model->getAll();
+      $titleEntry = null;
+
+      foreach ($top11Entries as $entry) {
+        if ($entry['placement'] == 99) {
+          $titleEntry = $entry;
+          break;
         }
       }
+
+      echo "<h2 class=\"center\">Top 11 @ 11 for " . $titleEntry['artist'] . "</h2>\n";
+      echo "<table class='table table-striped table-bordered-horizontal table-condensed no-header table-center'>";
+
+      foreach ($top11Entries as $entry) {
+        if ($entry['placement'] != 99 && $entry['placement'] != 98) {
+          echo "<tr>\n<td>" . $entry['placement'] . " </td>\n" .
+            "<td>" . $entry['artist'] . "</td>\n" .
+            "<td>" . $entry['song'] . "</td>\n" .
+            "<td>" . $entry['note'] . "</td>\n" .
+            "</tr>\n";
+        }
+      }
+      echo "</table>\n";
+
+      // Check if voting is open
+      if ($top11Model->getStatus() == "open") {
+        // Check if user is authenticated
+        $userInfo = $auth0->getUser();
+        $voter_email = $userInfo['email'] ?? null;
+
+        if (empty($voter_email)) {
+          // User is not logged in - show login button
+          echo "<h2 class=\"center\">Vote for Your Top 3 Y-Not Songs of the Week</h2>\n";
+          echo "<div class=\"information center top-spacer_20\">";
+          echo "<p><strong>Please log in to vote in the Top 11 @ 11.</strong></p>";
+          echo "<a href=\"top11_social_login.php\" class=\"btn-success\">Log in to Vote</a>";
+          echo "</div>";
+        } else if ($top11Model->hasUserVotedThisWeek($voter_email, $userInfo['sub'] ?? null)) {
+          // User has already voted this week
+          echo "<h2 class=\"center\">Vote for Your Top 3 Y-Not Songs of the Week</h2>\n";
+          echo "<div class=\"information center top-spacer_20\">";
+          echo "<p><strong>Thank you for voting!</strong></p>";
+          echo "<p>You have already voted in this week's Top 11 @ 11. Each user can only vote once per week.</p>";
+          echo "<p>Check back next week to vote again!</p>";
+          echo "<a href=\"top11_social_logout.php\" class=\"btn-info\">Log out</a>";
+          echo "</div>";
+        } else {
+          // User is logged in and hasn't voted - show voting form
+          $songs = $top11Model->getAllSongs();
+          echo "<h2 class=\"center\">Vote for Your Top 3 Y-Not Songs of the Week</h2>\n";
+          echo "<div class=\"information center\">Logged in as: <strong>" . htmlspecialchars($voter_email) . "</strong> | <a href=\"top11_social_logout.php\">Log out</a></div>";
+          echo "<form action=" . $page_file . " method=\"post\" name=\"top11\" class=\"form-default\">
+              <fieldset>\n<div class=\"control-group\">\n<div class=\"controls\">\n";
+
+          foreach ($songs as $song) {
+            echo "<label for=\"" . $song['id'] . "\" class=\"half\"><input type=\"checkbox\" name=\"top11[]\" id=\"" . $song['id'] . "\" value=\"" . $song['id'] . "\">" .
+              "<span class=\"top11_entry\"> " . $song['artist'] . " - " . $song['song'] . "\n</span>\n</label>\n";
+          }
+
+          echo "</div></div>\n<div class=\"control-group\">\n<div class=\"controls\">\n";
+          echo "<input type=\"checkbox\" id=\"top11_write_in\"> <input type=\"text\" disabled=\"disabled\" class=\"input-xl\" id=\"write_in_value\" name=\"write_in_value\">\n" .
+            "<div class=\"form-other\">Other (please specify)</div>\n</div>\n</div>\n";
+
+          echo "<div class=\"control-group top-spacer_20 input-seperation\">\n" .
+            "<label>Would you like to be entered into this week's contest?</label>\n" .
+            "<div class=\"controls inline clearfix\"><label for=\"yes\"><input type=\"radio\" name=\"contest\" id=\"yes\" value=\"yes\" />Yes</label>" .
+            "<label for=\"no\"><input type=\"radio\" name=\"contest\" id=\"no\" value=\"no\" />No</label></div>\n" .
+            "<label>Would you like to receive Y-Not Radio's weekly Y-Mail newsletter?</label>\n" .
+            "<div class=\"controls inline clearfix\"><label for=\"newsletter-yes\"><input type=\"radio\" name=\"newsletter\" id=\"newsletter-yes\" value=\"yes\" />Yes</label>" .
+            "<label for=\"newsletter-no\"><input type=\"radio\" name=\"newsletter\" id=\"newsletter-no\" value=\"no\" />No</label>" .
+            "<label for=\"newsletter-already\"><input type=\"radio\" name=\"newsletter\" id=\"newsletter-already\" value=\"already\" />I Already Receive It</label></div>\n" .
+            "<div class=\"form-actions\"><button class=\"btn-info\" type=\"submit\">Cast Your Vote</button>\n" .
+            "<input type=\"hidden\" name=\"action\" value=\"write\">" .
+            "<input type=\"hidden\" name=\"voter_email\" value=\"" . htmlspecialchars($voter_email) . "\">" .
+            "<input type=\"hidden\" name=\"auth0_id\" value=\"" . htmlspecialchars($userInfo['sub'] ?? '') . "\"></div>" .
+            "</form>\n</div>\n</fieldset>";
+        }
+      } else {
+        echo "<div class=\"information center\">Sorry but voting is currently closed.
+                <br>
+                Check back soon to vote for next week's Top 11 @ 11</div>";
+      }
+    }
     ?>
   </div>
-  <div class="three columns"><?php require ("partials/_featured_concerts_and_ads.php") ?></div>
+  <div class="three columns"><?php require("partials/_featured_concerts_and_ads.php") ?></div>
 </div> <!-- end of row div -->
-<?php require ("partials/_footer.php"); ?>
+<?php require("partials/_footer.php"); ?>

--- a/src/top11_social_login.php
+++ b/src/top11_social_login.php
@@ -1,0 +1,21 @@
+<?php
+$page_file = "top11_social_login.php";
+$page_title = "Top 11 Login";
+
+require 'vendor/autoload.php';
+require 'partials/__env_loader.php';
+
+$uri = $_SERVER["HTTP_HOST"];
+$protocol = isset($_SERVER["HTTPS"]) ? 'https' : 'http';
+
+$auth0 = new Auth0\SDK\Auth0([
+    'domain' => $_ENV['AUTH0_DOMAIN'],
+    'client_id' => $_ENV['AUTH0_CLIENT_ID'],
+    'client_secret' => $_ENV['AUTH0_CLIENT_SECRET'],
+    'redirect_uri' => $protocol . "://" . $uri . "/top11",
+    // The scope determines what data is provided in the ID token.
+     // See: https://auth0.com/docs/scopes/current
+     'scope' => 'openid email profile',
+]);
+
+$auth0->login();

--- a/src/top11_social_logout.php
+++ b/src/top11_social_logout.php
@@ -1,0 +1,19 @@
+<?php
+$page_file = "top11_social_logout.php";
+$page_title = "Top 11 Logout";
+
+require 'vendor/autoload.php';
+require 'partials/__env_loader.php';
+
+$uri = $_SERVER["HTTP_HOST"];
+$protocol = isset($_SERVER["HTTPS"]) ? 'https' : 'http';
+
+$auth0 = new Auth0\SDK\Auth0([
+    'domain' => $_ENV['AUTH0_DOMAIN'],
+    'client_id' => $_ENV['AUTH0_CLIENT_ID'],
+    'client_secret' => $_ENV['AUTH0_CLIENT_SECRET'],
+    'redirect_uri' => $protocol . "://" . $uri . "/top11",
+    'scope' => 'openid email profile',
+]);
+
+$auth0->logout($protocol . "://" . $uri . "/top11");


### PR DESCRIPTION
This update integrates Auth0 social login for Top 11 voting, requiring users to authenticate before voting. It introduces a new 'top11_user_votes' table and related model methods to ensure each user can only vote once per week. The voting form and flow are updated to use authenticated user info, and new login/logout endpoints are added.