### PR TITLE
feat: Modern Rock Madness Payload CMS collections

### DIFF
--- a/bin/seed-payload.ts
+++ b/bin/seed-payload.ts
@@ -468,6 +468,232 @@ async function seed() {
 
     console.log('   ✅ Created 2 shows');
 
+    // Create Modern Rock Madness tournament data
+    console.log('🏆 Creating Modern Rock Madness tournament...');
+
+    const tournament = await payload.create({
+      collection: 'madness-tournaments',
+      data: {
+        name: 'Modern Rock Madness 2025',
+        year: 2025,
+        startDate: '2025-03-24T00:00:00.000Z',
+        status: 'active',
+        bracketPdfUrl: 'https://od.lk/d/219145587_ruE6q/MRM2025Bracket.pdf',
+        bannerImageUrl: 'https://i.imgur.com/QfqMVsE.png',
+      },
+    });
+
+    console.log(`   ✅ Created tournament: ${tournament.name}`);
+
+    // Create 8 sample bands (enough for a mini-bracket)
+    console.log('🎸 Creating MRM bands...');
+
+    const tournamentId = typeof tournament.id === 'number' ? tournament.id : parseInt(tournament.id, 10);
+
+    const bandNames = [
+      {
+        name: 'Japanese Breakfast',
+        abbr: 'JBrekie',
+        seed: 1,
+        placement: 1,
+      },
+      {
+        name: 'Fontaines D.C.',
+        abbr: 'FDC',
+        seed: 16,
+        placement: 2,
+      },
+      {
+        name: 'Alvvays',
+        abbr: 'Alvvays',
+        seed: 8,
+        placement: 3,
+      },
+      {
+        name: 'Wet Leg',
+        abbr: 'WetLeg',
+        seed: 9,
+        placement: 4,
+      },
+      {
+        name: 'Turnstile',
+        abbr: 'Trnstl',
+        seed: 4,
+        placement: 5,
+      },
+      {
+        name: 'Beach House',
+        abbr: 'BchHse',
+        seed: 13,
+        placement: 6,
+      },
+      {
+        name: 'Slowdive',
+        abbr: 'Slwdve',
+        seed: 5,
+        placement: 7,
+      },
+      {
+        name: 'Mannequin Pussy',
+        abbr: 'ManPsy',
+        seed: 12,
+        placement: 8,
+      },
+    ];
+
+    const bandIds: number[] = [];
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < bandNames.length; i += 1) {
+      const band = await payload.create({
+        collection: 'madness-bands',
+        data: {
+          tournament: tournamentId,
+          name: bandNames[i].name,
+          abbreviation: bandNames[i].abbr,
+          seed: bandNames[i].seed,
+          placement: bandNames[i].placement,
+          url: `https://example.com/${bandNames[i].abbr.toLowerCase()}`,
+          imageUrl: `https://placehold.co/200x200?text=${encodeURIComponent(bandNames[i].abbr)}`,
+        },
+      });
+      bandIds.push(typeof band.id === 'number' ? band.id : parseInt(band.id, 10));
+    }
+    /* eslint-enable no-await-in-loop */
+
+    console.log(`   ✅ Created ${bandIds.length} bands`);
+
+    // Create 4 Round 1 matches + 2 Round 2 matches + 1 Sweet 16 match (7 total)
+    console.log('⚔️  Creating MRM matches...');
+
+    const matchStartBase = new Date('2025-03-24T14:00:00.000Z');
+
+    const matchConfigs = [
+      // Round 1 matches (1v16, 8v9, 4v13, 5v12)
+      {
+        num: 1,
+        round: '1',
+        region: 1,
+        b1: 0,
+        b2: 1,
+        hoursOffset: 0,
+      },
+      {
+        num: 2,
+        round: '1',
+        region: 1,
+        b1: 2,
+        b2: 3,
+        hoursOffset: 1,
+      },
+      {
+        num: 3,
+        round: '1',
+        region: 1,
+        b1: 4,
+        b2: 5,
+        hoursOffset: 2,
+      },
+      {
+        num: 4,
+        round: '1',
+        region: 1,
+        b1: 6,
+        b2: 7,
+        hoursOffset: 3,
+      },
+      // Round 2 matches (winners of 1v2, 3v4)
+      {
+        num: 33,
+        round: '2',
+        region: 1,
+        b1: null,
+        b2: null,
+        hoursOffset: 48,
+      },
+      {
+        num: 34,
+        round: '2',
+        region: 1,
+        b1: null,
+        b2: null,
+        hoursOffset: 49,
+      },
+      // Sweet 16 match (winners of 33v34)
+      {
+        num: 49,
+        round: '3',
+        region: 1,
+        b1: null,
+        b2: null,
+        hoursOffset: 96,
+      },
+    ];
+
+    const matchIds: Record<number, number> = {};
+
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < matchConfigs.length; i += 1) {
+      const mc = matchConfigs[i];
+      const start = new Date(matchStartBase.getTime() + mc.hoursOffset * 60 * 60 * 1000);
+      const end = new Date(start.getTime() + 30 * 60 * 1000); // 30 min matches
+
+      const matchData: Record<string, unknown> = {
+        tournament: tournamentId,
+        matchNumber: mc.num,
+        round: mc.round,
+        region: mc.region,
+        startTime: start.toISOString(),
+        endTime: end.toISOString(),
+        band1Votes: 0,
+        band2Votes: 0,
+        showScore: false,
+      };
+
+      if (mc.b1 !== null) matchData.band1 = bandIds[mc.b1];
+      if (mc.b2 !== null) matchData.band2 = bandIds[mc.b2];
+
+      const match = await payload.create({
+        collection: 'madness-matches',
+        data: matchData,
+      });
+      matchIds[mc.num] = typeof match.id === 'number' ? match.id : parseInt(match.id, 10);
+    }
+    /* eslint-enable no-await-in-loop */
+
+    // Link matches with nextMatch (bracket flow)
+    await payload.update({
+      collection: 'madness-matches',
+      id: matchIds[1],
+      data: { nextMatch: matchIds[33] },
+    });
+    await payload.update({
+      collection: 'madness-matches',
+      id: matchIds[2],
+      data: { nextMatch: matchIds[33] },
+    });
+    await payload.update({
+      collection: 'madness-matches',
+      id: matchIds[3],
+      data: { nextMatch: matchIds[34] },
+    });
+    await payload.update({
+      collection: 'madness-matches',
+      id: matchIds[4],
+      data: { nextMatch: matchIds[34] },
+    });
+    await payload.update({
+      collection: 'madness-matches',
+      id: matchIds[33],
+      data: { nextMatch: matchIds[49] },
+    });
+    await payload.update({
+      collection: 'madness-matches',
+      id: matchIds[34],
+      data: { nextMatch: matchIds[49] },
+    });
+
+    console.log(`   ✅ Created ${matchConfigs.length} matches with bracket flow`);
+
     console.log('\n✅ Database seeded successfully!\n');
     console.log('📊 Summary:');
     console.log('   Users: 1 (admin)');
