### PR TITLE
Update year end poll image to new URL

### DIFF
--- a/src/yearendpoll.php
+++ b/src/yearendpoll.php
@@ -82,7 +82,7 @@ $isPollActive = (time() <= $poll_end_datetime);
         <?php if ($isPollActive): ?>
             <div class="twelve columns">
                 <div class="center top-spacer_20 bottom-spacer_20" style="max-width: 100%">
-                    <img src="https://i.imgur.com/wKQaEW0.gif" alt="YNot Year End Poll 2025" style="max-width: 100%">
+                    <img src="https://i.imgur.com/U7gvgiH.gif" alt="YNot Year End Poll 2025" style="max-width: 100%">
                 </div>
             </div>
 
@@ -181,7 +181,7 @@ $isPollActive = (time() <= $poll_end_datetime);
             // Poll has ended
             ?>
             <div class="center top-spacer_20 bottom-spacer_20">
-                <img src="https://i.imgur.com/wKQaEW0.gif" alt="YNot Year End Poll 2025" style="max-width: 100%">
+                <img src="https://i.imgur.com/U7gvgiH.gif" alt="YNot Year End Poll 2025" style="max-width: 100%">
             </div>
             <p>Thanks to everyone who voted in Y-Not's 2025 Year End Poll! Voting is now closed and we'll be tabulating over the holiday. Tune in from December 29th - January 2nd to hear all the results in Y-Not's Top 225 of 2025 countdown, starting at 10am each day. In the meantime, check out the Y-Not DJs' <a href="yearendstaffpicks.php">top albums and songs</a>!</p>
     </div>

--- a/src/yearendstaffpicks.php
+++ b/src/yearendstaffpicks.php
@@ -17,7 +17,7 @@ $staffPickModel = \YNotRadio\Models\YearEndStaffPickFactory::create($db);
 
     <div class="twelve" style="display:inline-block;">
       <div class="twelve columns" style="max-width: 100%">
-        <div class="center top-spacer_20 bottom-spacer_20"><img src="https://i.imgur.com/wKQaEW0.gif" alt="YNot Year End Poll 2025" style="max-width: 100%"></div>
+        <div class="center top-spacer_20 bottom-spacer_20"><img src="https://i.imgur.com/U7gvgiH.gif" alt="YNot Year End Poll 2025" style="max-width: 100%"></div>
 
         <!-- <div class="six columns"><div class="center top-spacer_20 bottom-spacer_20"><a href="https://gopuff.onelink.me/QbZT/YNotRadio"><img src="https://i.imgur.com/HYYkf7G.png" style="max-width: 100%" /></a></div> -->
       </div>


### PR DESCRIPTION
Replaced the image source URL from https://i.imgur.com/wKQaEW0.gif to https://i.imgur.com/U7gvgiH.gif in yearendpoll.php and yearendstaffpicks.php to reflect the updated graphic for the 2025 Year End Poll.