### PR TITLE
fix: add Buildkite detection and rewrite agent environment skill

### DIFF
--- a/.claude/skills/detecting-agent-environment/SKILL.md
+++ b/.claude/skills/detecting-agent-environment/SKILL.md
@@ -1,89 +1,157 @@
 ---
 name: detecting-agent-environment
-description: Utilities and patterns for detecting execution environment (CI/CD vs local, network access, available ports, timeouts). Use when you need to adapt scripts or workflows based on where the agent is running, or when creating helper scripts that need environment-aware behavior.
+description: Utilities and patterns for detecting execution environment (CI/CD vs local, network access, available ports, timeouts). Use when you need to adapt scripts or workflows based on where the agent is running, when creating helper scripts that need environment-aware behavior, when writing Buildkite pipeline steps, or when debugging CI vs local behavior differences. Also use when setting timeouts for Docker, yarn install, or service health checks.
 ---
 
-# Agent Helper Scripts
+# Agent Environment Detection
 
-Utilities for GitHub Copilot agents working on Y-Not Radio site.
+Shell utilities in `bin/agent-helpers/detect-environment.sh` for adapting agent scripts to different execution environments. This project uses **Buildkite** for CI/CD.
 
-## Environment Detection
-
-Use `detect-environment.sh` to adapt scripts to different environments:
+## Quick Start
 
 ```bash
-# Source the utility
 source bin/agent-helpers/detect-environment.sh
-
-# Print environment info
 print_environment
+# Output:
+# 🔍 Environment Detection:
+#    📍 Environment: Local Development
+#    🌐 Network: Available
+#    🐳 Docker: Available
+```
 
-# Check environment
+## API Reference
+
+Source the script first: `source bin/agent-helpers/detect-environment.sh`
+
+### `detect_ci`
+
+Returns 0 (true) if running in any CI/CD environment. Checks `$CI`, `$BUILDKITE`, `$GITHUB_ACTIONS`, `$GITLAB_CI`, `$CIRCLECI`.
+
+```bash
 if detect_ci; then
-  echo "Running in CI/CD"
-  # Use optimized workflow
+  echo "In CI — use stricter timeouts and pre-built images"
+else
+  echo "Local dev — more lenient timeouts"
 fi
+```
 
+### `detect_ci_provider`
+
+Prints the name of the active CI provider. Returns empty string if running locally.
+
+| Environment Variable | Output |
+|---------------------|--------|
+| `$BUILDKITE` | `buildkite` |
+| `$GITHUB_ACTIONS` | `github-actions` |
+| `$GITLAB_CI` | `gitlab` |
+| `$CIRCLECI` | `circleci` |
+| `$CI` (only) | `unknown-ci` |
+| None | `` (empty) |
+
+```bash
+provider=$(detect_ci_provider)
+if [ "$provider" = "buildkite" ]; then
+  # Use Buildkite-specific features like annotations
+  buildkite-agent annotate "Deploy starting" --style info
+fi
+```
+
+### `detect_network`
+
+Returns 0 (true) if `registry.npmjs.org` is reachable (5s timeout). Use to guard package installs or external API calls.
+
+```bash
 if ! detect_network; then
-  echo "Network restricted - cannot pull packages"
+  echo "No network — use cached dependencies or pre-built images"
   exit 1
 fi
-
-# Get appropriate timeout
-TIMEOUT=$(get_timeout "service_ready")
-timeout $TIMEOUT bash -c 'until service_ready; do sleep 5; done'
 ```
+
+### `detect_port_available <port>`
+
+Returns 0 (true) if the given port is free. Uses `lsof`.
+
+```bash
+if detect_port_available 3000; then
+  yarn payload:dev
+else
+  echo "Port 3000 in use — Payload may already be running"
+fi
+```
+
+### `detect_docker`
+
+Returns 0 (true) if Docker is installed AND the daemon is running.
+
+```bash
+if ! detect_docker; then
+  echo "Docker unavailable — cannot run legacy PHP site or seeded databases"
+  exit 1
+fi
+```
+
+### `get_timeout <operation>`
+
+Prints a recommended timeout in seconds. CI gets stricter values; local gets lenient ones.
+
+| Operation | CI Timeout | Local Timeout |
+|-----------|-----------|---------------|
+| `container_start` | 120s | 180s |
+| `npm_install` | 180s | 300s |
+| `service_ready` | 240s | 360s |
+| (anything else) | 60s | 120s |
+
+```bash
+TIMEOUT=$(get_timeout "service_ready")
+timeout "$TIMEOUT" bash -c 'until curl -sf http://localhost:3000/admin; do sleep 5; done'
+```
+
+### `print_environment`
+
+Prints a human-readable summary of the current environment (CI provider, network, Docker status).
 
 ## Creating New Helper Scripts
 
-When creating helper scripts:
+When adding scripts to `bin/agent-helpers/`:
 