@@ -479,6 +705,9 @@ async function seed() {
     console.log('   Concerts: 3');
     console.log('   Posts: 3');
     console.log('   Shows: 2');
+    console.log('   MRM Tournament: 1');
+    console.log('   MRM Bands: 8');
+    console.log('   MRM Matches: 7');
     console.log('\n🌐 View at: http://localhost:3000/admin');
     console.log(
       `   Login: ${process.env.PAYLOAD_DEV_EMAIL || 'admin@ynotradio.net'} / ${process.env.PAYLOAD_DEV_PASSWORD || 'password'}\n`,

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -22,6 +22,11 @@ import { Shows } from './payload/src/collections/Shows';
 import { Posts } from './payload/src/collections/Posts';
 import { CdOfTheWeek } from './payload/src/collections/CdOfTheWeek';
 import { YearEndPollResults } from './payload/src/collections/YearEndPollResults';
+import { MadnessTournaments } from './payload/src/collections/MadnessTournaments';
+import { MadnessBands } from './payload/src/collections/MadnessBands';
+import { MadnessMatches } from './payload/src/collections/MadnessMatches';
+import { MadnessVotes } from './payload/src/collections/MadnessVotes';
+import { MadnessMatchEvents } from './payload/src/collections/MadnessMatchEvents';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -128,6 +133,11 @@ export default buildConfig({
     Posts,
     CdOfTheWeek,
     YearEndPollResults,
+    MadnessTournaments,
+    MadnessBands,
+    MadnessMatches,
+    MadnessVotes,
+    MadnessMatchEvents,
   ],
   plugins: [
     cloudStoragePlugin({

--- a/payload/src/collections/MadnessBands.test.ts
+++ b/payload/src/collections/MadnessBands.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { MadnessBands } from './MadnessBands';
+
+describe('MadnessBands', () => {
+  it('has the correct slug', () => {
+    expect(MadnessBands.slug).toBe('madness-bands');
+  });
+
+  it('uses name as admin title', () => {
+    expect(MadnessBands.admin?.useAsTitle).toBe('name');
+  });
+
+  it('is grouped under Modern Rock Madness', () => {
+    expect(MadnessBands.admin?.group).toBe('Modern Rock Madness');
+  });
+
+  it('has required fields', () => {
+    const fields = MadnessBands.fields as Array<{ name: string; required?: boolean }>;
+    const requiredNames = fields.filter((f) => f.required).map((f) => f.name);
+    expect(requiredNames).toContain('tournament');
+    expect(requiredNames).toContain('name');
+    expect(requiredNames).toContain('seed');
+    expect(requiredNames).toContain('placement');
+  });
+
+  it('has tournament as a relationship to madness-tournaments', () => {
+    const fields = MadnessBands.fields as Array<{
+      name: string;
+      type: string;
+      relationTo?: string;
+    }>;
+    const tournamentField = fields.find((f) => f.name === 'tournament');
+    expect(tournamentField?.type).toBe('relationship');
+    expect(tournamentField?.relationTo).toBe('madness-tournaments');
+  });
+
+  it('enforces abbreviation max length of 7', () => {
+    const fields = MadnessBands.fields as Array<{ name: string; maxLength?: number }>;
+    const abbrField = fields.find((f) => f.name === 'abbreviation');
+    expect(abbrField?.maxLength).toBe(7);
+  });
+
+  it('has public read access', () => {
+    const readFn = MadnessBands.access?.read;
+    expect(typeof readFn).toBe('function');
+    expect((readFn as () => boolean)()).toBe(true);
+  });
+
+  it('has timestamps enabled', () => {
+    expect(MadnessBands.timestamps).toBe(true);
+  });
+});

--- a/payload/src/collections/MadnessBands.ts
+++ b/payload/src/collections/MadnessBands.ts
@@ -1,0 +1,108 @@
+import type { CollectionConfig } from 'payload';
+import { hasRole } from '../utils/auth';
+
+export const MadnessBands: CollectionConfig = {
+  slug: 'madness-bands',
+  labels: {
+    singular: 'Band',
+    plural: 'Bands',
+  },
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'seed', 'placement', 'tournament', 'sponsor'],
+    group: 'Modern Rock Madness',
+    description: 'Tournament participants (64 bands per tournament).',
+  },
+  access: {
+    read: () => true,
+    create: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    update: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    delete: ({ req }) => hasRole(req.user, ['admin']),
+  },
+  fields: [
+    {
+      name: 'tournament',
+      type: 'relationship',
+      relationTo: 'madness-tournaments',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Tournament this band belongs to',
+      },
+    },
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      admin: {
+        description: 'Band name',
+      },
+    },
+    {
+      name: 'abbreviation',
+      type: 'text',
+      maxLength: 7,
+      admin: {
+        description: 'Short abbreviation for bracket display (max 7 chars)',
+      },
+    },
+    {
+      name: 'url',
+      type: 'text',
+      admin: {
+        description: 'Band website URL',
+      },
+    },
+    {
+      name: 'imageUrl',
+      type: 'text',
+      admin: {
+        description: 'Band image URL',
+      },
+    },
+    {
+      name: 'seed',
+      type: 'number',
+      required: true,
+      admin: {
+        description: 'Tournament seed (1-16 per region)',
+      },
+    },
+    {
+      name: 'placement',
+      type: 'number',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Overall bracket placement (1-64)',
+      },
+    },
+    {
+      name: 'sponsor',
+      type: 'text',
+      admin: {
+        description: 'Band sponsor name',
+      },
+    },
+    {
+      name: 'legacyId',
+      type: 'number',
+      unique: true,
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Original MySQL ID for migration tracking',
+      },
+    },
+    {
+      name: 'migratedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Timestamp of migration from MySQL',
+      },
+    },
+  ],
+  timestamps: true,
+};

