### PR TITLE
fix: skip pushDevSchema in integrity check scripts

### DIFF
--- a/bin/integrity-check-display-names.ts
+++ b/bin/integrity-check-display-names.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+// Skip Drizzle pushDevSchema — these scripts only read/write data, never alter schema
 /**
  * Display Name Integrity Check
  *
@@ -29,6 +30,8 @@ import {
   computeDJDisplayName,
   computeMusicDisplayName,
 } from './integrity-check-display-names-utils';
+
+process.env.PAYLOAD_MIGRATING = 'true';
 
 const PAGE_SIZE = 100;
 

--- a/bin/integrity-check-musicbrainz.ts
+++ b/bin/integrity-check-musicbrainz.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+// Skip Drizzle pushDevSchema — these scripts only read/write data, never alter schema
 /**
  * MusicBrainz Integrity Check
  *
@@ -35,6 +36,8 @@ import {
   type CollectionConfig,
 } from './integrity-check-musicbrainz-utils';
 
+process.env.PAYLOAD_MIGRATING = 'true';
+
 // ---------------------------------------------------------------------------
 // Process a single collection
 // ---------------------------------------------------------------------------
@@ -52,9 +55,7 @@ async function processCollection(
   let processed = 0;
 
   while (hasMore) {
-    const limit = options.limit
-      ? Math.min(PAGE_SIZE, options.limit - processed)
-      : PAGE_SIZE;
+    const limit = options.limit ? Math.min(PAGE_SIZE, options.limit - processed) : PAGE_SIZE;
     if (limit <= 0) break;
 
     const result = await payload.find({
@@ -67,30 +68,22 @@ async function processCollection(
     });
 
     for (const doc of result.docs) {
-      const rawName = (
-        doc as Record<string, unknown>
-      )[collectionCfg.nameField] as string;
+      const rawName = (doc as Record<string, unknown>)[collectionCfg.nameField] as string;
       const name = repairEncoding(rawName);
       const mbid = (doc as { musicbrainzId?: string }).musicbrainzId;
 
       if (mbid) {
         const artistName = collectionCfg.needsArtist
           ? (() => {
-            const raw = getArtistName(
-              (doc as { artist?: unknown }).artist,
-            );
+            const raw = getArtistName((doc as { artist?: unknown }).artist);
             return raw ? repairEncoding(raw) : null;
           })()
           : null;
 
-        const identifier = collectionCfg.needsArtist && artistName
-          ? `${artistName} — ${name}`
-          : name;
+        const identifier = collectionCfg.needsArtist && artistName ? `${artistName} — ${name}` : name;
 
         if (options.verbose) {
-          console.log(
-            `  Checking [${collectionCfg.slug}] ${identifier} (${mbid})`,
-          );
+          console.log(`  Checking [${collectionCfg.slug}] ${identifier} (${mbid})`);
         }
 
         let handled = false;
@@ -147,9 +140,7 @@ async function processCollection(
                 });
                 checkResult.status = 'fixed';
                 if (options.verbose) {
-                  console.log(
-                    `    ✅ Fixed: ${mbid} → ${bestMatch.foundMbid}`,
-                  );
+                  console.log(`    ✅ Fixed: ${mbid} → ${bestMatch.foundMbid}`);
                 }
               } catch (err) {
                 checkResult.status = 'fix-failed';
@@ -177,8 +168,7 @@ async function processCollection(
       }
     }
 
-    hasMore = result.hasNextPage
-      && (!options.limit || processed < options.limit);
+    hasMore = result.hasNextPage && (!options.limit || processed < options.limit);
     page++;
   }
 }
@@ -225,9 +215,7 @@ async function main() {
   const exitCode = report.mismatch > 0 || report.fixFailed > 0 ? 1 : 0;
 
   if (!options.fix && report.mismatch > 0) {
-    console.log(
-      '\n💡 This was a dry run. Use --fix to update mismatched MBIDs.\n',
-    );
+    console.log('\n💡 This was a dry run. Use --fix to update mismatched MBIDs.\n');
   }
 
   process.exit(exitCode);

--- a/bin/integrity-check-record-metadata.ts
+++ b/bin/integrity-check-record-metadata.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+// Skip Drizzle pushDevSchema — these scripts only read/write data, never alter schema
 /**
  * Record Metadata Integrity Check
  *
@@ -40,6 +41,8 @@ import {
   type RecordCheckContext,
   type MbLookupResult,
 } from './integrity-check-record-metadata-utils';
+
+process.env.PAYLOAD_MIGRATING = 'true';
 
 const PAGE_SIZE = 100;
 

--- a/bin/integrity-check-slugs.ts
+++ b/bin/integrity-check-slugs.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+// Skip Drizzle pushDevSchema — these scripts only read/write data, never alter schema
 /**
  * Slug Integrity Check
  *
@@ -25,6 +26,8 @@ import {
   type CheckReport,
   type IntegrityReport,
 } from './content-integrity-utils';
+
+process.env.PAYLOAD_MIGRATING = 'true';
 
 const PAGE_SIZE = 100;
 
@@ -100,10 +103,7 @@ export async function generateCdOfTheWeekSlug(
       depth: 1,
     });
     if (!found) return null;
-    return await generateMusicSlug(
-      payload,
-      found as unknown as Record<string, unknown>,
-    );
+    return await generateMusicSlug(payload, found as unknown as Record<string, unknown>);
   } catch {
     return null;
   }
@@ -191,9 +191,7 @@ async function checkCollection(
 
       const entry = doc as unknown as Record<string, unknown>;
       const entryId = entry.id as string | number;
-      const identifier = String(
-        entry[collectionConfig.identifierField] ?? `id:${entryId}`,
-      );
+      const identifier = String(entry[collectionConfig.identifierField] ?? `id:${entryId}`);
       const currentSlug = (entry.slug as string | undefined) ?? '';
 
       try {
@@ -212,7 +210,7 @@ async function checkCollection(
           if (options.verbose) {
             console.log(
               `  \u23ED  [${collectionConfig.collection}] ${identifier}`
-              + ' \u2014 skipped (no expected slug)',
+                + ' \u2014 skipped (no expected slug)',
             );
           }
         } else if (!currentSlug) {
@@ -237,7 +235,7 @@ async function checkCollection(
               if (options.verbose) {
                 console.log(
                   `  \u2705 [${collectionConfig.collection}] ${identifier}`
-                  + ` \u2014 fixed (was empty \u2192 ${expectedSlug})`,
+                    + ` \u2014 fixed (was empty \u2192 ${expectedSlug})`,
                 );
               }
             } catch (err) {
@@ -265,7 +263,7 @@ async function checkCollection(
             if (options.verbose) {
               console.log(
                 `  \u274C [${collectionConfig.collection}] ${identifier}`
-                + ` \u2014 missing slug (expected: ${expectedSlug})`,
+                  + ` \u2014 missing slug (expected: ${expectedSlug})`,
               );
             }
           }
@@ -291,7 +289,7 @@ async function checkCollection(
               if (options.verbose) {
                 console.log(
                   `  \u2705 [${collectionConfig.collection}] ${identifier}`
-                  + ` \u2014 fixed (${currentSlug} \u2192 ${expectedSlug})`,
+                    + ` \u2014 fixed (${currentSlug} \u2192 ${expectedSlug})`,
                 );
               }
             } catch (err) {
@@ -319,7 +317,7 @@ async function checkCollection(
             if (options.verbose) {
               console.log(
                 `  \u26A0\uFE0F  [${collectionConfig.collection}] ${identifier}`
-                + ` \u2014 mismatch: "${currentSlug}" vs "${expectedSlug}"`,
+                  + ` \u2014 mismatch: "${currentSlug}" vs "${expectedSlug}"`,
               );
             }
           }
@@ -332,9 +330,7 @@ async function checkCollection(
             status: 'ok',
           });
           if (options.verbose) {
-            console.log(
-              `  \u2713  [${collectionConfig.collection}] ${identifier} \u2014 ok`,
-            );
+            console.log(`  \u2713  [${collectionConfig.collection}] ${identifier} \u2014 ok`);
           }
         }
       } catch (err) {
@@ -376,9 +372,7 @@ async function main(): Promise<void> {
   const start = Date.now();
 
   for (const collectionConfig of COLLECTION_CONFIGS) {
-    console.log(
-      `\uD83D\uDCE6 ${collectionConfig.label} (${collectionConfig.collection}):`,
-    );
+    console.log(`\uD83D\uDCE6 ${collectionConfig.label} (${collectionConfig.collection}):`);
     const beforeTotal = report.total;
     await checkCollection(payload, collectionConfig, report, options);
     const checked = report.total - beforeTotal;


### PR DESCRIPTION
Sets PAYLOAD_MIGRATING=true at the top of each integrity check script to prevent Drizzle from attempting schema ALTER against the target database during getPayload() init.