-1. **Source environment detection**
-   ```bash
-   source "$(dirname "$0")/detect-environment.sh"
-   print_environment
-   ```
+```bash
+#!/bin/bash
+# 1. Source environment detection from the same directory
+source "$(dirname "$0")/detect-environment.sh"
+print_environment
 
-2. **Use appropriate timeouts**
-   ```bash
-   TIMEOUT=$(get_timeout "npm_install")
-   timeout $TIMEOUT npm install
-   ```
+# 2. Guard on requirements
+detect_docker || { echo "❌ Docker required"; exit 1; }
 
-3. **Provide clear output**
-   ```bash
-   echo "✅ Success message"
-   echo "⚠️  Warning message"
-   echo "❌ Error message"
-   ```
+# 3. Use environment-aware timeouts
+TIMEOUT=$(get_timeout "container_start")
+timeout "$TIMEOUT" docker compose up -d
 
-4. **Exit with proper codes**
-   ```bash
-   exit 0  # Success
-   exit 1  # Failure
-   ```
+# 4. Use clear status output
+echo "✅ Services started"
 
-5. **Log to .agent-tmp/**
-   ```bash
-   mkdir -p .agent-tmp
-   command 2>&1 | tee .agent-tmp/command.log
-   ```
-
-## Related Skills
-
-Before creating scripts or PRs, see:
-
-- `testing-pr-changes` skill - Success criteria and testing workflows
-- `agent-automation-infrastructure` skill - Current automation state and pre-built images
+# 5. Log verbose output to tmp/ (gitignored)
+mkdir -p tmp
+docker compose logs 2>&1 > tmp/docker-startup.log
+```
 
 ## Performance Baselines
 
-Scripts should respect these baselines:
+Scripts should respect these thresholds. Report in the PR if you exceed "Warning":
 
 | Operation | Expected | Warning | Failure |
 |-----------|----------|---------|---------|
-| Container start | < 60s | 60-120s | > 120s |
-| npm install | < 120s | 120-300s | > 300s |
-| Service ready | < 180s | 180-360s | > 360s |
+| Container start | < 60s | 60–120s | > 120s |
+| yarn install | < 120s | 120–300s | > 300s |
+| Service ready | < 180s | 180–360s | > 360s |
 
-If exceeding "Warning" thresholds, report performance issues in PR.
+When hitting failures, consider pre-built images:
+```bash
+docker pull ghcr.io/ynotradio/site/postgres-seeded:latest
+docker pull ghcr.io/ynotradio/site/payload-dev:latest
+```
+
+## Related Skills
+
+- `agent-automation-infrastructure` — Pre-built images and CI pipeline details
+- `testing-pr-changes` — Success criteria and proof-of-functionality requirements

--- a/bin/agent-helpers/detect-environment.sh
+++ b/bin/agent-helpers/detect-environment.sh
@@ -4,10 +4,21 @@
 
 # Detect if we're in CI/CD
 detect_ci() {
-  if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ] || [ -n "$GITLAB_CI" ] || [ -n "$CIRCLECI" ]; then
+  if [ -n "$CI" ] || [ -n "$BUILDKITE" ] || [ -n "$GITHUB_ACTIONS" ] || [ -n "$GITLAB_CI" ] || [ -n "$CIRCLECI" ]; then
     return 0  # true
   fi
   return 1  # false
+}
+
+# Return which CI provider is active (empty string if local)
+detect_ci_provider() {
+  if [ -n "$BUILDKITE" ]; then echo "buildkite"
+  elif [ -n "$GITHUB_ACTIONS" ]; then echo "github-actions"
+  elif [ -n "$GITLAB_CI" ]; then echo "gitlab"
+  elif [ -n "$CIRCLECI" ]; then echo "circleci"
+  elif [ -n "$CI" ]; then echo "unknown-ci"
+  else echo ""
+  fi
 }
 
 # Detect if we have network access to key services
@@ -65,8 +76,10 @@ get_timeout() {
 print_environment() {
   echo "🔍 Environment Detection:"
   
-  if detect_ci; then
-    echo "   📍 Environment: CI/CD"
+  local provider
+  provider=$(detect_ci_provider)
+  if [ -n "$provider" ]; then
+    echo "   📍 Environment: CI/CD ($provider)"
   else
     echo "   📍 Environment: Local Development"
   fi
@@ -88,6 +101,7 @@ print_environment() {
 
 # Export functions for use in other scripts
 export -f detect_ci
+export -f detect_ci_provider
 export -f detect_network
 export -f detect_port_available
 export -f detect_docker


### PR DESCRIPTION
## Changes
- `detect_ci()` now checks `$BUILDKITE` — the actual CI system for this repo was missing
- Added `detect_ci_provider()` to identify which CI system is active
- `print_environment()` now displays the CI provider name
- Rewrote SKILL.md with full API reference documenting every function, its arguments, and return values
- Improved skill triggering description to mention Buildkite, timeouts, and specific use cases

## Testing
- [x] Shell script passes `bash -n` syntax check
- [x] `print_environment` works locally (shows Local Development)
- [x] `BUILDKITE=true` correctly detected as `CI/CD (buildkite)`