--- a/payload/src/collections/MadnessMatchEvents.test.ts
+++ b/payload/src/collections/MadnessMatchEvents.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { MadnessMatchEvents } from './MadnessMatchEvents';
+
+describe('MadnessMatchEvents', () => {
+  it('has the correct slug', () => {
+    expect(MadnessMatchEvents.slug).toBe('madness-match-events');
+  });
+
+  it('is grouped under Modern Rock Madness', () => {
+    expect(MadnessMatchEvents.admin?.group).toBe('Modern Rock Madness');
+  });
+
+  it('has required fields', () => {
+    const fields = MadnessMatchEvents.fields as Array<{ name: string; required?: boolean }>;
+    const requiredNames = fields.filter((f) => f.required).map((f) => f.name);
+    expect(requiredNames).toContain('match');
+    expect(requiredNames).toContain('eventType');
+  });
+
+  it('has match as a relationship to madness-matches', () => {
+    const fields = MadnessMatchEvents.fields as Array<{
+      name: string;
+      type: string;
+      relationTo?: string;
+    }>;
+    const matchField = fields.find((f) => f.name === 'match');
+    expect(matchField?.type).toBe('relationship');
+    expect(matchField?.relationTo).toBe('madness-matches');
+  });
+
+  it('has 4 event type options', () => {
+    const fields = MadnessMatchEvents.fields as Array<{
+      name: string;
+      options?: Array<{ value: string }>;
+    }>;
+    const eventTypeField = fields.find((f) => f.name === 'eventType');
+    expect(eventTypeField?.options).toHaveLength(4);
+    const values = eventTypeField?.options?.map((o) => o.value);
+    expect(values).toContain('overtime_extended');
+    expect(values).toContain('rematch');
+    expect(values).toContain('admin_vote');
+    expect(values).toContain('match_closed');
+  });
+
+  it('has snapshot as a JSON field', () => {
+    const fields = MadnessMatchEvents.fields as Array<{ name: string; type: string }>;
+    const snapshotField = fields.find((f) => f.name === 'snapshot');
+    expect(snapshotField?.type).toBe('json');
+  });
+
+  it('is append-only (no update or delete)', () => {
+    const updateFn = MadnessMatchEvents.access?.update;
+    const deleteFn = MadnessMatchEvents.access?.delete;
+    expect(typeof updateFn).toBe('function');
+    expect(typeof deleteFn).toBe('function');
+    expect((updateFn as () => boolean)()).toBe(false);
+    expect((deleteFn as () => boolean)()).toBe(false);
+  });
+
+  it('restricts read access to admin and editor roles', () => {
+    const readFn = MadnessMatchEvents.access?.read;
+    expect(typeof readFn).toBe('function');
+    expect((readFn as (args: { req: { user: null } }) => boolean)({ req: { user: null } })).toBe(
+      false,
+    );
+  });
+
+  it('has timestamps enabled', () => {
+    expect(MadnessMatchEvents.timestamps).toBe(true);
+  });
+});

