### PR TITLE
test: Add E2E tests for Year End Poll

### DIFF
--- a/bin/seed-legacy.sh
+++ b/bin/seed-legacy.sh
@@ -83,6 +83,90 @@ INSERT INTO cdotw (artist, title, label, review, cd_pic_url, band, reviewer, dat
 'This is a sample review for testing purposes. <b>Sample Artist</b> delivers an incredible performance on their latest album <em>Great Album</em>. The production is crisp, the songwriting is mature, and the energy is infectious. Standout tracks include "Hit Single" and "Deep Cut". Highly recommended!', 
 'https://i.imgur.com/album1.jpg', 'https://sampleartist.com', 'Test Reviewer', CURDATE(), 'no');
 
+-- Seed Year End Poll tables with controlled test fixtures
+-- Clear voting tracking tables for a clean test state
+DELETE FROM year_end_ips;
+DELETE FROM year_end_song_votes;
+DELETE FROM year_end_write_ins;
+DELETE FROM year_end_contestants;
+
+-- Seed poll option tables with a small, predictable dataset
+DELETE FROM year_end_songs;
+INSERT INTO year_end_songs (artist, title, votes) VALUES
+('Franz Ferdinand', 'Audacious', 0),
+('Wet Leg', 'Oh No', 0),
+('HAIM', 'Lost Track', 0),
+('The Beths', 'Knucklehead', 0),
+('Pulp', 'Spike Island', 0);
+
+DELETE FROM year_end_albums;
+INSERT INTO year_end_albums (artist, title, votes) VALUES
+('Franz Ferdinand', 'The Human Fear', 0),
+('Wet Leg', 'moisturizer', 0),
+('HAIM', 'I Quit', 0),
+('The Beths', 'Straight Line Was a Lie', 0),
+('Pulp', 'More', 0);
+
+DELETE FROM year_end_artists;
+INSERT INTO year_end_artists (artist, votes) VALUES
+('Franz Ferdinand', 0),
+('Wet Leg', 0),
+('HAIM', 0),
+('The Beths', 0),
+('Pulp', 0);
+
+DELETE FROM year_end_concerts;
+INSERT INTO year_end_concerts (concert, votes) VALUES
+('Franz Ferdinand @ The Fillmore', 0),
+('Wet Leg @ Franklin Music Hall', 0),
+('HAIM @ Mann Center', 0);
+
+DELETE FROM year_end_new_artists;
+INSERT INTO year_end_new_artists (artist, votes) VALUES
+('Lambrini Girls', 0),
+('Rocket', 0),
+('Wisp', 0);
+
+DELETE FROM year_end_philly_artists;
+INSERT INTO year_end_philly_artists (artist, votes) VALUES
+('Kurt Vile', 0),
+('Mannequin Pussy', 0),
+('Tisburys, The', 0);
+
+DELETE FROM year_end_most_anticipated_albums;
+INSERT INTO year_end_most_anticipated_albums (artist, votes) VALUES
+('LCD Soundsystem', 0),
+('Radiohead', 0);
+
+DELETE FROM year_end_tv_dramas;
+INSERT INTO year_end_tv_dramas (title, votes) VALUES
+('Severance', 0),
+('Andor', 0),
+('The Bear', 0);
+
+DELETE FROM year_end_tv_comedies;
+INSERT INTO year_end_tv_comedies (title, votes) VALUES
+('Abbott Elementary', 0),
+('Only Murders in the Building', 0),
+('Hacks', 0);
+
+DELETE FROM year_end_best_movies;
+INSERT INTO year_end_best_movies (title, votes) VALUES
+('Sinners', 0),
+('Superman', 0),
+('The Naked Gun', 0);
+
+DELETE FROM year_end_worst_movies;
+INSERT INTO year_end_worst_movies (title, votes) VALUES
+('Snow White', 0),
+('A Minecraft Movie', 0);
+
+DELETE FROM year_end_unnecessary_sequels;
+INSERT INTO year_end_unnecessary_sequels (title, votes) VALUES
+('Freakier Friday', 0),
+('Happy Gilmore 2', 0),
+('Five Nights at Freddy''s 2', 0);
+
 EOF
 
 # Import the seed data
