### PR TITLE
Fix CD of the Week multiple review display

### DIFF
--- a/src/cdoftheweek.php
+++ b/src/cdoftheweek.php
@@ -31,13 +31,35 @@ $cd_id = isset($_GET['id']) ? $_GET['id'] : null;
                      "<div class=\"footnote\">Review by " . $cd['reviewer'] . "</div>\n";
             }
         } else {
+            // Get the most recent date
             $current = $cdOfTheWeek->getCurrent();
             if ($current) {
-                echo "Week of " . date('n/j/y', strtotime($current['date']));
-                echo "<h3>" . $current['artist'] . " - <em>" . $current['title'] . "</em> (" . $current['label'] . ")</h3>\n" .
-                     "<div class='review'> <a href=\"" . $current['band'] . "\" target=_new><img src=\"" . $current['cd_pic_url'] . "\" height=\"200\"> </a>\n" .
-                     $current['review'] . "</div>\n" .
-                     "<div class=\"footnote\">Review by " . $current['reviewer'] . "</div>\n";
+                $latestDate = $current['date'];
+                
+                // Get all CDs with the latest date
+                $latestCds = [];
+                $allCds = $cdOfTheWeek->getAll();
+                foreach ($allCds as $cd) {
+                    if ($cd['date'] == $latestDate) {
+                        $latestCds[] = $cd;
+                    }
+                }
+                
+                // Display the date once
+                echo "Week of " . date('n/j/y', strtotime($latestDate));
+                
+                // Display each CD of the week for the latest date
+                foreach ($latestCds as $cd) {
+                    echo "<h3>" . $cd['artist'] . " - <em>" . $cd['title'] . "</em> (" . $cd['label'] . ")</h3>\n" .
+                         "<div class='review'> <a href=\"" . $cd['band'] . "\" target=_new><img src=\"" . $cd['cd_pic_url'] . "\" height=\"200\"> </a>\n" .
+                         $cd['review'] . "</div>\n" .
+                         "<div class=\"footnote\">Review by " . $cd['reviewer'] . "</div>\n";
+                    
+                    // Add some spacing between multiple reviews
+                    if (end($latestCds) !== $cd) {
+                        echo "<hr class=\"review-separator\">\n";
+                    }
+                }
             }
         }
     } catch (Exception $e) {

--- a/src/models/implementations/SqlCdOfTheWeek.php
+++ b/src/models/implementations/SqlCdOfTheWeek.php
@@ -13,7 +13,22 @@ class SqlCdOfTheWeek implements CdOfTheWeek {
     }
 
     public function getCurrent(): ?array {
-        $query = "SELECT * FROM cdotw WHERE deleted = 'no' ORDER BY date DESC LIMIT 1";
+        // First, get the most recent date
+        $dateQuery = "SELECT MAX(date) as latest_date FROM cdotw WHERE deleted = 'no'";
+        $dateResult = mysqli_query($this->db, $dateQuery);
+        
+        if (!$dateResult) {
+            throw new \RuntimeException("Error fetching latest CD of the week date: " . mysqli_error($this->db));
+        }
+        
+        $dateRow = mysqli_fetch_assoc($dateResult);
+        if (!$dateRow || !$dateRow['latest_date']) {
+            return null;
+        }
+        
+        // Then get the most recent CD with that date
+        $latestDate = mysqli_real_escape_string($this->db, $dateRow['latest_date']);
+        $query = "SELECT * FROM cdotw WHERE date = '{$latestDate}' AND deleted = 'no' ORDER BY id DESC LIMIT 1";
         $result = mysqli_query($this->db, $query);
 
         if (!$result) {
@@ -39,7 +54,7 @@ class SqlCdOfTheWeek implements CdOfTheWeek {
 
     public function getAll(int $limit = 64): array {
         $limit = mysqli_real_escape_string($this->db, $limit);
-        $query = "SELECT * FROM cdotw WHERE deleted = 'no' ORDER BY date DESC LIMIT $limit";
+        $query = "SELECT * FROM cdotw WHERE deleted = 'no' ORDER BY date DESC, id DESC LIMIT $limit";
         $result = mysqli_query($this->db, $query);
 
         if (!$result) {


### PR DESCRIPTION
This PR fixes an issue where multiple CD of the Week reviews with the same date weren't all displaying on the main cdoftheweek.php page. Previously, when two CDOTW reviews had the same date, they would both be displayed, but recently only one was showing.

The changes ensure that:
1. All CD reviews with the most recent date are shown on the main page
2. Date is displayed once at the top
3. Each review is displayed with proper artist, title, label, and reviewer info
4. Multiple reviews are separated with a horizontal rule

This restores the previous functionality that allowed multiple reviews to be featured simultaneously.