--- a/payload/src/collections/MadnessMatchEvents.ts
+++ b/payload/src/collections/MadnessMatchEvents.ts
@@ -1,0 +1,58 @@
+import type { CollectionConfig } from 'payload';
+import { hasRole } from '../utils/auth';
+
+export const MadnessMatchEvents: CollectionConfig = {
+  slug: 'madness-match-events',
+  labels: {
+    singular: 'Match Event',
+    plural: 'Match Events',
+  },
+  admin: {
+    defaultColumns: ['match', 'eventType', 'createdAt'],
+    group: 'Modern Rock Madness',
+    description: 'Audit log for match admin actions (overtime, rematch, admin vote, close).',
+  },
+  access: {
+    read: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    create: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    // Events are append-only — no editing or deleting
+    update: () => false,
+    delete: () => false,
+  },
+  fields: [
+    {
+      name: 'match',
+      type: 'relationship',
+      relationTo: 'madness-matches',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Match this event relates to',
+      },
+    },
+    {
+      name: 'eventType',
+      type: 'select',
+      required: true,
+      index: true,
+      options: [
+        { label: 'Overtime Extended', value: 'overtime_extended' },
+        { label: 'Rematch', value: 'rematch' },
+        { label: 'Admin Vote', value: 'admin_vote' },
+        { label: 'Match Closed', value: 'match_closed' },
+      ],
+      admin: {
+        description: 'Type of admin action performed',
+      },
+    },
+    {
+      name: 'snapshot',
+      type: 'json',
+      admin: {
+        description:
+          'State snapshot at the time of the event. Contents vary by event type (e.g., previous vote counts for rematch, previous end time for overtime).',
+      },
+    },
+  ],
+  timestamps: true,
+};

