### PR TITLE
Update backup location and implement automatic cleanup

### DIFF
--- a/bin/pre-deploy.sh
+++ b/bin/pre-deploy.sh
@@ -44,9 +44,14 @@ fi
 echo "📦 Creating backup of htdocs..."
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 BACKUP_FILE="htdocs_backup_${TIMESTAMP}.tar.gz"
-ssh ynotradio "cd /opt/bitnami/apache2 && \
-    tar -czf ~/${BACKUP_FILE} --transform 's,^htdocs/,,' htdocs/ && \
-    echo 'Backup created: ${BACKUP_FILE}'"
+BACKUP_DIR="~/backups/htdocs"
+ssh ynotradio "mkdir -p ${BACKUP_DIR} && \
+    cd /opt/bitnami/apache2 && \
+    tar -czf ${BACKUP_DIR}/${BACKUP_FILE} --transform 's,^htdocs/,,' htdocs/ && \
+    echo 'Backup created: ${BACKUP_DIR}/${BACKUP_FILE}' && \
+    cd ${BACKUP_DIR} && \
+    ls -t htdocs_backup_*.tar.gz | tail -n +16 | xargs -r rm -f && \
+    echo 'Cleaned up old backups, keeping latest 15'"
 
 # Change to the src directory
 cd "$(dirname "$0")/../src"

--- a/bin/rollback.sh
+++ b/bin/rollback.sh
@@ -6,7 +6,7 @@ echo "🔄 Starting rollback process..."
 
 # Get list of backups
 echo "📋 Available backups:"
-BACKUPS=$(ssh ynotradio "ls -1 ~/htdocs_backup_*.tar.gz 2>/dev/null | sort -r")
+BACKUPS=$(ssh ynotradio "ls -1 ~/backups/htdocs/htdocs_backup_*.tar.gz 2>/dev/null | sort -r")
 if [ -z "$BACKUPS" ]; then
     echo "❌ No backups found!"
     exit 1
@@ -55,7 +55,7 @@ ssh ynotradio "set -x && \
     echo 'Creating temporary directory...' && \
     mkdir -p ~/temp_restore && \
     echo 'Extracting backup...' && \
-    tar -xzf ~/$(basename "$BACKUP_FILE") -C ~/temp_restore && \
+    tar -xzf "$BACKUP_FILE" -C ~/temp_restore && \
     echo 'Checking extracted contents...' && \
     ls -la ~/temp_restore/ && \
     echo 'Copying files to htdocs...' && \


### PR DESCRIPTION
## Summary
- Move htdocs backups from home directory to `~/backups/htdocs/` for better organization
- Implement automatic cleanup to keep only the latest 15 backup files, preventing unlimited disk usage growth
- Update rollback script to find backups in the new location

## Changes
- **bin/pre-deploy.sh**: Modified backup creation to use `~/backups/htdocs/` directory and added cleanup logic using `ls -t | tail -n +16 | xargs rm` to remove old backups
- **bin/rollback.sh**: Updated backup file path from `~/htdocs_backup_*.tar.gz` to `~/backups/htdocs/htdocs_backup_*.tar.gz` and fixed extraction to use full path

## Test plan
- [ ] Deploy to production and verify backup is created in `~/backups/htdocs/`
- [ ] Run multiple deploys to verify old backups are automatically cleaned up after the 15th backup
- [ ] Test rollback script to ensure it can find and restore from backups in the new location
- [ ] Verify existing backups can be moved to new location using: `mkdir -p ~/backups/htdocs && mv ~/*.tar.gz ~/backups/htdocs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)