### PR TITLE
Fix Storybook mock imports to resolve TypeScript build errors

### DIFF
--- a/payload/src/components/fields/MusicBrainzArtistField.stories.tsx
+++ b/payload/src/components/fields/MusicBrainzArtistField.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { setMockFieldValue, setMockFormFields, resetMocks } from '@payloadcms/ui';
+import { setMockFieldValue, setMockFormFields, resetMocks } from '@/.storybook/mocks/@payloadcms/ui';
 import { MusicBrainzArtistField } from './MusicBrainzArtistField';
 
 const meta = {

--- a/payload/src/components/fields/MusicBrainzRecordingField.stories.tsx
+++ b/payload/src/components/fields/MusicBrainzRecordingField.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { setMockFieldValue, setMockFormFields, resetMocks } from '@payloadcms/ui';
+import { setMockFieldValue, setMockFormFields, resetMocks } from '@/.storybook/mocks/@payloadcms/ui';
 import { MusicBrainzRecordingField } from './MusicBrainzRecordingField';
 
 const meta = {

--- a/payload/src/components/fields/MusicBrainzReleaseField.stories.tsx
+++ b/payload/src/components/fields/MusicBrainzReleaseField.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { setMockFieldValue, setMockFormFields, resetMocks } from '@payloadcms/ui';
+import { setMockFieldValue, setMockFormFields, resetMocks } from '@/.storybook/mocks/@payloadcms/ui';
 import { MusicBrainzReleaseField } from './MusicBrainzReleaseField';
 
 const meta = {


### PR DESCRIPTION
## Problem

`yarn build` was failing with TypeScript errors:
```
'@payloadcms/ui' has no exported member named 'setMockFormFields'
```

## Root Cause

The story files were importing mock functions (`setMockFieldValue`, `setMockFormFields`, `resetMocks`) from `@payloadcms/ui`, which doesn't actually export them. 

These mock functions only exist in `.storybook/mocks/@payloadcms/ui.ts` and are aliased during **Storybook builds only** via Vite config in `.storybook/main.ts`.

TypeScript compilation (`yarn build`) doesn't use the Vite config, so it doesn't know about the alias.

## How It Was Working Before

- **Storybook builds** were passing because Vite aliases `@payloadcms/ui` → `.storybook/mocks/@payloadcms/ui.ts`
- **TypeScript compilation** wasn't running on `.stories.tsx` files (they were likely excluded or not checked)

## Solution

Changed all three story files to import mocks directly from the mock file:
```typescript
// Before
import { setMockFieldValue, setMockFormFields, resetMocks } from '@payloadcms/ui';

// After  
import { setMockFieldValue, setMockFormFields, resetMocks } from '@/.storybook/mocks/@payloadcms/ui';
```

This fixes the TypeScript build while maintaining Storybook functionality.

## Testing

- ✅ `yarn build` now passes
- ✅ Storybook should still work (Vite alias is still in place for the actual components)