### PR TITLE
Fix: Ensure role field is loaded in req.user for access control

### DIFF
--- a/payload/src/collections/Users.ts
+++ b/payload/src/collections/Users.ts
@@ -30,6 +30,7 @@ export const Users: CollectionConfig = {
   auth: {
     tokenExpiration: 60 * 60 * 4, // 4 hours
     verify: true,
+    depth: 0, // Ensure all user fields are loaded
   },
   access: {
     read: ({ req, id }) => {


### PR DESCRIPTION
## Problem
Admin users were getting 403 Forbidden errors when trying to create new users at /admin/collections/users/create.

## Root Cause
`req.user` in Payload CMS only includes `id` and `email` by default. The `role` field wasn't being loaded, so `hasRole(req.user, 'admin')` checks were failing even for valid admin users.

## Solution
Added `depth: 0` to the auth configuration in the Users collection. This ensures all user fields (including `role`) are loaded into `req.user` during authentication.

## Testing
After deployment, log out and log back in to get a fresh auth token with the role field included. User creation should then work for admin users.