### PR TITLE
fix: Add @next/env ESM workaround for import scripts

### DIFF
--- a/bin/incremental-import.ts
+++ b/bin/incremental-import.ts
@@ -202,8 +202,19 @@ function runImportScript(
 ): Promise<ImportResult> {
   return new Promise((resolve) => {
     // Pass --to directly to individual import scripts
-    const args = ['tsx', script, '--to', to, '--start-id', startId.toString()];
-    const child = spawn('yarn', args, { stdio: 'pipe' });
+    // Use preload fix for @next/env ESM/CJS interop issue with Payload
+    const args = [
+      '--import',
+      './bin/preload-nextenv-fix.mjs',
+      '--import',
+      'tsx',
+      script,
+      '--to',
+      to,
+      '--start-id',
+      startId.toString(),
+    ];
+    const child = spawn('node', args, { stdio: 'pipe' });
 
     let output = '';
     const skipReasons: string[] = [];

--- a/bin/preload-nextenv-fix.mjs
+++ b/bin/preload-nextenv-fix.mjs
@@ -1,0 +1,25 @@
+// Preload script to fix @next/env ESM/CJS interop issue
+// Usage: node --import tsx --import ./bin/preload-nextenv-fix.mjs bin/migrations/importMusic.ts
+
+import * as nextEnv from '@next/env';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const Module = require('module');
+const originalLoad = Module._load;
+
+// Patch Module._load to return fixed @next/env module
+Module._load = function(request, parent, isMain) {
+  if (request === '@next/env') {
+    // Return a module with both named exports and a default that works with Payload
+    return {
+      ...nextEnv,
+      default: nextEnv
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+// Also patch for ESM dynamic imports
+const originalDynamicImport = globalThis.import;
+// Note: Can't easily patch dynamic imports, but the Module._load should handle CJS requires


### PR DESCRIPTION
## Changes
- Added `bin/preload-nextenv-fix.mjs` to patch @next/env ESM/CJS interop issue
- Updated `incremental-import.ts` to use preload fix for child processes

## Context
Payload 3.76.1 + tsx has an ESM compatibility issue where `@next/env` named exports aren't properly destructured. This blocked all import scripts.

## Testing
- [x] Ran `importGapReport.ts` successfully
- [x] Ran `incremental-import.ts` with all collections
- [x] Achieved full MySQL → Neon parity (0 missing records)

## Import Parity Report
| Collection | MySQL | Payload | Missing |
|------------|-------|---------|---------|
| ✅ Posts | 651 | 767 | 0 |
| ✅ Custom Texts | 35 | 35 | 0 |
| ✅ Songs | 5,451 | 5,451 | 0 |
| ✅ Concerts | 4,440 | 4,440 | 0 |
| ✅ On Demand | 0 | 484 | 0 |
| ✅ CD of the Week | 0 | 460 | 0 |
| ✅ Ads | 41 | 57 | 0 |
| ✅ DJs | 84 | 84 | 0 |