### PR TITLE
Fix on-air DJ display timezone regression

### DIFF
--- a/src/functions/main_fns.php
+++ b/src/functions/main_fns.php
@@ -166,8 +166,9 @@ function on_air(){
     $db = open_db();
     $scheduleModel = \YNotRadio\Models\ScheduleFactory::create($db);
     
-    // Get today's schedule
-    $todaySchedule = $scheduleModel->getByDate(gmdate('Y-m-d')); // Use UTC date to match database timezone
+    // Get today's schedule using local date, not UTC
+    // This avoids timezone issues where gmdate() can give the next day in UTC while date() is still in local time
+    $todaySchedule = $scheduleModel->getByDate(date('Y-m-d'));
     
     // Find current time slot
     $currentTime = date('H:i:s');


### PR DESCRIPTION
## Problem
Joey O. reported seeing "Judy G." in the on-air spot on Jan 29 at 7:26 PM EST, when he expected to see his own name.

## Root Cause
Regression from commit d2825c1 (Jan 28, 2026) that incorrectly changed the on_air() function to use `gmdate('Y-m-d')` instead of `date('Y-m-d')`.

When local time is EST and crosses into UTC's next day (e.g., Jan 29 at 19:26 EST = Jan 30 at 00:26 UTC):
- `gmdate('Y-m-d')` returns "2026-01-30" (UTC date)
- `date('H:i:s')` returns "19:26" (EST time)

This mismatch caused the function to fetch Jan 30's schedule while checking Jan 29's time slot, finding Judy G. (18:00-21:00 on Jan 30) instead of Joey O. (15:00-21:00 on Jan 29).

## Solution
Reverted to `date('Y-m-d')` for consistent local timezone. Both date and time now use the server's local timezone, ensuring correct schedule retrieval.

## Data Verification
- Jan 29, 15:00-21:00: Joey O. ✓
- Jan 30, 18:00-21:00: Judy G. (was being shown incorrectly)

## Testing
- [x] Verified on local environment
- [x] Confirmed schedule data in MySQL
- [x] Regression identified in git history