### PR TITLE
Redirect yearendpoll.php to top225of2025 page

### DIFF
--- a/src/yearendpoll.php
+++ b/src/yearendpoll.php
@@ -1,5 +1,8 @@
 <?php
 
+header("Location: pages.php?page=top225of2025");
+exit;
+
 $page_file = "yearendpoll.php";
 $page_title = "Year End Poll";
 $poll_end_datetime = strtotime("12/23/25 11:59pm EST");


### PR DESCRIPTION
Added a header redirect and exit statement at the start of yearendpoll.php to forward users to pages.php?page=top225of2025. This change prevents direct access to the yearendpoll.php script.