@@ -101,6 +185,8 @@ echo "   Stories: $(docker compose exec -T -e MYSQL_PWD=root mysql mysql -u root
 echo "   DJs: $(docker compose exec -T -e MYSQL_PWD=root mysql mysql -u root ynot_site -N -e "SELECT COUNT(*) FROM deejays")"
 echo "   Concerts: $(docker compose exec -T -e MYSQL_PWD=root mysql mysql -u root ynot_site -N -e "SELECT COUNT(*) FROM concerts")"
 echo "   CD of the Week: $(docker compose exec -T -e MYSQL_PWD=root mysql mysql -u root ynot_site -N -e "SELECT COUNT(*) FROM cdotw")"
+echo "   Year End Songs: $(docker compose exec -T -e MYSQL_PWD=root mysql mysql -u root ynot_site -N -e "SELECT COUNT(*) FROM year_end_songs")"
+echo "   Year End Albums: $(docker compose exec -T -e MYSQL_PWD=root mysql mysql -u root ynot_site -N -e "SELECT COUNT(*) FROM year_end_albums")"
 echo ""
 echo "🌐 View at: http://localhost:8080"
 echo "🗄️  PHPMyAdmin: http://localhost:8181"

--- a/bin/setup-e2e-env.sh
+++ b/bin/setup-e2e-env.sh
@@ -67,6 +67,9 @@ USE_POSTGRES_CDOFTHEWEEK=true
 USE_POSTGRES_SCHEDULE=true
 USE_POSTGRES_CUSTOMTEXT=true
 
+# Force seasonal features open for E2E testing
+FORCE_YEAR_END_POLL_OPEN=true
+
 # Configure for legacy PHP site with MySQL (inside Docker network)
 DB_HOST=mysql
 DB_PORT=3306

--- a/e2e/top11.spec.ts
+++ b/e2e/top11.spec.ts
@@ -31,7 +31,7 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
 
   test('page loads without PHP errors', async ({ page }, testInfo) => {
     const url = `${LEGACY_BASE_URL}/top11.php`;
-    const status = await navigateWithRetry(page, url);
+    const { status } = await navigateWithRetry(page, url);
 
     expect(status).toBe(200);
 
@@ -79,9 +79,7 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
     await expect(knobImage).toBeVisible();
 
     // Should display the weekly countdown message text
-    await expect(
-      page.getByText(/Y-Not Radio counts down the Top 11/i),
-    ).toBeVisible();
+    await expect(page.getByText(/Y-Not Radio counts down the Top 11/i)).toBeVisible();
 
     await captureScreenshot(page, testInfo, '03-Top11-Message-Section');
   });
@@ -104,7 +102,10 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
 
     const loginButton = page.getByRole('link', { name: /log in to vote/i });
     const showsLoginPrompt = await loginButton.isVisible().catch(() => false);
-    test.skip(!showsLoginPrompt, 'Login prompt is not visible; voting may be closed or user is already logged in');
+    test.skip(
+      !showsLoginPrompt,
+      'Login prompt is not visible; voting may be closed or user is already logged in',
+    );
 
     await expect(loginButton).toBeVisible();
     await captureScreenshot(page, testInfo, '04b-Top11-Login-Required');
@@ -117,20 +118,24 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
 
     const alreadyVotedMessage = page.getByText(/you've already voted/i);
     const hasAlreadyVoted = await alreadyVotedMessage.isVisible().catch(() => false);
-    test.skip(!hasAlreadyVoted, 'Already-voted message is not visible; user has not voted or voting is closed');
+    test.skip(
+      !hasAlreadyVoted,
+      'Already-voted message is not visible; user has not voted or voting is closed',
+    );
 
     await expect(alreadyVotedMessage).toBeVisible();
     await captureScreenshot(page, testInfo, '04c-Top11-Already-Voted');
   });
 