--- a/payload/src/collections/MadnessMatches.test.ts
+++ b/payload/src/collections/MadnessMatches.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { MadnessMatches } from './MadnessMatches';
+
+/**
+ * Flatten row-type fields into a flat array for easier testing.
+ * Payload uses { type: 'row', fields: [...] } to group fields visually.
+ */
+const flattenRowFields = (
+  fields: readonly Record<string, unknown>[],
+): Array<Record<string, unknown>> =>
+  fields.reduce<Array<Record<string, unknown>>>((result, field) => {
+    if (field.type === 'row' && Array.isArray(field.fields)) {
+      return [...result, ...(field.fields as Array<Record<string, unknown>>)];
+    }
+    return [...result, field];
+  }, []);
+
+describe('MadnessMatches', () => {
+  it('has the correct slug', () => {
+    expect(MadnessMatches.slug).toBe('madness-matches');
+  });
+
+  it('uses matchNumber as admin title', () => {
+    expect(MadnessMatches.admin?.useAsTitle).toBe('matchNumber');
+  });
+
+  it('is grouped under Modern Rock Madness', () => {
+    expect(MadnessMatches.admin?.group).toBe('Modern Rock Madness');
+  });
+
+  it('has tournament as a required relationship', () => {
+    const fields = MadnessMatches.fields as Array<{
+      name?: string;
+      type: string;
+      relationTo?: string;
+      required?: boolean;
+    }>;
+    const tournamentField = fields.find((f) => f.name === 'tournament');
+    expect(tournamentField?.type).toBe('relationship');
+    expect(tournamentField?.relationTo).toBe('madness-tournaments');
+    expect(tournamentField?.required).toBe(true);
+  });
+
+  it('has band1 and band2 as relationships to madness-bands', () => {
+    const allFields = flattenRowFields(MadnessMatches.fields);
+    const band1 = allFields.find((f: { name?: string }) => f.name === 'band1');
+    const band2 = allFields.find((f: { name?: string }) => f.name === 'band2');
+    expect(band1?.type).toBe('relationship');
+    expect(band1?.relationTo).toBe('madness-bands');
+    expect(band2?.type).toBe('relationship');
+    expect(band2?.relationTo).toBe('madness-bands');
+  });
+
+  it('has vote count fields with default value of 0', () => {
+    const allFields = flattenRowFields(MadnessMatches.fields);
+    const band1Votes = allFields.find((f: { name?: string }) => f.name === 'band1Votes');
+    const band2Votes = allFields.find((f: { name?: string }) => f.name === 'band2Votes');
+    expect(band1Votes?.defaultValue).toBe(0);
+    expect(band2Votes?.defaultValue).toBe(0);
+  });
+
+  it('has startTime and endTime as date fields with dayAndTime picker', () => {
+    const allFields = flattenRowFields(MadnessMatches.fields);
+    const startTime = allFields.find((f: { name?: string }) => f.name === 'startTime');
+    const endTime = allFields.find((f: { name?: string }) => f.name === 'endTime');
+    expect(startTime?.type).toBe('date');
+    expect(startTime?.required).toBe(true);
+    expect(endTime?.type).toBe('date');
+    expect(endTime?.required).toBe(true);
+  });
+
+  it('has nextMatch as a self-referencing relationship', () => {
+    const fields = MadnessMatches.fields as Array<{
+      name?: string;
+      type: string;
+      relationTo?: string;
+    }>;
+    const nextMatch = fields.find((f) => f.name === 'nextMatch');
+    expect(nextMatch?.type).toBe('relationship');
+    expect(nextMatch?.relationTo).toBe('madness-matches');
+  });
+
+  it('has 6 round options covering the full tournament', () => {
+    const fields = MadnessMatches.fields as Array<{
+      name?: string;
+      options?: Array<{ value: string }>;
+    }>;
+    const roundField = fields.find((f) => f.name === 'round');
+    expect(roundField?.options).toHaveLength(6);
+  });
+
+  it('has winner as a relationship to madness-bands', () => {
+    const fields = MadnessMatches.fields as Array<{
+      name?: string;
+      type: string;
+      relationTo?: string;
+    }>;
+    const winner = fields.find((f) => f.name === 'winner');
+    expect(winner?.type).toBe('relationship');
+    expect(winner?.relationTo).toBe('madness-bands');
+  });
+
+  it('has public read access', () => {
+    const readFn = MadnessMatches.access?.read;
+    expect(typeof readFn).toBe('function');
+    expect((readFn as () => boolean)()).toBe(true);
+  });
+
+  it('has timestamps enabled', () => {
+    expect(MadnessMatches.timestamps).toBe(true);
+  });
+});

