### PR TITLE
docs: MRM match management features (overtime, rematch, admin vote, audit log)

### DIFF
--- a/docs/migrations/phases/phase4_modern_rock_madness.yml
+++ b/docs/migrations/phases/phase4_modern_rock_madness.yml
@@ -189,11 +189,11 @@ match_management:
       - vote_count_after
 
   audit_log:
-    # A new Payload collection: MadnessMatchEvents
+    # A new Payload collection: ModernRockMadnessEvents
     # Append-only event log for all admin actions on matches.
     # Payload auto-tracks createdAt and the authenticated user,
     # so "who did it and when" comes for free.
-    collection: MadnessMatchEvents
+    collection: ModernRockMadnessEvents
     description: >
       Append-only log of admin actions on matches. Each record captures
       a single event (overtime extension, rematch, admin vote, match close).
@@ -233,5 +233,5 @@ match_management:
 # 6. Sponsor relationships need to be preserved
 # 7. Match management features (overtime, rematch, admin vote) are currently
 #    handled manually in PHPMyAdmin and need proper admin UI in Payload
-# 8. Audit log (MadnessMatchEvents) is new — no legacy data to migrate, but
+# 8. Audit log (ModernRockMadnessEvents) is new — no legacy data to migrate, but
 #    the collection must be created alongside the matches collection

--- a/docs/payload-migration/03-core-data-models.md
+++ b/docs/payload-migration/03-core-data-models.md
@@ -35,7 +35,7 @@
 | 23       | ModernRockMadnessGroups      | `modern_rock_madness_groups`      | 🔲 Todo     | Tournament participants                                                                |
 | 24       | ModernRockMadnessMatches     | `modern_rock_madness_matches`     | 🔲 Todo     | Bracket matchups                                                                       |
 | 25       | ModernRockMadnessVotes       | `modern_rock_madness_votes`       | 🔲 Todo     | User votes (PostgreSQL native)                                                         |
-| 26       | MadnessMatchEvents           | `madness_match_events`            | 🔲 Todo     | Audit log for match admin actions (overtime, rematch, admin vote)                      |
+| 26       | ModernRockMadnessEvents      | `modern_rock_madness_events`      | 🔲 Todo     | Audit log for match admin actions (overtime, rematch, admin vote)                      |
 
 ### Summary
 


### PR DESCRIPTION
## Changes
- Document overtime, rematch, and admin vote workflows in phase 4 migration spec
- Add MadnessMatchEvents audit log collection to core data models
- Captures decisions from design discussion about how tied matches are resolved

## Context
These features are currently handled manually in PHPMyAdmin. The docs describe how they'll become first-class Payload admin actions with an append-only audit trail.