-  test('shows voting form when user is logged in and has not voted', async ({
-    page,
-  }, testInfo) => {
+  test('shows voting form when user is logged in and has not voted', async ({ page }, testInfo) => {
     await navigateWithRetry(page, `${LEGACY_BASE_URL}/top11.php`);
 
     const votingForm = page.locator('form[name="top11"]');
     const hasVotingForm = await votingForm.isVisible().catch(() => false);
-    test.skip(!hasVotingForm, 'Voting form is not visible; voting may be closed or user is not logged in');
+    test.skip(
+      !hasVotingForm,
+      'Voting form is not visible; voting may be closed or user is not logged in',
+    );
 
     await expect(votingForm).toBeVisible();
     await captureScreenshot(page, testInfo, '04d-Top11-Voting-Form');
@@ -144,7 +149,10 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
     const isFormVisible = await votingForm.isVisible().catch(() => false);
 
     if (!isFormVisible) {
-      test.skip(!isFormVisible, 'Voting form is not visible; voting closed or user is not logged in');
+      test.skip(
+        !isFormVisible,
+        'Voting form is not visible; voting closed or user is not logged in',
+      );
       return;
     }
 
@@ -155,7 +163,9 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
     expect(checkboxCount).toBeGreaterThan(0);
 
     // Write-in section - find fields by the "Other (please specify)" label text
-    const writeInContainer = page.locator('.controls').filter({ hasText: 'Other (please specify)' });
+    const writeInContainer = page
+      .locator('.controls')
+      .filter({ hasText: 'Other (please specify)' });
     await expect(writeInContainer.locator('input[type="checkbox"]')).toBeVisible();
     await expect(writeInContainer.locator('input[type="text"]')).toBeVisible();
 
@@ -176,7 +186,10 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
     const isLoginVisible = await loginButton.isVisible().catch(() => false);
 
     if (!isLoginVisible) {
-      test.skip(!isLoginVisible, 'Login button not visible; voting closed or user is already logged in');
+      test.skip(
+        !isLoginVisible,
+        'Login button not visible; voting closed or user is already logged in',
+      );
       return;
     }
 

--- a/e2e/utils/test-helpers.ts
+++ b/e2e/utils/test-helpers.ts
@@ -5,19 +5,21 @@ import { Page, TestInfo } from '@playwright/test';
  * @param page - Playwright page object
  * @param url - URL to navigate to
  * @param maxRetries - Maximum number of retry attempts (default: 5)
- * @returns HTTP status code or null if all retries fail
+ * @returns Object with HTTP status code and final URL after any redirects
  */
 export async function navigateWithRetry(
   page: Page,
   url: string,
   maxRetries = 5,
-): Promise<number | null> {
+): Promise<{ status: number | null; finalUrl: string }> {
   let response = null;
   for (let i = 0; i < maxRetries; i += 1) {
     try {
       // eslint-disable-next-line no-await-in-loop
       response = await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
-      if (response?.status() === 200) return response.status();
+      if (response?.status() === 200) {
+        return { status: response.status(), finalUrl: page.url() };
+      }
     } catch {
       // eslint-disable-next-line no-console
       console.log(`Navigation attempt ${i + 1}/${maxRetries} failed, retrying...`);
@@ -25,7 +27,7 @@ export async function navigateWithRetry(
       await page.waitForTimeout(5000);
     }
   }
-  return response?.status() || null;
+  return { status: response?.status() || null, finalUrl: page.url() };
 }
 
 /**
@@ -120,11 +122,7 @@ function getOrdinalSuffix(day: number): string {
  * @param fieldId - ID of the date field (e.g., 'field-date')
  * @param date - Date object to set
  */
-export async function fillPayloadDateField(
-  page: Page,
-  fieldId: string,
-  date: Date,
-): Promise<void> {
+export async function fillPayloadDateField(page: Page, fieldId: string, date: Date): Promise<void> {
   // Click on the date field to open date picker
   const dateField = page.locator(`#${fieldId}`).getByRole('textbox');
   await dateField.waitFor({ state: 'visible', timeout: 30000 });

--- a/e2e/year-end-poll.spec.ts
+++ b/e2e/year-end-poll.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Year End Poll E2E Tests
+ *
+ * Tests for the Y-Not Radio Year End Poll feature.
+ * The poll allows users to vote in 12 categories with different max picks,
+ * and enter a contest for prizes.
+ *
+ * Poll Categories (from SqlYearEndPoll model):
+ * - songs (20 picks), albums (10), artists (5), concerts (2),
+ *   new_artists (3), philly_artists (5), most_anticipated_albums (2),
+ *   tv_dramas (3), tv_comedies (3), best_movies (3),
+ *   worst_movies (2), unnecessary_sequels (2)
+ *
+ * Note: The poll is seasonal. When closed, yearendpoll.php redirects.
+ * Set FORCE_YEAR_END_POLL_OPEN=true in .env.local to test the active state.
+ */
+import { test, expect, Page } from '@playwright/test';
+import { checkForPhpErrors, captureScreenshot, navigateWithRetry } from './utils/test-helpers';
+
+const LEGACY_BASE_URL = process.env.LEGACY_BASE_URL || 'http://localhost:8080';
+
+/**
+ * Check if poll is currently active (not redirecting)
+ */
+async function isPollActive(page: Page): Promise<boolean> {
+  const { finalUrl } = await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php`);
+  return finalUrl.includes('yearendpoll.php') && !finalUrl.includes('page=');
+}
+
+test.describe('Year End Poll', () => {
+  test.describe('Page Accessibility', () => {
+    test('yearendpoll.php is accessible and returns valid response', async ({ page }) => {
+      const { status } = await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php`);
+
+      expect(status).toBe(200);
+
+      const pageContent = await page.content();
+      const errors = checkForPhpErrors(pageContent);
+      expect(errors).toHaveLength(0);
+    });
+
+    test('staff picks page loads correctly', async ({ page }) => {
+      const { status } = await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendstaffpicks.php`);
+
+      expect(status).toBe(200);
+
+      const pageContent = await page.content();
+      const errors = checkForPhpErrors(pageContent);
+      expect(errors).toHaveLength(0);
+
+      await expect(page.getByRole('heading', { name: /Y-Not Staff Favorites/i })).toBeVisible();
+    });
+  });
+
+  test.describe('Poll Active State', () => {
+    test.beforeEach(async ({ page }) => {
+      const active = await isPollActive(page);
+      test.skip(
+        !active,
+        'Poll is currently closed/redirecting — set FORCE_YEAR_END_POLL_OPEN=true to test',
+      );
+    });
+
+    test('poll dashboard displays all 12 categories', async ({ page }, testInfo) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php`);
+
+      await captureScreenshot(page, testInfo, 'poll-dashboard');
+
+      await expect(page.getByRole('link', { name: 'songs' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'albums' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'artists' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'concerts' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'new artists' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'philly artists' })).toBeVisible();
+      await expect(page.getByRole('link', { name: /most anticipated/i })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'tv dramas' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'tv comedies' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'best movies' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'worst movies' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'unnecessary sequels' })).toBeVisible();
+    });
+
+    test('albums voting form is visible when category selected', async ({ page }, testInfo) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=albums`);
+
+      await captureScreenshot(page, testInfo, 'poll-albums-form');
+
+      const form = page.locator('form[name*="year_end"]');
+      await expect(form).toBeVisible({ timeout: 10000 });
+    });
+
+    test('albums voting form has checkbox options', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=albums`);
+
+      const checkboxes = page.locator('input[type="checkbox"][name="year_end_votes[]"]');
+      const checkboxCount = await checkboxes.count();
+      expect(checkboxCount).toBeGreaterThan(0);
+    });
+
+    test('albums voting form shows seeded artist and album names', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=albums`);
+
+      // These are seeded in bin/seed-legacy.sh
+      await expect(page.getByText('Franz Ferdinand')).toBeVisible();
+      await expect(page.getByText('The Human Fear')).toBeVisible();
+      await expect(page.getByText('Wet Leg')).toBeVisible();
+    });
+
+    test('submit button is initially disabled', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=albums`);
+
+      const submitButton = page.locator('#vote');
+      await expect(submitButton).toBeVisible();
+      await expect(submitButton).toBeDisabled();
+    });
+
+    test('submit button shows remaining pick count', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=concerts`);
+
+      const submitButton = page.locator('#vote');
+      await expect(submitButton).toHaveText(/Pick 2 more!/i);
+    });
+
+    test('submit button decrements count after selecting a checkbox', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=concerts`);
+
+      const checkboxes = page.locator('input[type="checkbox"][name="year_end_votes[]"]');
+      await checkboxes.first().check();
+
+      const submitButton = page.locator('#vote');
+      await expect(submitButton).toHaveText(/Pick 1 more!/i);
+    });
+
+    test('checkbox selection respects max picks limit', async ({ page }, testInfo) => {
+      // artists category has max 5 picks
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=artists`);
+
+      const checkboxes = page.locator('input[type="checkbox"][name="year_end_votes[]"]');
+      const checkboxCount = await checkboxes.count();
+      expect(checkboxCount).toBeGreaterThan(0);
+
+      for (let i = 0; i < Math.min(5, checkboxCount); i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await checkboxes.nth(i).check();
+      }
+
+      await captureScreenshot(page, testInfo, 'poll-artists-max-selected');
+
+      const submitButton = page.locator('#vote');
+      await expect(submitButton).not.toBeDisabled({ timeout: 5000 });
+
+      const checkedCount = await page
+        .locator('input[type="checkbox"][name="year_end_votes[]"]:checked')
+        .count();
+      expect(checkedCount).toBe(5);
+    });
+
+    test('write-in field is disabled until checkbox is checked', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=songs`);
+
+      const writeInArea = page.locator('.control-group:has(.form-other)');
+      const writeInCheckbox = writeInArea.locator('input[type="checkbox"]');
+      const writeInField = writeInArea.locator('input[type="text"]');
+
+      const hasWriteIn = (await writeInCheckbox.count()) > 0;
+      test.skip(!hasWriteIn, 'This poll category does not have write-in option');
+
+      await expect(writeInField).toBeDisabled();
+      await writeInCheckbox.check();
+      await expect(writeInField).toBeEnabled();
+    });
+
+    test('all 12 poll category links are present on dashboard', async ({ page }) => {
+      await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php`);
+
+      const allPollLinks = page.locator('a.poll');
+      await expect(allPollLinks).toHaveCount(12);
+    });
+  });
+
+  test.describe('Poll Closed State', () => {
+    test('closed poll redirects away from yearendpoll.php', async ({ page }, testInfo) => {
+      const { finalUrl } = await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php`);
+
+      const isActive = finalUrl.includes('yearendpoll.php') && !finalUrl.includes('page=');
+      test.skip(isActive, 'Poll is currently active — this test requires the poll to be closed');
+
+      await captureScreenshot(page, testInfo, 'poll-closed-redirect');
+
+      expect(finalUrl).toMatch(/pages\.php|top\d+/i);
+
+      const pageContent = await page.content();
+      const errors = checkForPhpErrors(pageContent);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  test.describe('Error Handling', () => {
+    test.beforeEach(async ({ page }) => {
+      const active = await isPollActive(page);
+      test.skip(!active, 'Poll is closed — error handling tests require active poll');
+    });
+
+    test('invalid poll parameter is handled gracefully', async ({ page }) => {
+      const { status } = await navigateWithRetry(
+        page,
+        `${LEGACY_BASE_URL}/yearendpoll.php?poll=invalid_poll_name`,
+      );
+
+      expect(status).toBe(200);
+
+      const pageContent = await page.content();
+      const errors = checkForPhpErrors(pageContent);
+      expect(errors).toHaveLength(0);
+    });
+
+    test('empty poll param loads dashboard', async ({ page }) => {
+      const { status } = await navigateWithRetry(page, `${LEGACY_BASE_URL}/yearendpoll.php?poll=`);
+
+      expect(status).toBe(200);
+
+      const pageContent = await page.content();
+      const errors = checkForPhpErrors(pageContent);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/yearendpoll.php
+++ b/src/yearendpoll.php
@@ -1,11 +1,18 @@
 <?php
 
-header("Location: pages.php?page=top225of2025");
-exit;
+// Allow E2E tests to force the poll open via environment variable
+$forcePollOpen = getenv('FORCE_YEAR_END_POLL_OPEN') === 'true';
+
+if (!$forcePollOpen) {
+    header("Location: pages.php?page=top225of2025");
+    exit;
+}
 
 $page_file = "yearendpoll.php";
 $page_title = "Year End Poll";
-$poll_end_datetime = strtotime("12/23/25 11:59pm EST");
+$poll_end_datetime = $forcePollOpen
+    ? strtotime("+1 year")
+    : strtotime("12/23/25 11:59pm EST");
 
 require_once "functions/main_fns.php";
 require_once "controllers/YearEndPollController.php";


### PR DESCRIPTION
Supersedes #293 (rebased cleanly on master).

## Changes
- Add `e2e/year-end-poll.spec.ts` — 14 Playwright tests covering dashboard, voting forms, checkbox limits, write-in fields, poll closed state, error handling
- Upgrade `navigateWithRetry` to return `{ status, finalUrl }` for redirect tracking
- Add `FORCE_YEAR_END_POLL_OPEN` env var override to `yearendpoll.php` so tests can exercise the active poll state even when seasonally closed
- Seed year-end poll tables in `bin/seed-legacy.sh` with controlled test fixtures

## Testing
- [x] Lint passes
- [x] All tests designed to run in both poll-open and poll-closed states