### PR TITLE
Fix deejay import to create DJ documents

### DIFF
--- a/bin/migrations/sanityImport.ts
+++ b/bin/migrations/sanityImport.ts
@@ -186,9 +186,26 @@ export async function importDeejaysDirectly(deejays: Deejay[]): Promise<boolean>
     let successCount = 0;
     for (const deejay of deejays) {
       try {
-        const doc = await processSingleDeejay(deejay);
-        await client.createOrReplace(doc);
-        console.log(`Imported deejay: ${deejay.name}`);
+        // Create the person document
+        const personDoc = await processSingleDeejay(deejay);
+        await client.createOrReplace(personDoc);
+        console.log(`Imported person: ${deejay.name}`);
+        
+        // Create the DJ document that references the person
+        const djDoc = {
+          _id: `dj-${deejay.id}`,
+          _type: 'dj',
+          person: {
+            _type: 'reference',
+            _ref: `deejay-${deejay.id}`,
+          },
+          sortOrder: deejay.sort,
+          isActive: true,
+          _createdAt: `${new Date().toISOString().split('T')[0]}T00:00:00Z`,
+        };
+        await client.createOrReplace(djDoc);
+        console.log(`Imported DJ document for: ${deejay.name}`);
+        
         successCount++;
       } catch (error) {
         console.error(`Failed to import deejay ${deejay.name}:`, error);


### PR DESCRIPTION
## Problem
The deejay import script was only creating `person` documents, but the Sanity Studio DJ list requires `dj` documents that reference those person records. This caused all imported DJs to be invisible in the DJ management section.

## Solution
Updated `importDeejaysDirectly()` in `bin/migrations/sanityImport.ts` to create both:
1. A `person` document with biographical information
2. A `dj` document that references the person and includes `sortOrder` and `isActive` fields

## Testing
- Verified all 48 person records now have corresponding DJ documents
- Confirmed DJs appear in Sanity Studio at http://localhost:3333/sanity/structure/dJs;allDJs
- Re-ran import script successfully

## Notes
This fix has been applied to the existing data as well, so all previously imported DJs are now visible in the Studio.