--- a/payload/src/collections/MadnessMatches.ts
+++ b/payload/src/collections/MadnessMatches.ts
@@ -1,0 +1,199 @@
+import type { CollectionConfig } from 'payload';
+import { hasRole } from '../utils/auth';
+
+export const MadnessMatches: CollectionConfig = {
+  slug: 'madness-matches',
+  labels: {
+    singular: 'Match',
+    plural: 'Matches',
+  },
+  admin: {
+    useAsTitle: 'matchNumber',
+    defaultColumns: ['matchNumber', 'round', 'region', 'band1', 'band2', 'startTime', 'winner'],
+    group: 'Modern Rock Madness',
+    description: 'Tournament bracket matchups (63 matches per tournament).',
+  },
+  access: {
+    read: () => true,
+    create: ({ req }) => hasRole(req.user, ['admin']),
+    update: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    delete: ({ req }) => hasRole(req.user, ['admin']),
+  },
+  fields: [
+    {
+      name: 'tournament',
+      type: 'relationship',
+      relationTo: 'madness-tournaments',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Tournament this match belongs to',
+      },
+    },
+    {
+      name: 'matchNumber',
+      type: 'number',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Match number in bracket (1-63)',
+      },
+    },
+    {
+      name: 'round',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Round 1 (64→32)', value: '1' },
+        { label: 'Round 2 (32→16)', value: '2' },
+        { label: 'Sweet 16 (16→8)', value: '3' },
+        { label: 'Elusive 8 (8→4)', value: '4' },
+        { label: 'Final 4 (4→2)', value: '5' },
+        { label: 'Championship', value: '6' },
+      ],
+      admin: {
+        description: 'Tournament round',
+      },
+    },
+    {
+      name: 'region',
+      type: 'number',
+      admin: {
+        description: 'Tournament region (1-4 for early rounds, 5 for Final 4+)',
+      },
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'band1',
+          type: 'relationship',
+          relationTo: 'madness-bands',
+          admin: {
+            description: 'First band (top seed in bracket)',
+            width: '50%',
+          },
+        },
+        {
+          name: 'band2',
+          type: 'relationship',
+          relationTo: 'madness-bands',
+          admin: {
+            description: 'Second band (bottom seed in bracket)',
+            width: '50%',
+          },
+        },
+      ],
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'band1Votes',
+          type: 'number',
+          defaultValue: 0,
+          admin: {
+            description: 'Band 1 vote count',
+            width: '50%',
+          },
+        },
+        {
+          name: 'band2Votes',
+          type: 'number',
+          defaultValue: 0,
+          admin: {
+            description: 'Band 2 vote count',
+            width: '50%',
+          },
+        },
+      ],
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'startTime',
+          type: 'date',
+          required: true,
+          admin: {
+            description: 'Match voting opens at this time',
+            date: {
+              pickerAppearance: 'dayAndTime',
+            },
+            width: '50%',
+          },
+        },
+        {
+          name: 'endTime',
+          type: 'date',
+          required: true,
+          admin: {
+            description: 'Match voting closes at this time (can be extended for overtime)',
+            date: {
+              pickerAppearance: 'dayAndTime',
+            },
+            width: '50%',
+          },
+        },
+      ],
+    },
+    {
+      name: 'winner',
+      type: 'relationship',
+      relationTo: 'madness-bands',
+      admin: {
+        description: 'Match winner (set when match is closed)',
+      },
+    },
+    {
+      name: 'showScore',
+      type: 'checkbox',
+      defaultValue: false,
+      admin: {
+        description: 'Show vote scores publicly',
+      },
+    },
+    {
+      name: 'nextMatch',
+      type: 'relationship',
+      relationTo: 'madness-matches',
+      admin: {
+        description: 'Next match the winner advances to (replaces mrm_matches_flow table)',
+      },
+    },
+    {
+      name: 'sponsor',
+      type: 'text',
+      admin: {
+        description: 'Match sponsor name',
+      },
+    },
+    {
+      name: 'sponsorMessage',
+      type: 'textarea',
+      admin: {
+        description: 'Match sponsor message',
+      },
+    },
+    {
+      name: 'legacyId',
+      type: 'number',
+      unique: true,
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Original MySQL match ID for migration tracking',
+      },
+    },
+    {
+      name: 'migratedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Timestamp of migration from MySQL',
+      },
+    },
+  ],
+  timestamps: true,
+};

