### PR TITLE
Skip unnecessary Netlify and Storybook deploys

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,6 +54,24 @@ steps:
   - label: ":storybook: Storybook Build & Deploy"
     key: "storybook"
     command: |
+      # Skip if no storybook-relevant files changed (saves Netlify credits + build time)
+      if [ "$${BUILDKITE_PULL_REQUEST:-false}" != "false" ]; then
+        STORYBOOK_CHANGES=$$(git diff --name-only origin/main...HEAD -- \
+          'app/' 'payload/src/' '.storybook/' 'package.json' 'yarn.lock' \
+          | grep -v '\.test\.\|\.spec\.' || true)
+      else
+        STORYBOOK_CHANGES=$$(git diff --name-only HEAD~1 HEAD -- \
+          'app/' 'payload/src/' '.storybook/' 'package.json' 'yarn.lock' \
+          | grep -v '\.test\.\|\.spec\.' || true)
+      fi
+
+      if [ -z "$$STORYBOOK_CHANGES" ]; then
+        echo "No storybook-relevant files changed — skipping build."
+        exit 0
+      fi
+      echo "Storybook-relevant changes detected:"
+      echo "$$STORYBOOK_CHANGES"
+
       corepack enable && yarn install --immutable && yarn build-storybook
       if [ "$${BUILDKITE_PULL_REQUEST:-false}" != "false" ]; then
         node .buildkite/scripts/deploy-storybook.mjs storybook-static

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   command = "npm run payload:migrate && yarn build"
   publish = ".next"
+  ignore = "./scripts/netlify-ignore.sh"
 
 [functions]
   # Externalize lexical packages to prevent esbuild from bundling them as CJS

--- a/scripts/netlify-ignore.sh
+++ b/scripts/netlify-ignore.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Netlify ignore-build script — skips builds when no deployable files changed.
+#
+# How it works:
+#   Netlify runs this before every build. Exit 0 = skip build, exit 1 = build.
+#   Uses git diff against $CACHED_COMMIT_REF to check if any Payload/Next.js
+#   files changed. Skips builds triggered by doc-only, CI-only, Storybook-only,
+#   or PHP-only changes.
+#
+# Docs: https://docs.netlify.com/configure-builds/ignore-builds/
+
+set -euo pipefail
+
+# Directories/files that trigger a Netlify build (Payload CMS / Next.js app)
+DEPLOY_PATHS=(
+  app/
+  payload/
+  netlify/
+  public/
+  next.config.mjs
+  payload.config.ts
+  package.json
+  yarn.lock
+  tsconfig.json
+  tsconfig.build.json
+  next-env.d.ts
+  netlify.toml
+)
+
+# File patterns to always ignore even if they're under a deploy path.
+# These never affect the Next.js/Payload production build.
+is_non_deploy_file() {
+  local file="$1"
+  case "$file" in
+    *.stories.tsx|*.stories.ts|*.stories.jsx|*.stories.js) return 0 ;;
+    *.test.tsx|*.test.ts|*.test.jsx|*.test.js)             return 0 ;;
+    *.spec.tsx|*.spec.ts|*.spec.jsx|*.spec.js)             return 0 ;;
+    *.md)                                                   return 0 ;;
+    .storybook/*)                                           return 0 ;;
+    *)                                                      return 1 ;;
+  esac
+}
+
+# If CACHED_COMMIT_REF is empty (first build), always build
+if [ -z "${CACHED_COMMIT_REF:-}" ]; then
+  echo "No cached commit ref — first build, proceeding."
+  exit 1
+fi
+
+echo "Comparing $CACHED_COMMIT_REF...$COMMIT_REF"
+echo "Checking for changes in deploy-relevant paths..."
+
+CHANGED_FILES=$(git diff --name-only "$CACHED_COMMIT_REF" "$COMMIT_REF" 2>/dev/null || echo "DIFF_FAILED")
+
+# If git diff fails (e.g. shallow clone), build to be safe
+if [ "$CHANGED_FILES" = "DIFF_FAILED" ]; then
+  echo "git diff failed — building to be safe."
+  exit 1
+fi
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No files changed at all — skipping build."
+  exit 0
+fi
+
+echo "Changed files:"
+echo "$CHANGED_FILES" | head -30
+TOTAL=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
+[ "$TOTAL" -gt 30 ] && echo "... and $((TOTAL - 30)) more"
+
+# Check if any changed file is under a deploy-relevant path AND is not excluded
+for file in $CHANGED_FILES; do
+  # Skip files that never affect the production build
+  if is_non_deploy_file "$file"; then
+    continue
+  fi
+
+  for path in "${DEPLOY_PATHS[@]}"; do
+    if [[ "$file" == "$path"* ]] || [[ "$file" == "$path" ]]; then
+      echo ""
+      echo "Deploy-relevant change detected: $file (matches $path)"
+      echo "Proceeding with build."
+      exit 1
+    fi
+  done
+done
+
+echo ""
+echo "No deploy-relevant changes found — skipping build."
+exit 0


### PR DESCRIPTION
## Changes
- Add `scripts/netlify-ignore.sh` — Netlify runs this before every build; skips when only docs, CI config, stories, tests, PHP, or Docker files changed
- Wire it into `netlify.toml` via `ignore` directive (applies to production + deploy-preview contexts)
- Add git-diff guard to Buildkite Storybook step — skips `yarn build-storybook` + Netlify deploy when no UI files changed

## How it works

**Netlify ignore script** uses `git diff` against `$CACHED_COMMIT_REF` to check if any deploy-relevant paths changed (`app/`, `payload/`, `netlify/`, `public/`, config files). Filters out `.stories.*`, `.test.*`, `.spec.*`, and `.md` files even under deploy paths.

**Buildkite Storybook guard** diffs against `origin/main` (PRs) or `HEAD~1` (pushes) looking for changes in `app/`, `payload/src/`, `.storybook/`, `package.json`, or `yarn.lock`.

## Testing
- [x] Ignore script tested against 13 scenarios (all pass)