### PR TITLE
feat: add playwright-ci-workflow skill

### DIFF
--- a/.claude/skills/e2e-debugging-workflow/SKILL.md
+++ b/.claude/skills/e2e-debugging-workflow/SKILL.md
@@ -30,11 +30,13 @@ yarn playwright test e2e/collections/shows.spec.ts --headed
 ### 1. Selector Timeouts
 
 **Symptom:**
+
 ```
 Error: Timeout 30000ms exceeded waiting for locator('#field-note')
 ```
 
 **Debugging Steps:**
+
 1. Run the test with `--headed` to see the actual page state
 2. Open browser DevTools to inspect the actual element IDs/classes
 3. Payload CMS often uses:
@@ -44,6 +46,7 @@ Error: Timeout 30000ms exceeded waiting for locator('#field-note')
    - `input[id^="react-select"]` for relationship dropdowns
 
 **Common Fixes:**
+
 ```typescript
 // Rich text fields - find via label, not direct ID
 const fieldLabel = page.locator(`label[for="field-${fieldName}"]`);
@@ -60,6 +63,7 @@ await page.waitForSelector('[role="listbox"]', { state: 'visible' });
 ### 2. Date Picker Issues
 
 **Symptom:**
+
 ```
 Error: strict mode violation: locator matched 2 elements
 ```
@@ -67,9 +71,11 @@ Error: strict mode violation: locator matched 2 elements
 **Cause:** Date picker regex like `Choose.*3.*2026` matches multiple days (3rd, 13th, 23rd).
 
 **Fix:** Use ordinal suffix matching:
+
 ```typescript
 function getOrdinalSuffix(day: number): string {
-  const j = day % 10, k = day % 100;
+  const j = day % 10,
+    k = day % 100;
   if (j === 1 && k !== 11) return 'st';
   if (j === 2 && k !== 12) return 'nd';
   if (j === 3 && k !== 13) return 'rd';
@@ -83,17 +89,20 @@ const dayRegex = new RegExp(`Choose.*\\b${day}${getOrdinalSuffix(day)}\\b.*${yea
 ### 3. PHP Page Verification Failures
 
 **Symptom:**
+
 ```
 expect(pageContent).toContain(uniqueShowNote)  # Fails even though data was created
 ```
 
 **Causes:**
+
 1. **Timestamp vs date comparison**: PostgreSQL `timestamp with time zone` vs `date` comparison fails for same-day timestamps after midnight UTC
 2. **Feature flags not set**: PHP page needs `?ff=use_postgres_schedule` parameter
 3. **Date filter excludes data**: Query uses `date <= CURRENT_DATE` but test data is in the future
 4. **Data not committed**: Test didn't wait for save to complete
 
 **Recommendation:** For reliability, test Payload CMS CRUD only:
+
 ```typescript
 // Instead of checking PHP page:
 await test.step('Verify in Payload list', async () => {
@@ -105,6 +114,7 @@ await test.step('Verify in Payload list', async () => {
 ### 4. Auth Session Issues
 
 **Symptom:**
+
 ```
 Error: page.goto: net::ERR_CONNECTION_REFUSED
 # or
@@ -114,6 +124,7 @@ Redirected to login page
 **Cause:** Auth setup didn't run or session expired.
 
 **Check:**
+
 1. Verify `auth.setup.ts` runs first in `playwright.config.ts`
 2. Check `.auth/` directory has session files
 3. Ensure `storageState` is configured for test projects
@@ -121,6 +132,7 @@ Redirected to login page
 ### 5. Stale Listbox Options
 
 **Symptom:**
+
 ```
 Error: Timeout waiting for getByRole('option')
 ```
@@ -128,6 +140,7 @@ Error: Timeout waiting for getByRole('option')
 **Cause:** Relationship dropdown is empty (no seeded data) or search didn't match.
 
 **Fix:**
+
 ```typescript
 // Type to search for specific item
 await field.locator('input[id^="react-select"]').fill(uniqueArtistName);
@@ -183,6 +196,7 @@ yarn playwright test e2e/collections/shows.spec.ts --trace on
 When a selector isn't working:
 
 1. **Pause the test:**
+
    ```typescript
    await page.pause(); // Opens Playwright Inspector
    ```
@@ -193,8 +207,8 @@ When a selector isn't working:
 
 3. **Test selector in console:**
    ```javascript
-   document.querySelector('#field-note')
-   document.querySelectorAll('[data-lexical-editor="true"]')
+   document.querySelector('#field-note');
+   document.querySelectorAll('[data-lexical-editor="true"]');
    ```
 
 ### Step 5: Verify Fix Works
@@ -213,6 +227,7 @@ yarn playwright test
 ### Step 6: Check Screenshots
 
 Test screenshots are saved to `e2e/screenshots/`. Review them to verify:
+
 - Form was filled correctly
 - Save completed successfully
 - Data appears in collection list
@@ -222,6 +237,7 @@ Test screenshots are saved to `e2e/screenshots/`. Review them to verify:
 ### 1. Focus on Payload CMS, Not PHP
 
 The Payload admin UI is consistent and predictable. The PHP pages have:
+
 - Complex date/time filters
 - Feature flag dependencies
 - Timezone sensitivities
@@ -267,15 +283,16 @@ await test.step('Fill artist form', async () => {
 
 ## CI vs Local Differences
 
-| Aspect | Local | CI |
-|--------|-------|-----|
-| Node version | May vary | Uses nvm 22 |
-| Docker images | Built locally | Pulled from GHCR |
-| Database | Persistent volume | Fresh each run |
-| Network | localhost | Docker network |
-| Timezone | System TZ | UTC |
+| Aspect        | Local             | CI               |
+| ------------- | ----------------- | ---------------- |
+| Node version  | May vary          | Uses nvm 22      |
+| Docker images | Built locally     | Pulled from GHCR |
+| Database      | Persistent volume | Fresh each run   |
+| Network       | localhost         | Docker network   |
+| Timezone      | System TZ         | UTC              |
 
 **Key insight:** If tests pass locally but fail in CI, suspect:
+
 1. Timezone differences (especially date comparisons)
 2. Missing seeded data
 3. Docker network configuration
@@ -284,7 +301,15 @@ await test.step('Fill artist form', async () => {
 ## Getting Help
 
 If stuck after following this workflow:
+
 1. Check CI logs for the actual error message
 2. Look for screenshots in test artifacts
 3. Search for similar issues in the Playwright docs
 4. Ask for help with specific error details
+
+## Related Skills
+
+- **playwright-ci-workflow** — The complete lifecycle for writing tests that pass in CI. Covers Buildkite monitoring, fast feedback loops (pipeline trimming), environment-aware workflows for CLI vs web agents, and adding tests to the CI curated list. **Use that skill for the CI workflow; use this skill for debugging specific test failures.**
+- **detecting-agent-environment** — Environment detection utilities (`detect_docker`, `detect_ci`, etc.)
+- **agent-automation-infrastructure** — Pre-built Docker images, CI pipeline details
+- **testing-pr-changes** — PR verification checklist and proof requirements

--- a/.claude/skills/playwright-ci-workflow/SKILL.md
+++ b/.claude/skills/playwright-ci-workflow/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: playwright-ci-workflow
+description: End-to-end workflow for writing, running, and verifying Playwright E2E tests through CI. Use this skill whenever you are writing new e2e tests, adding tests to the Buildkite CI pipeline, troubleshooting CI e2e failures, monitoring Buildkite build results, or need to get Playwright tests passing in CI. Also use when you need faster CI feedback loops by temporarily disabling unrelated pipeline steps. This skill adapts to your environment — it works for both CLI agents (with Docker and `bk` CLI) and web agents (using GitHub MCP tools to monitor check runs). If you are doing ANY work involving Playwright tests and CI, use this skill.
+---
+
+# Playwright CI Workflow
+
+**The complete lifecycle for writing e2e tests that pass in CI — from first draft to green build.**
+
+This skill is about the _workflow_: how to write tests, verify them, monitor CI, and iterate. For debugging specific test failures (broken selectors, timeout issues, date picker quirks), see the `e2e-debugging-workflow` skill — it's the companion to this one.
+
+## Know Your Environment
+
+Before doing anything, figure out what tools you have. This determines your workflow.
+
+```bash
+source bin/agent-helpers/detect-environment.sh
+print_environment
+```
+
+| Capability             | CLI Agent (local) | Web Agent (github.com) |
+| ---------------------- | ----------------- | ---------------------- |
+| Docker                 | ✅ Yes            | ❌ Usually no          |
+| `bk` CLI               | ✅ Yes            | ❌ No                  |
+| Run Playwright locally | ✅ Yes            | ❌ No                  |
+| GitHub MCP tools       | ✅ Yes            | ✅ Yes                 |
+| Push commits           | ✅ Yes            | ✅ Yes                 |
+| Edit pipeline.yml      | ✅ Yes            | ✅ Yes                 |
+
+**The core principle**: never push a test blindly. Always verify it works — locally if you can, via CI monitoring if you can't.
+
+## ⚡ Fast Feedback Loop (CRITICAL)
+
+**This is the single most important technique in this skill.** The full Buildkite pipeline takes 10-15 minutes. When iterating on e2e tests, temporarily disable unrelated steps to cut this to ~5 minutes:
+
+```yaml
+# In .buildkite/pipeline.yml, comment out ALL non-e2e steps:
+steps:
+  # - label: ":eslint: ESLint"
+  #   command: yarn lint
+  # - label: ":vitest: Vitest"
+  #   command: yarn test:coverage
+  # - label: ":storybook: Storybook"
+  #   ...
+  # - label: ":php: PHP Lint"
+  #   ...
+  # - label: ":docker: Build Images"
+  #   ...
+  - wait: ~
+  - label: ':playwright: E2E Tests'
+    # ... keep ONLY this step
+```
+
+**Include this edit in your commits while iterating.** Revert it once tests are green:
+
+```bash
+git checkout -- .buildkite/pipeline.yml
+git add .buildkite/pipeline.yml
+git commit --amend --no-edit
+git push --force-with-lease
+```
+
+**Both CLI and web agents MUST do this.** It's especially critical for web agents who can't run tests locally — every CI cycle is your only feedback mechanism.
+
+## CLI Agent Workflow (Docker + `bk` available)
+
+This is the gold-standard workflow. You can run tests locally before pushing.
+
+### Step 1: Write the Test
+
+Follow these patterns (they work in both local and CI):
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { navigateWithRetry, captureScreenshot } from './utils/test-helpers';
+import { navigateToPayloadCollection, waitForPayloadSave } from './utils/payload-helpers';
+
+test.describe('Feature Name', () => {
+  test('should do the thing', async ({ page }, testInfo) => {
+    await test.step('Navigate', async () => {
+      await navigateWithRetry(page, 'http://localhost:3000/admin');
+    });
+
+    await test.step('Act', async () => {
+      // Your test actions here
+    });
+
+    await test.step('Assert', async () => {
+      await expect(page.getByText('Expected')).toBeVisible();
+      await captureScreenshot(page, testInfo, 'result');
+    });
+  });
+});
+```
+
+**CI-critical patterns:**
+
+- Always use `navigateWithRetry()` for URLs — Docker networking can be flaky
+- Use `test.step()` for clear failure reporting
+- Capture screenshots — they become CI artifacts on failure
+- Use helper functions from `e2e/utils/` — they handle CI/local differences
+- Use unique identifiers (`generateUniqueId()`) to avoid test pollution
+
+### Step 2: Run Locally
+
+```bash
+# Start services if not already running
+docker compose up -d
+yarn payload:dev &
+until curl -sf http://localhost:3000/admin > /dev/null 2>&1; do sleep 2; done
+
+# Seed data
+yarn seed:payload
+
+# Run your specific test
+npx playwright test e2e/your-test.spec.ts --headed
+
+# If it fails, debug interactively
+npx playwright test e2e/your-test.spec.ts --debug
+```
+
+If the test passes locally, it has a good chance of passing in CI. But "good chance" isn't certainty — the CI environment differs (Docker-in-Docker, different networking, UTC timezone). Move to Step 3.
+
+### Step 3: Add to CI Test Suite (if needed)
+
+Tests only run in CI if they're in the curated list in `playwright.config.ts`:
+
+```typescript
+// In playwright.config.ts, find the testMatch line:
+testMatch: isCi
+  ? /(payload-basic|mrm-postgres-fresh|mrm-postgres-extended|mrm-payload-admin|your-new-test)\.spec\.ts/
+  : undefined,
+```
+
+Add your test file name to this regex. If your test depends on specific seed data, make sure the CI seeding (in `docker-compose.e2e.yml` payload service command) includes it.
+
+### Step 4: Push and Monitor Buildkite
+
+Push your changes (with pipeline already trimmed per the Fast Feedback Loop section above), then monitor with `bk`:
+
+```bash
+# Watch the build
+bk build list --mine --pipeline site | head -5
+
+# Get the build number from the output, then watch jobs
+bk job list --build <build-number>
+
+# Stream logs from the e2e job
+bk job log <job-id>
+```
+
+**After tests pass:** revert the pipeline.yml changes before merging (see Fast Feedback Loop section above).
+
+### Step 5: Iterate on Failures
+
+If CI fails, check the logs and artifacts:
+
+```bash
+# Get the failing job's log
+bk job log <job-id>
+
+# Download playwright report artifacts
+bk artifacts list --build <build-number>
+bk artifacts download <artifact-id>
+```
+
+Common CI-only failures:
+
+- **Timeout**: CI is slower. Increase timeout or add `{ timeout: 10000 }` to assertions
+- **DNS resolution**: Playwright in Docker uses hostnames (`payload`, `apache`) not `localhost`
+- **Timezone**: CI runs in UTC. Use `gmdate()`-style comparisons, not local time
+- **Stale data**: CI gets fresh database each run. Don't assume data from previous runs exists
+- **esbuild mismatch**: The CI payload container swaps native esbuild for wasm version
+
+See `e2e-debugging-workflow` skill for detailed debugging of specific failure types.
+
+## Web Agent Workflow (No Docker, No `bk`)
+
+Web agents (triggered from github.com) can't run Docker or use the `bk` CLI. The workflow adapts: write carefully, push, then monitor via GitHub.
+
+### Step 1: Write the Test (Extra Carefully)
+
+Without local execution, you need to be more deliberate. Before writing:
+
+1. **Study existing tests** — read 2-3 similar `.spec.ts` files in `e2e/` to understand patterns
+2. **Study the helpers** — read `e2e/utils/test-helpers.ts` and `e2e/utils/payload-helpers.ts`
+3. **Understand the CI environment** — tests run inside Docker where services are at hostnames like `payload:3000` and `apache:80`, but `playwright.config.ts` handles the URL mapping via `PLAYWRIGHT_BASE_URL` and `PLAYWRIGHT_LEGACY_URL`
+
+Use proven patterns from existing tests. Don't innovate on infrastructure — innovate on test coverage.
+
+### Step 2: Enable Fast CI Feedback
+
+**MANDATORY**: Before pushing, modify `.buildkite/pipeline.yml` per the Fast Feedback Loop section above. This is your only way to iterate quickly since you can't run tests locally. Without this, each CI cycle takes 10-15 minutes instead of ~5.
+
+### Step 3: Push and Monitor via GitHub
+
+After pushing, use GitHub MCP tools to monitor the Buildkite results:
+
+```
+# First, check the PR's check runs to find the Buildkite build
+github-mcp-server-pull_request_read:
+  method: get_check_runs
+  owner: ynotradio
+  repo: site
+  pullNumber: <pr-number>
+
+# Look for a check run named "buildkite/site" in the response.
+# Status meanings:
+#   queued / in_progress — still running, wait 2-3 minutes and check again
+#   completed + conclusion: success — tests passed 🎉
+#   completed + conclusion: failure — tests failed, investigate
+
+# If it failed, get the job logs:
+github-mcp-server-get_job_logs:
+  owner: ynotradio
+  repo: site
+  run_id: <run-id-from-check-run>
+  failed_only: true
+  return_content: true
+  tail_lines: 200
+```
+
+**Monitoring cadence**: Check every 3-5 minutes. The e2e step alone takes ~5 minutes (with pipeline trimmed). Don't check more often than that.
+
+### Step 4: Investigate Failures
+
+When CI fails, get the details:
+
+```
+# Get job logs from GitHub (if Buildkite posts them)
+github-mcp-server-get_job_logs:
+  owner: <owner>
+  repo: <repo>
+  run_id: <workflow-run-id>
+  failed_only: true
+  return_content: true
+```
+
+Also check for Buildkite annotations on the PR — they often contain failure summaries.
+
+If the GitHub MCP tools don't surface enough detail, look at the build URL from the check run output and note the failure patterns. Common fixes:
+
+- **Selector not found**: Check Payload UI field IDs (`#field-{name}`) — use existing helpers
+- **Timeout**: Increase assertion timeouts, add `navigateWithRetry()`
+- **Connection refused**: Service probably wasn't healthy yet — check service dependencies
+
+### Step 5: Fix, Push, Monitor Again
+
+Make targeted fixes based on the error. Push again (with pipeline still trimmed). Repeat until green.
+
+**Once tests pass**: revert the pipeline.yml changes in a final commit:
+
+```bash
+git checkout -- .buildkite/pipeline.yml
+```
+
+## Test Architecture Reference
+
+### Which Tests Run in CI
+
+Only tests matching this pattern in `playwright.config.ts` run in Buildkite:
+
+```typescript
+testMatch: /(payload-basic|mrm-postgres-fresh|mrm-postgres-extended|mrm-payload-admin)\.spec\.ts/;
+```
+
+To add a new test to CI, append its filename to this regex.
+
+### CI Service Architecture
+
+```
+postgres:5432 ─┬─► payload:3000 ──┬─► playwright
+               ├─► phpfpm:9000 ──►├─► (runs tests)
+mysql:3306 ────┘    apache:8080 ──┘
+```
+
+- Payload runs in **production mode** (`yarn build` + `yarn start`) in CI
+- PHP runs behind Apache with mod_proxy_fcgi
+- Playwright container adds service hostnames to `/etc/hosts` for Chromium DNS
+
+### CI Seed Data
+
+The payload container runs `yarn payload:migrate` then `bin/seed-mrm-fresh.ts` on startup. MySQL imports `src/db/docker/ynot_db.sql` automatically. If your test needs specific data, either:
+
+1. Seed it in the test itself (via Payload API)
+2. Add it to the CI seed scripts
+
+### Timeouts
+
+| Context                | Default          | Max Reasonable                     |
+| ---------------------- | ---------------- | ---------------------------------- |
+| Test assertion (CI)    | 60s              | 60s (increase with care)           |
+| Test assertion (local) | 20s              | 30s                                |
+| Service health (CI)    | 300s for Payload | Already configured                 |
+| E2E step overall       | 20min            | Don't increase without good reason |
+
+## Writing Tests That Work in CI
+
+These patterns prevent the most common CI failures:
+
+### Use Environment-Aware URLs
+
+Don't hardcode `localhost`. The helpers and config handle this:
+
+```typescript
+// ✅ Good — uses config
+const PAYLOAD_BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+
+// ❌ Bad — breaks in Docker
+await page.goto('http://localhost:3000/admin');
+```
+
+### Handle Flaky Navigation
+
+Docker networking hiccups are real. Always retry:
+
+```typescript
+// ✅ Good
+await navigateWithRetry(page, `${BASE_URL}/admin`);
+
+// ❌ Bad — fails on first network blip
+await page.goto(`${BASE_URL}/admin`);
+```
+
+### Check for PHP Errors
+
+When testing legacy pages, always verify no PHP errors leaked through:
+
+```typescript
+import { checkForPhpErrors } from './utils/test-helpers';
+
+const errors = checkForPhpErrors(await page.content());
+expect(errors).toHaveLength(0);
+```
+
+### Use the Payload Helper Functions
+
+Don't reinvent CRUD interactions. The helpers in `e2e/utils/payload-helpers.ts` handle:
+
+- Navigation to collections (`navigateToPayloadCollection`)
+- Form filling (text, date, time, relationship, rich text, slug, checkbox fields)
+- Save and publish workflows (`clickPayloadSave`, `waitForPayloadSave`, `clickPayloadPublish`)
+- Legacy PHP navigation with feature flags (`navigateToLegacySiteWithPostgres`)
+
+### Date and Time Handling
+
+CI runs in UTC. This causes subtle failures:
+
+```typescript
+// ✅ Good — timezone-safe
+const futureDate = getFutureDate(7); // from test-helpers
+
+// ❌ Bad — timezone-dependent
+const date = new Date().toLocaleDateString(); // Different in UTC vs local
+```
+
+### PHP/Legacy-Specific CI Gotchas
+
+These bite you when testing legacy PHP pages in CI:
+
+- **POSTGRES_SSL_MODE**: PHP's `Database::getPostgres()` defaults to `sslmode=require`. The CI postgres container has SSL disabled. Without `POSTGRES_SSL_MODE=disable` in phpfpm env vars, PDO connects silently fail and the app falls back to MySQL. This is already configured in `docker-compose.e2e.yml` but watch for it if modifying Docker config.
+- **Feature flags**: Legacy PHP pages require explicit feature flag query parameters (e.g., `?ff=use_postgres_schedule`). The `navigateToLegacySiteWithPostgres()` helper handles this — use it instead of building URLs manually.
+- **Seed data coverage**: CI only runs `bin/seed-mrm-fresh.ts` (for MRM tournament data). If your test needs shows, concerts, or other data, you must either add seeding to `seed-mrm-fresh.ts` or create the data in the test itself via the Payload API.
+- **PHP timezone**: The phpfpm container may have a non-UTC timezone. PostgreSQL queries use `AT TIME ZONE 'UTC'` and PHP should use `gmdate()` not `date()`. Date-based assertions can break if the test assumes local time.
+
+## Checklist Before Pushing
+
+Run through this mentally (or literally) before every push:
+
+- [ ] Test uses `navigateWithRetry()` for all page navigations
+- [ ] Test uses helper functions from `e2e/utils/` where possible
+- [ ] Test uses unique identifiers (not hardcoded names that might collide)
+- [ ] Test captures screenshots at key steps
+- [ ] Test uses `test.step()` blocks for clarity
+- [ ] If new to CI: test filename added to `playwright.config.ts` testMatch
+- [ ] If needs seed data: data available in CI seed scripts
+- [ ] Pipeline.yml temporarily trimmed for fast feedback (will revert after)
+
+## Related Skills
+
+- **e2e-debugging-workflow** — Debugging specific Playwright failures (selectors, timing, dates)
+- **detecting-agent-environment** — Environment detection utilities (`detect_docker`, `detect_ci`, etc.)
+- **agent-automation-infrastructure** — Pre-built Docker images, CI pipeline details
+- **testing-pr-changes** — PR verification checklist and proof requirements

--- a/.claude/skills/playwright-ci-workflow/evals/evals.json
+++ b/.claude/skills/playwright-ci-workflow/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "playwright-ci-workflow",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need to write a Playwright e2e test for the new 'Venues' collection in Payload CMS. The test should create a new venue with a name, address, and URL, then verify it appears in the list view. I want this running in CI. I'm working from github.com so I don't have Docker locally.",
+      "expected_output": "Agent should: (1) study existing collection CRUD tests for patterns, (2) write a test using payload-helpers, (3) add the test to playwright.config.ts testMatch, (4) trim pipeline.yml for fast feedback, (5) push and monitor via GitHub MCP check runs, (6) iterate on any failures, (7) revert pipeline.yml changes",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "I wrote a new e2e test for the MRM bracket page that checks the bracket renders correctly with seeded tournament data. It passes locally with `npx playwright test e2e/mrm-bracket.spec.ts --headed` but the Buildkite build is failing. Can you help me figure out why and get it passing in CI?",
+      "expected_output": "Agent should: (1) check Buildkite logs via `bk` CLI, (2) identify CI-specific issues (Docker networking, UTC timezone, seed data differences), (3) suggest fixes for common CI-only failures, (4) use fast feedback loop (trim pipeline.yml), (5) push fix and monitor Buildkite, (6) restore pipeline.yml after success",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We need e2e test coverage for the legacy PHP shows page that reads from PostgreSQL. The page is at /shows.php?ff=use_postgres_schedule and it should display upcoming shows. Write the test and make sure it passes in our Buildkite CI pipeline.",
+      "expected_output": "Agent should: (1) use navigateToLegacySiteWithPostgres helper, (2) use navigateWithRetry for Docker networking, (3) check for PHP errors, (4) handle timezone-aware date assertions, (5) add test to CI curated list, (6) trim pipeline for fast feedback, (7) verify via bk CLI or GitHub MCP depending on environment",
+      "files": []
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,17 +30,18 @@ yarn test:e2e                 # Playwright integration tests
 
 Skills are in `.claude/skills/`. **YOU MUST check available skills BEFORE starting any task.** Invoke them when relevant—they contain specialized knowledge that prevents common mistakes.
 
-| Skill | When to Use |
-|-------|-------------|
-| **testing-pr-changes** | Before submitting any PR. Success criteria and proof requirements. |
-| **payload-migration-workflow** | When working on Payload collections, data models, or PHP→Payload migration. |
-| **code-quality-standards** | When writing new TypeScript/React code. Airbnb style, React 19, Next.js 15 patterns. |
-| **test-story-coupling** | When creating components. Ensures matching test and story files exist. |
-| **dependency-best-practices** | When adding packages. Approved libraries and security practices. |
-| **agent-automation-infrastructure** | When dealing with slow builds or Docker issues. Pre-built images available. |
-| **detecting-agent-environment** | When creating environment-aware scripts. CI/CD vs local detection. |
-| **storybook-best-practices** | When creating `.stories.tsx` files. Payload UI mocking, provider wrapping. |
-| **e2e-debugging-workflow** | When E2E tests fail. Playwright debugging, selector issues, local verification. |
+| Skill                               | When to Use                                                                                                                   |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **testing-pr-changes**              | Before submitting any PR. Success criteria and proof requirements.                                                            |
+| **payload-migration-workflow**      | When working on Payload collections, data models, or PHP→Payload migration.                                                   |
+| **code-quality-standards**          | When writing new TypeScript/React code. Airbnb style, React 19, Next.js 15 patterns.                                          |
+| **test-story-coupling**             | When creating components. Ensures matching test and story files exist.                                                        |
+| **dependency-best-practices**       | When adding packages. Approved libraries and security practices.                                                              |
+| **agent-automation-infrastructure** | When dealing with slow builds or Docker issues. Pre-built images available.                                                   |
+| **detecting-agent-environment**     | When creating environment-aware scripts. CI/CD vs local detection.                                                            |
+| **storybook-best-practices**        | When creating `.stories.tsx` files. Payload UI mocking, provider wrapping.                                                    |
+| **e2e-debugging-workflow**          | When E2E tests fail. Playwright debugging, selector issues, local verification.                                               |
+| **playwright-ci-workflow**          | When writing new e2e tests or getting them through CI. Buildkite monitoring, fast feedback loops, web vs CLI agent workflows. |
 
 ### Skills Usage Workflow
 
@@ -53,6 +54,7 @@ Skills are in `.claude/skills/`. **YOU MUST check available skills BEFORE starti
    - Payload CMS? → `payload-migration-workflow`
    - Creating a PR? → `testing-pr-changes` (ALWAYS)
    - E2E test failures? → `e2e-debugging-workflow`
+   - Writing/adding e2e tests? → `playwright-ci-workflow`
    - Build/Docker issues? → `agent-automation-infrastructure`
    - Storybook stories? → `storybook-best-practices`
 
@@ -63,6 +65,7 @@ Skills are in `.claude/skills/`. **YOU MUST check available skills BEFORE starti
 **Why this matters**: Skills contain project-specific conventions that prevent CI failures, code that doesn't match standards, and wasted rework time.
 
 **Common mistakes to avoid**:
+
 - ❌ Skipping skills check → code doesn't match conventions, CI fails
 - ❌ Invoking skills but ignoring content → skills become useless
 - ❌ Assuming simple changes don't need testing-pr-changes → forgot CI verification, pushed failing code
@@ -74,11 +77,11 @@ In addition to interactive agent skills, this repository uses **GitHub Agentic W
 
 See `.github/agents/README.md` for details. Available workflows:
 
-| Workflow | Purpose | Schedule |
-|----------|---------|----------|
-| **Code Simplifier** | Automatically simplifies recently modified code | Daily |
-| **Test Coverage Improver** | Systematically adds tests to under-tested areas | Daily |
-| **Code Refactoring Assistant** | Implements strategic refactoring from checklist | Weekly |
+| Workflow                       | Purpose                                         | Schedule |
+| ------------------------------ | ----------------------------------------------- | -------- |
+| **Code Simplifier**            | Automatically simplifies recently modified code | Daily    |
+| **Test Coverage Improver**     | Systematically adds tests to under-tested areas | Daily    |
+| **Code Refactoring Assistant** | Implements strategic refactoring from checklist | Weekly   |
 
 These workflows run automatically and create pull requests for human review. They handle repetitive code quality tasks so you can focus on building features.
 
@@ -166,6 +169,7 @@ await page.screenshot({ path: 'screenshot.png' });
 ```
 
 Or use the MCP browser tools:
+
 1. Navigate to the URL (`playwright-browser_navigate`)
 2. Take a snapshot (`playwright-browser_snapshot`)
 3. Take a screenshot (`playwright-browser_take_screenshot`)
@@ -209,6 +213,7 @@ When modifying code, actively look for and remove dead code:
 **CRITICAL**: You must verify CI passes BEFORE pushing code. Never push code that fails CI.
 
 **Pre-push verification workflow**:
+
 1. Run `bash bin/agent-helpers/bootstrap.sh` — installs node_modules if missing
 2. Run `yarn lint` - must exit 0
 3. Run `yarn test` - must exit 0
@@ -217,6 +222,7 @@ When modifying code, actively look for and remove dead code:
 6. Only push after ALL checks pass locally
 
 **If CI fails after push**:
+
 1. Pull the branch immediately
 2. Fix the failure locally
 3. Verify all checks pass
@@ -224,6 +230,7 @@ When modifying code, actively look for and remove dead code:
 5. **NEVER** push multiple failing commits to the same branch
 
 Your PR must pass all CI checks:
+
 - ESLint (no warnings)
 - Vitest tests with coverage
 - E2E Playwright tests
@@ -235,13 +242,14 @@ Your PR must pass all CI checks:
 
 Know when to report blockers:
 
-| Operation | Expected | Stop & Report If |
-|-----------|----------|------------------|
-| Container startup | < 60s | > 120s |
-| yarn install | < 120s | > 300s |
-| Service ready | < 180s | > 360s |
+| Operation         | Expected | Stop & Report If |
+| ----------------- | -------- | ---------------- |
+| Container startup | < 60s    | > 120s           |
+| yarn install      | < 120s   | > 300s           |
+| Service ready     | < 180s   | > 360s           |
 
 If hitting timeouts, use pre-built images:
+
 ```bash
 docker pull ghcr.io/ynotradio/site/postgres-seeded:latest
 docker pull ghcr.io/ynotradio/site/payload-dev:latest
@@ -252,6 +260,7 @@ docker pull ghcr.io/ynotradio/site/payload-dev:latest
 **This is a solo hobby project** with one expert maintainer who has occasional time to spare, not a full-time team.
 
 **What this means for you**:
+
 - No need for technical comparisons or pro/con analyses
 - No need for multiple implementation options
 - Make good engineering decisions and implement them
@@ -259,6 +268,7 @@ docker pull ghcr.io/ynotradio/site/payload-dev:latest
 - Trust that the maintainer knows the codebase and doesn't need hand-holding
 
 **If you need the human maintainer**:
+
 - Tag them in the PR description (e.g., "@owner please review security concerns")
 - Or create a GitHub issue for complex decisions that need input
 - Don't create TODO lists expecting others to complete your work
@@ -268,12 +278,14 @@ docker pull ghcr.io/ynotradio/site/payload-dev:latest
 **Your code and tests are your documentation. Let them speak.**
 
 **Do:**
+
 - Let passing tests demonstrate functionality
 - Include screenshots as evidence of working features
 - Write clear commit messages
 - Make a brief PR description (2-3 sentences max)
 
 **Don't:**
+
 - Write lengthy summaries of what you did
 - Create "proof of work" documentation (action plans, checklists, summaries)
 - Repeat information that's in the code or tests
@@ -288,13 +300,16 @@ docker pull ghcr.io/ynotradio/site/payload-dev:latest
 
 ```markdown
 ## Changes
+
 - [Brief bullet points of what changed]
 
 ## Testing
+
 - [x] All checks pass locally before push
 - [x] Screenshot attached
 
 ## Evidence
+
 [Single screenshot showing it works]
 ```
 
@@ -344,13 +359,13 @@ docs/payload-migration/   # Migration documentation
 
 When you need more context:
 
-| Topic | Document |
-|-------|----------|
-| Project status | `docs/PROJECT_STATUS.md` |
-| Migration overview | `docs/payload-migration/README.md` |
-| Data models | `docs/payload-migration/03-core-data-models.md` |
+| Topic                  | Document                                                 |
+| ---------------------- | -------------------------------------------------------- |
+| Project status         | `docs/PROJECT_STATUS.md`                                 |
+| Migration overview     | `docs/payload-migration/README.md`                       |
+| Data models            | `docs/payload-migration/03-core-data-models.md`          |
 | PHP PostgreSQL queries | `docs/payload-migration/03.5-php-postgresql-querying.md` |
-| E2E testing | `e2e/README.md` |
+| E2E testing            | `e2e/README.md`                                          |
 
 ## Common Patterns
 


### PR DESCRIPTION
Adds a new skill covering the full Playwright e2e test lifecycle from writing to green CI. Key features:
- Environment-aware workflows (CLI agents with Docker/bk vs web agents with GitHub MCP)
- Fast feedback loops via temporary pipeline trimming
- PHP/Docker-specific CI gotchas (SSL mode, feature flags, seed data, timezones)
- Concrete monitoring examples for both `bk` CLI and GitHub check runs

Also cross-references the existing e2e-debugging-workflow skill and updates AGENTS.md routing.