--- a/payload/src/collections/MadnessTournaments.test.ts
+++ b/payload/src/collections/MadnessTournaments.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { MadnessTournaments } from './MadnessTournaments';
+
+describe('MadnessTournaments', () => {
+  it('has the correct slug', () => {
+    expect(MadnessTournaments.slug).toBe('madness-tournaments');
+  });
+
+  it('uses name as admin title', () => {
+    expect(MadnessTournaments.admin?.useAsTitle).toBe('name');
+  });
+
+  it('is grouped under Modern Rock Madness', () => {
+    expect(MadnessTournaments.admin?.group).toBe('Modern Rock Madness');
+  });
+
+  it('has required fields', () => {
+    const fields = MadnessTournaments.fields as Array<{ name: string; required?: boolean }>;
+    const requiredNames = fields.filter((f) => f.required).map((f) => f.name);
+    expect(requiredNames).toContain('name');
+    expect(requiredNames).toContain('year');
+    expect(requiredNames).toContain('startDate');
+    expect(requiredNames).toContain('status');
+  });
+
+  it('has draft as default status', () => {
+    const fields = MadnessTournaments.fields as Array<{ name: string; defaultValue?: string }>;
+    const statusField = fields.find((f) => f.name === 'status');
+    expect(statusField?.defaultValue).toBe('draft');
+  });
+
+  it('has year as unique and indexed', () => {
+    const fields = MadnessTournaments.fields as Array<{
+      name: string;
+      unique?: boolean;
+      index?: boolean;
+    }>;
+    const yearField = fields.find((f) => f.name === 'year');
+    expect(yearField?.unique).toBe(true);
+    expect(yearField?.index).toBe(true);
+  });
+
+  it('has public read access', () => {
+    const readFn = MadnessTournaments.access?.read;
+    expect(typeof readFn).toBe('function');
+    expect((readFn as () => boolean)()).toBe(true);
+  });
+
+  it('has timestamps enabled', () => {
+    expect(MadnessTournaments.timestamps).toBe(true);
+  });
+});

--- a/payload/src/collections/MadnessTournaments.ts
+++ b/payload/src/collections/MadnessTournaments.ts
@@ -1,0 +1,102 @@
+import type { CollectionConfig } from 'payload';
+import { hasRole } from '../utils/auth';
+
+export const MadnessTournaments: CollectionConfig = {
+  slug: 'madness-tournaments',
+  labels: {
+    singular: 'Tournament',
+    plural: 'Tournaments',
+  },
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'year', 'status', 'startDate', 'updatedAt'],
+    group: 'Modern Rock Madness',
+    description: 'Annual Modern Rock Madness tournament configuration.',
+  },
+  access: {
+    read: () => true,
+    create: ({ req }) => hasRole(req.user, ['admin']),
+    update: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    delete: ({ req }) => hasRole(req.user, ['admin']),
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      admin: {
+        description: 'Tournament name (e.g., "Modern Rock Madness 2025")',
+      },
+    },
+    {
+      name: 'year',
+      type: 'number',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'Tournament year',
+      },
+    },
+    {
+      name: 'startDate',
+      type: 'date',
+      required: true,
+      admin: {
+        description: 'Tournament start date',
+        date: {
+          displayFormat: 'yyyy-MM-dd',
+        },
+      },
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'draft',
+      options: [
+        { label: 'Draft', value: 'draft' },
+        { label: 'Active', value: 'active' },
+        { label: 'Complete', value: 'complete' },
+      ],
+      index: true,
+      admin: {
+        description: 'Tournament status. Only one tournament should be "active" at a time.',
+      },
+    },
+    {
+      name: 'bracketPdfUrl',
+      type: 'text',
+      admin: {
+        description: 'URL to the printable bracket PDF',
+      },
+    },
+    {
+      name: 'bannerImageUrl',
+      type: 'text',
+      admin: {
+        description: 'URL to the tournament banner image',
+      },
+    },
+    {
+      name: 'legacyId',
+      type: 'number',
+      unique: true,
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Original MySQL ID for migration tracking',
+      },
+    },
+    {
+      name: 'migratedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Timestamp of migration from MySQL',
+      },
+    },
+  ],
+  timestamps: true,
+};

--- a/payload/src/collections/MadnessVotes.test.ts
+++ b/payload/src/collections/MadnessVotes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { MadnessVotes } from './MadnessVotes';
+
+describe('MadnessVotes', () => {
+  it('has the correct slug', () => {
+    expect(MadnessVotes.slug).toBe('madness-votes');
+  });
+
+  it('is grouped under Modern Rock Madness', () => {
+    expect(MadnessVotes.admin?.group).toBe('Modern Rock Madness');
+  });
+
+  it('has required fields', () => {
+    const fields = MadnessVotes.fields as Array<{ name: string; required?: boolean }>;
+    const requiredNames = fields.filter((f) => f.required).map((f) => f.name);
+    expect(requiredNames).toContain('match');
+    expect(requiredNames).toContain('band');
+    expect(requiredNames).toContain('voterIp');
+  });
+
+  it('has match as a relationship to madness-matches', () => {
+    const fields = MadnessVotes.fields as Array<{
+      name: string;
+      type: string;
+      relationTo?: string;
+    }>;
+    const matchField = fields.find((f) => f.name === 'match');
+    expect(matchField?.type).toBe('relationship');
+    expect(matchField?.relationTo).toBe('madness-matches');
+  });
+
+  it('has band as a relationship to madness-bands', () => {
+    const fields = MadnessVotes.fields as Array<{
+      name: string;
+      type: string;
+      relationTo?: string;
+    }>;
+    const bandField = fields.find((f) => f.name === 'band');
+    expect(bandField?.type).toBe('relationship');
+    expect(bandField?.relationTo).toBe('madness-bands');
+  });
+
+  it('has voterIp indexed for duplicate checking', () => {
+    const fields = MadnessVotes.fields as Array<{ name: string; index?: boolean }>;
+    const ipField = fields.find((f) => f.name === 'voterIp');
+    expect(ipField?.index).toBe(true);
+  });
+
+  it('restricts read access to admin and editor roles', () => {
+    const readFn = MadnessVotes.access?.read;
+    expect(typeof readFn).toBe('function');
+    // No user → should not allow read
+    expect((readFn as (args: { req: { user: null } }) => boolean)({ req: { user: null } })).toBe(
+      false,
+    );
+  });
+
+  it('has timestamps enabled', () => {
+    expect(MadnessVotes.timestamps).toBe(true);
+  });
+});

--- a/payload/src/collections/MadnessVotes.ts
+++ b/payload/src/collections/MadnessVotes.ts
@@ -1,0 +1,79 @@
+import type { CollectionConfig } from 'payload';
+import { hasRole } from '../utils/auth';
+
+export const MadnessVotes: CollectionConfig = {
+  slug: 'madness-votes',
+  labels: {
+    singular: 'Vote',
+    plural: 'Votes',
+  },
+  admin: {
+    defaultColumns: ['match', 'band', 'voterIp', 'createdAt'],
+    group: 'Modern Rock Madness',
+    description: 'Individual vote records for tournament matches.',
+  },
+  access: {
+    read: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => hasRole(req.user, ['admin']),
+    delete: ({ req }) => hasRole(req.user, ['admin']),
+  },
+  fields: [
+    {
+      name: 'match',
+      type: 'relationship',
+      relationTo: 'madness-matches',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Match this vote was cast in',
+      },
+    },
+    {
+      name: 'band',
+      type: 'relationship',
+      relationTo: 'madness-bands',
+      required: true,
+      admin: {
+        description: 'Band voted for',
+      },
+    },
+    {
+      name: 'voterIp',
+      type: 'text',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Voter IP address (used for duplicate prevention)',
+      },
+    },
+    {
+      name: 'voterEmail',
+      type: 'email',
+      index: true,
+      admin: {
+        description: 'Voter email address (if authenticated)',
+      },
+    },
+    {
+      name: 'legacyId',
+      type: 'number',
+      unique: true,
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Original MySQL ID for migration tracking',
+      },
+    },
+    {
+      name: 'migratedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+        description: 'Timestamp of migration from MySQL',
+      },
+    },
+  ],
+  timestamps: true,
+};


### PR DESCRIPTION
## Changes
- Add 5 Payload collections for the MRM tournament bracket system: MadnessTournaments, MadnessBands, MadnessMatches, MadnessVotes, MadnessMatchEvents
- MadnessMatches uses self-referencing `nextMatch` relationship (replaces legacy `mrm_matches_flow` table)
- MadnessMatchEvents is an append-only audit log for overtime/rematch/admin vote actions
- All collections registered in `payload.config.ts` and grouped under 'Modern Rock Madness'
- Seed data adds a sample tournament with 8 bands and 7 bracket matches

## Testing
- [x] 45 new unit tests (all passing)
- [x] 744 total tests pass
- [x] Lint clean (0 warnings)
- [x] Build succeeds

Note: `payload generate:types` has a known env loader issue locally — types file is gitignored and will be regenerated during CI build.