### PR TITLE
feat: standardize date-prefixed slugs for Posts and CdOfTheWeek

### DIFF
--- a/bin/integrity-check-slugs.test.ts
+++ b/bin/integrity-check-slugs.test.ts
@@ -5,12 +5,7 @@ import type { Payload } from 'payload';
 vi.mock('@payload-config', () => ({ default: {} }));
 vi.mock('payload', () => ({ getPayload: vi.fn() }));
 
-const {
-  generateNameSlug,
-  generatePostSlug,
-  generateMusicSlug,
-  generateCdOfTheWeekSlug,
-} = await import('./integrity-check-slugs');
+const { generateNameSlug, generatePostSlug, generateMusicSlug, generateCdOfTheWeekSlug } = await import('./integrity-check-slugs');
 
 // ---------------------------------------------------------------------------
 // generateNameSlug
@@ -47,37 +42,48 @@ describe('generateNameSlug', () => {
 // ---------------------------------------------------------------------------
 
 describe('generatePostSlug', () => {
-  it('slugifies plain text headline', () => {
-    expect(generatePostSlug('Hello World')).toBe('hello-world');
+  it('generates date-prefixed slug from headline and startDate', () => {
+    expect(generatePostSlug({ headline: 'Hello World', startDate: '2014-10-20T12:00:00Z' })).toBe(
+      '2014-10-20--hello-world',
+    );
   });
 
-  it('strips HTML tags', () => {
-    expect(generatePostSlug('<b>Bold</b> and <i>Italic</i>')).toBe('bold-and-italic');
+  it('strips HTML tags from headline', () => {
+    expect(
+      generatePostSlug({ headline: '<b>Bold</b> and <i>Italic</i>', startDate: '2025-06-15' }),
+    ).toBe('2025-06-15--bold-and-italic');
   });
 
-  it('strips nested HTML tags', () => {
-    expect(generatePostSlug('<p><a href="http://example.com">Link Text</a></p>'))
-      .toBe('link-text');
+  it('returns headline-only slug when no startDate', () => {
+    expect(generatePostSlug({ headline: 'No Date Post' })).toBe('no-date-post');
   });
 
-  it('handles special characters', () => {
-    expect(generatePostSlug("What's New in 2024!")).toBe('whats-new-in-2024');
+  it('returns null when no headline', () => {
+    expect(generatePostSlug({ startDate: '2025-01-01' })).toBeNull();
   });
 
-  it('collapses multiple hyphens', () => {
-    expect(generatePostSlug('Foo---Bar')).toBe('foo-bar');
+  it('returns null when headline is empty', () => {
+    expect(generatePostSlug({ headline: '' })).toBeNull();
   });
 
-  it('removes leading/trailing hyphens', () => {
-    expect(generatePostSlug('---Surrounded---')).toBe('surrounded');
+  it('returns null when headline produces empty slug', () => {
+    expect(generatePostSlug({ headline: '<br/><hr/>', startDate: '2025-01-01' })).toBeNull();
   });
 
-  it('handles empty string', () => {
-    expect(generatePostSlug('')).toBe('');
+  it('handles special characters in headline', () => {
+    expect(generatePostSlug({ headline: "What's New in 2024!", startDate: '2024-03-15' })).toBe(
+      '2024-03-15--whats-new-in-2024',
+    );
   });
 
-  it('handles only HTML tags', () => {
-    expect(generatePostSlug('<br/><hr/>')).toBe('');
+  it('preserves the double-hyphen separator between date and slug', () => {
+    const result = generatePostSlug({
+      headline: 'Courtney Barnett Radio Takeover',
+      startDate: '2014-10-20',
+    });
+    expect(result).toBe('2014-10-20--courtney-barnett-radio-takeover');
+    // Verify the -- separator is present
+    expect(result!.match(/^\d{4}-\d{2}-\d{2}--/)).toBeTruthy();
   });
 });
 
@@ -117,8 +123,7 @@ describe('generateMusicSlug', () => {
   });
 
   it('returns title-only slug when artist lookup fails', async () => {
-    (mockPayload.findByID as ReturnType<typeof vi.fn>)
-      .mockRejectedValue(new Error('not found'));
+    (mockPayload.findByID as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('not found'));
     const doc = { title: 'Solo Track', artist: 999 };
     const result = await generateMusicSlug(mockPayload, doc);
     expect(result).toBe('solo-track');
@@ -162,14 +167,14 @@ describe('generateCdOfTheWeekSlug', () => {
     vi.clearAllMocks();
   });
 
-  it('derives slug from associated record with populated artist', async () => {
+  it('generates date-prefixed slug from associated record', async () => {
     (mockPayload.findByID as ReturnType<typeof vi.fn>).mockResolvedValue({
       title: 'Album Title',
       artist: { name: 'Great Artist', id: 5 },
     });
-    const doc = { record: 10 };
+    const doc = { record: 10, date: '2026-01-15' };
     const result = await generateCdOfTheWeekSlug(mockPayload, doc);
-    expect(result).toBe('great-artist--album-title');
+    expect(result).toBe('2026-01-15--great-artist--album-title');
     expect(mockPayload.findByID).toHaveBeenCalledWith({
       collection: 'records',
       id: 10,
@@ -177,19 +182,24 @@ describe('generateCdOfTheWeekSlug', () => {
     });
   });
 
-  it('handles populated record object', async () => {
+  it('handles populated record object with date', async () => {
     (mockPayload.findByID as ReturnType<typeof vi.fn>).mockResolvedValue({
       title: 'Record Title',
       artist: { name: 'Some Band', id: 3 },
     });
-    const doc = { record: { id: 7 } };
+    const doc = { record: { id: 7 }, date: '2026-03-01' };
     const result = await generateCdOfTheWeekSlug(mockPayload, doc);
-    expect(result).toBe('some-band--record-title');
-    expect(mockPayload.findByID).toHaveBeenCalledWith({
-      collection: 'records',
-      id: 7,
-      depth: 1,
+    expect(result).toBe('2026-03-01--some-band--record-title');
+  });
+
+  it('returns record slug without date prefix when no date', async () => {
+    (mockPayload.findByID as ReturnType<typeof vi.fn>).mockResolvedValue({
+      title: 'Album',
+      artist: { name: 'Artist', id: 1 },
     });
+    const doc = { record: 5 };
+    const result = await generateCdOfTheWeekSlug(mockPayload, doc);
+    expect(result).toBe('artist--album');
   });
 
   it('returns null when record is missing', async () => {
@@ -199,8 +209,7 @@ describe('generateCdOfTheWeekSlug', () => {
   });
 
   it('returns null when record lookup fails', async () => {
-    (mockPayload.findByID as ReturnType<typeof vi.fn>)
-      .mockRejectedValue(new Error('not found'));
+    (mockPayload.findByID as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('not found'));
     const doc = { record: 999 };
     const result = await generateCdOfTheWeekSlug(mockPayload, doc);
     expect(result).toBeNull();

--- a/bin/integrity-check-slugs.ts
+++ b/bin/integrity-check-slugs.ts
@@ -16,7 +16,11 @@
 import { getPayload, type Payload } from 'payload';
 // eslint-disable-next-line import/no-cycle
 import config from '@payload-config';
-import { slugifyText } from '../payload/src/collections/hooks/musicSlugify';
+import {
+  slugifyText,
+  slugifyHeadline,
+  formatDatePrefix,
+} from '../payload/src/collections/hooks/slugUtils';
 import {
   parseArgs,
   emptyReport,
@@ -40,15 +44,17 @@ export function generateNameSlug(name: string): string {
   return slugifyText(name);
 }
 
-export function generatePostSlug(headline: string): string {
-  return headline
-    .replace(/<[^>]*>/g, '')
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-    .trim();
+export function generatePostSlug(doc: Record<string, unknown>): string | null {
+  const headline = doc.headline as string | undefined;
+  if (!headline) return null;
+  const headlineSlug = slugifyHeadline(headline);
+  if (!headlineSlug) return null;
+  const startDate = doc.startDate as string | undefined;
+  if (startDate) {
+    const datePrefix = formatDatePrefix(new Date(startDate));
+    return `${datePrefix}--${headlineSlug}`;
+  }
+  return headlineSlug;
 }
 
 export async function generateMusicSlug(
@@ -104,7 +110,17 @@ export async function generateCdOfTheWeekSlug(
       depth: 1,
     });
     if (!found) return null;
-    return await generateMusicSlug(payload, found as unknown as Record<string, unknown>);
+    const recordSlug = await generateMusicSlug(
+      payload,
+      found as unknown as Record<string, unknown>,
+    );
+    if (!recordSlug) return null;
+    const date = doc.date as string | undefined;
+    if (date) {
+      const datePrefix = formatDatePrefix(new Date(date));
+      return `${datePrefix}--${recordSlug}`;
+    }
+    return recordSlug;
   } catch {
     return null;
   }
@@ -155,7 +171,7 @@ const COLLECTION_CONFIGS: CollectionSlugConfig[] = [
     collection: 'posts',
     label: 'Posts',
     identifierField: 'headline',
-    generateSlug: (_p, doc) => generatePostSlug(doc.headline as string),
+    generateSlug: (_p, doc) => generatePostSlug(doc),
   },
 ];
 

--- a/bin/migrations/importMusic.ts
+++ b/bin/migrations/importMusic.ts
@@ -19,7 +19,7 @@ import { connectToDatabase } from './database';
 import { getPayloadClient, findOrCreateArtist } from './shared/payloadClient';
 import { createLogger, logProgress, logSummary } from './shared/logger';
 import type { PostgresTarget } from './shared/payloadClient';
-import { slugifyText, buildMusicSlug } from '../../payload/src/collections/hooks/musicSlugify';
+import { slugifyText, buildMusicSlug } from '../../payload/src/collections/hooks/slugUtils';
 
 const logger = createLogger('MusicImport');
 

--- a/bin/migrations/importPosts.ts
+++ b/bin/migrations/importPosts.ts
@@ -17,7 +17,8 @@ import { createLogger, logProgress, logSummary } from './shared/logger';
 import { convertHtmlToLexical } from './shared/importUtils';
 import { convertHtmlToLexicalEnhanced } from './shared/enhancedHtmlToLexical';
 import { importImageFromUrl } from './shared/mediaImporter';
-import { slugify, cleanHeadline } from './shared/slugify';
+import { cleanHeadline } from './shared/slugify';
+import { slugifyHeadline, formatDatePrefix } from '../../payload/src/collections/hooks/slugUtils';
 import type { PostgresTarget } from './shared/payloadClient';
 
 const logger = createLogger('PostsImport');
@@ -187,13 +188,12 @@ async function importPost(payload: Payload, post: Post): Promise<'success' | 'sk
       slug = post.permalink;
     } else if (post.source === 'story') {
       // For stories, generate slug with date prefix: YYYY-MM-DD--headline
-      const date = new Date(post.start_date);
-      const datePrefix = date.toISOString().split('T')[0];
-      const headlineSlug = slugify(post.headline);
+      const datePrefix = formatDatePrefix(new Date(post.start_date));
+      const headlineSlug = slugifyHeadline(post.headline);
       slug = headlineSlug ? `${datePrefix}--${headlineSlug}` : `${datePrefix}--post-${post.id}`;
     } else {
       // Fallback for other cases — use legacy ID if headline can't be slugified
-      slug = slugify(post.headline) || `post-${post.id}`;
+      slug = slugifyHeadline(post.headline) || `post-${post.id}`;
     }
 
     // Create post record — retry with legacyId-suffixed slug on unique constraint violation

--- a/bin/migrations/shared/slugify.ts
+++ b/bin/migrations/shared/slugify.ts
@@ -1,19 +1,10 @@
 /**
  * Generate a URL-friendly slug from text
  * Removes HTML tags, special characters, and normalizes whitespace
+ *
+ * @deprecated Use slugifyHeadline from payload/src/collections/hooks/slugUtils instead
  */
-export function slugify(text: string): string {
-  if (!text) return '';
-
-  return text
-    .replace(/<[^>]*>/g, '') // Remove HTML tags like <br>, <font>, etc.
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, '') // Remove special chars except hyphens
-    .replace(/\s+/g, '-') // Replace spaces with hyphens
-    .replace(/-+/g, '-') // Replace multiple hyphens with single
-    .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
-    .trim();
-}
+export { slugifyHeadline as slugify } from '../../../payload/src/collections/hooks/slugUtils';
 
 /**
  * Clean HTML tags from headline text

--- a/bin/regenerate-slugs.test.ts
+++ b/bin/regenerate-slugs.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import type { Payload } from 'payload';
-import { slugifyText } from '../payload/src/collections/hooks/musicSlugify';
+import { slugifyText } from '../payload/src/collections/hooks/slugUtils';
 
 // Mock modules – vitest hoists vi.mock calls above imports automatically
 vi.mock('./migrations/shared/payloadClient', () => ({
   getPayloadClient: vi.fn(),
 }));
 
-vi.mock('../payload/src/collections/hooks/musicSlugify', () => ({
+vi.mock('../payload/src/collections/hooks/slugUtils', () => ({
   slugifyText: (text: string) => text
     .toLowerCase()
     .replace(/[^\w\s-]+/g, '')

--- a/bin/regenerate-slugs.ts
+++ b/bin/regenerate-slugs.ts
@@ -18,7 +18,7 @@
 
 import type { Payload } from 'payload';
 import { getPayloadClient, type PostgresTarget } from './migrations/shared/payloadClient';
-import { slugifyText } from '../payload/src/collections/hooks/musicSlugify';
+import { slugifyText } from '../payload/src/collections/hooks/slugUtils';
 
 /* eslint-disable no-console */
 

--- a/payload/src/collections/CdOfTheWeek.ts
+++ b/payload/src/collections/CdOfTheWeek.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
-import { setCdOfTheWeekSlugFromRecord } from './hooks/musicSlugify';
+import { setCdOfTheWeekSlugFromRecord } from './hooks/slugUtils';
 
 export const CdOfTheWeek: CollectionConfig = {
   slug: 'cdoftheweek',

--- a/payload/src/collections/Posts.ts
+++ b/payload/src/collections/Posts.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { EmbedFeature } from '../features/embed';
+import { slugifyHeadline, formatDatePrefix } from './hooks/slugUtils';
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
@@ -54,21 +55,18 @@ export const Posts: CollectionConfig = {
       index: true,
       admin: {
         position: 'sidebar',
-        description: 'URL-friendly slug (auto-generated from headline if not provided)',
+        description: 'URL-friendly slug (auto-generated as YYYY-MM-DD--headline)',
       },
       hooks: {
         beforeValidate: [
           ({ data, operation, value }) => {
-            // Auto-generate slug from headline if not provided or if creating new post
             if (operation === 'create' && !value && data?.headline) {
-              return data.headline
-                .replace(/<[^>]*>/g, '') // Remove HTML tags
-                .toLowerCase()
-                .replace(/[^\w\s-]/g, '') // Remove special chars except hyphens
-                .replace(/\s+/g, '-') // Replace spaces with hyphens
-                .replace(/-+/g, '-') // Replace multiple hyphens with single
-                .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
-                .trim();
+              const headlineSlug = slugifyHeadline(data.headline);
+              if (!headlineSlug) return value;
+              const dateStr = data.startDate
+                ? formatDatePrefix(new Date(data.startDate as string))
+                : '';
+              return dateStr ? `${dateStr}--${headlineSlug}` : headlineSlug;
             }
             return value;
           },
@@ -148,7 +146,8 @@ export const Posts: CollectionConfig = {
       defaultValue: true,
       admin: {
         position: 'sidebar',
-        description: 'Whether this post appears on the front page. Disable for standalone pages (e.g. custom text pages).',
+        description:
+          'Whether this post appears on the front page. Disable for standalone pages (e.g. custom text pages).',
       },
     },
     {

--- a/payload/src/collections/Records.ts
+++ b/payload/src/collections/Records.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { slugField } from 'payload';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { generateMusicDisplayName } from './hooks/displayNameHooks';
-import { musicSlugify } from './hooks/musicSlugify';
+import { musicSlugify } from './hooks/slugUtils';
 
 export const Records: CollectionConfig = {
   slug: 'records',

--- a/payload/src/collections/Songs.ts
+++ b/payload/src/collections/Songs.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { slugField } from 'payload';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { generateMusicDisplayName } from './hooks/displayNameHooks';
-import { musicSlugify } from './hooks/musicSlugify';
+import { musicSlugify } from './hooks/slugUtils';
 
 export const Songs: CollectionConfig = {
   slug: 'songs',

--- a/payload/src/collections/hooks/slugUtils.test.ts
+++ b/payload/src/collections/hooks/slugUtils.test.ts
@@ -1,14 +1,21 @@
 /**
- * Unit tests for music slug generation hooks
+ * Unit tests for slug generation hooks
  *
- * Tests the custom slug generation for Songs, Records, and CdOfTheWeek.
+ * Tests the custom slug generation for Songs, Records, Posts, and CdOfTheWeek.
  * - Songs/Records: "artist-name--title" format
- * - CdOfTheWeek: inherits slug from associated record
+ * - Posts: "YYYY-MM-DD--headline" format
+ * - CdOfTheWeek: "YYYY-MM-DD--record-slug" format
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Payload } from 'payload';
-import { slugifyText, musicSlugify, setCdOfTheWeekSlugFromRecord } from './musicSlugify';
+import {
+  slugifyText,
+  slugifyHeadline,
+  formatDatePrefix,
+  musicSlugify,
+  setCdOfTheWeekSlugFromRecord,
+} from './slugUtils';
 
 // Helper to create a mock request object
 const createMockReq = (payload: Partial<Payload>) => ({
@@ -26,6 +33,42 @@ describe('slugifyText', () => {
 
   it('should handle already slugified text', () => {
     expect(slugifyText('already-slug')).toBe('already-slug');
+  });
+});
+
+describe('slugifyHeadline', () => {
+  it('should strip HTML tags and slugify', () => {
+    expect(slugifyHeadline('Hello <br> World')).toBe('hello-world');
+  });
+
+  it('should strip nested HTML tags', () => {
+    expect(slugifyHeadline('<font color="red">Headline</font> Text')).toBe('headline-text');
+  });
+
+  it('should handle plain text the same as slugifyText', () => {
+    expect(slugifyHeadline('Simple Headline')).toBe('simple-headline');
+  });
+
+  it('should return empty string for HTML-only input', () => {
+    expect(slugifyHeadline('<br><br>')).toBe('');
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(slugifyHeadline('')).toBe('');
+  });
+});
+
+describe('formatDatePrefix', () => {
+  it('should format date as YYYY-MM-DD', () => {
+    expect(formatDatePrefix(new Date('2014-10-20T12:00:00Z'))).toBe('2014-10-20');
+  });
+
+  it('should handle midnight UTC dates', () => {
+    expect(formatDatePrefix(new Date('2026-01-01T00:00:00Z'))).toBe('2026-01-01');
+  });
+
+  it('should handle end-of-year dates', () => {
+    expect(formatDatePrefix(new Date('2025-12-31T23:59:59Z'))).toBe('2025-12-31');
   });
 });
 
@@ -154,33 +197,48 @@ describe('setCdOfTheWeekSlugFromRecord', () => {
     };
   });
 
-  it('should copy slug from associated record (ID)', async () => {
+  it('should generate date-prefixed slug from associated record (ID)', async () => {
     (mockPayload.findByID as ReturnType<typeof vi.fn>).mockResolvedValue({
       id: 10,
       slug: 'pink-floyd--the-dark-side-of-the-moon',
     });
 
     const result = await setCdOfTheWeekSlugFromRecord({
-      data: { record: 10, date: '2026-01-01' },
+      data: { record: 10, date: '2026-01-15' },
       req: createMockReq(mockPayload),
       operation: 'create',
     });
 
-    expect(result.slug).toBe('pink-floyd--the-dark-side-of-the-moon');
+    expect(result.slug).toBe('2026-01-15--pink-floyd--the-dark-side-of-the-moon');
     expect(mockPayload.findByID).toHaveBeenCalledWith({
       collection: 'records',
       id: 10,
     });
   });
 
-  it('should copy slug from populated record object', async () => {
+  it('should generate date-prefixed slug from populated record object', async () => {
     (mockPayload.findByID as ReturnType<typeof vi.fn>).mockResolvedValue({
       id: 10,
       slug: 'the-beatles--abbey-road',
     });
 
     const result = await setCdOfTheWeekSlugFromRecord({
-      data: { record: { id: 10 }, date: '2026-01-01' },
+      data: { record: { id: 10 }, date: '2026-03-01' },
+      req: createMockReq(mockPayload),
+      operation: 'create',
+    });
+
+    expect(result.slug).toBe('2026-03-01--the-beatles--abbey-road');
+  });
+
+  it('should use record slug without prefix when no date', async () => {
+    (mockPayload.findByID as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 10,
+      slug: 'the-beatles--abbey-road',
+    });
+
+    const result = await setCdOfTheWeekSlugFromRecord({
+      data: { record: 10 },
       req: createMockReq(mockPayload),
       operation: 'create',
     });

--- a/payload/src/collections/hooks/slugUtils.ts
+++ b/payload/src/collections/hooks/slugUtils.ts
@@ -11,6 +11,27 @@ export function slugifyText(text: string): string {
 }
 
 /**
+ * Format a Date as YYYY-MM-DD for use as a slug prefix.
+ */
+export function formatDatePrefix(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+/**
+ * Slugify a post headline, stripping HTML tags first.
+ */
+export function slugifyHeadline(headline: string): string {
+  return headline
+    .replace(/<[^>]*>/g, '')
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .trim();
+}
+
+/**
  * Resolve the artist name from data, handling both populated objects and IDs.
  */
 async function resolveArtistName(data: Record<string, unknown>, payload: Payload): Promise<string> {
@@ -23,9 +44,10 @@ async function resolveArtistName(data: Record<string, unknown>, payload: Payload
   }
 
   // Look up artist by ID
-  const artistId = typeof artist === 'object' && artist !== null && 'id' in artist
-    ? (artist as { id: unknown }).id
-    : artist;
+  let artistId = artist;
+  if (typeof artist === 'object' && artist !== null && 'id' in artist) {
+    artistId = (artist as { id: unknown }).id;
+  }
   try {
     const found = await payload.findByID({
       collection: 'artists',
@@ -86,9 +108,7 @@ export const musicSlugify: Slugify = ({ data, req, valueToSlugify }) => {
   }
 
   // Artist is an ID — need async DB lookup, returns a Promise
-  return resolveArtistName(data, req.payload).then(
-    (artistName) => buildMusicSlug(artistName, titleSlug),
-  );
+  return resolveArtistName(data, req.payload).then((name) => buildMusicSlug(name, titleSlug));
 };
 
 export const setCdOfTheWeekSlugFromRecord: CollectionBeforeChangeHook = async ({ data, req }) => {
@@ -96,9 +116,10 @@ export const setCdOfTheWeekSlugFromRecord: CollectionBeforeChangeHook = async ({
 
   if (!updatedData.record) return updatedData;
 
-  const recordId = typeof updatedData.record === 'object'
-    ? (updatedData.record as { id: unknown }).id
-    : updatedData.record;
+  let recordId = updatedData.record;
+  if (typeof updatedData.record === 'object') {
+    recordId = (updatedData.record as { id: unknown }).id;
+  }
 
   try {
     const record = await req.payload.findByID({
@@ -107,7 +128,10 @@ export const setCdOfTheWeekSlugFromRecord: CollectionBeforeChangeHook = async ({
     });
 
     if (record?.slug) {
-      updatedData.slug = record.slug;
+      const dateStr = updatedData.date
+        ? formatDatePrefix(new Date(updatedData.date as string))
+        : '';
+      updatedData.slug = dateStr ? `${dateStr}--${record.slug}` : record.slug;
     }
   } catch {
     // Silently handle errors - slug will remain unchanged


### PR DESCRIPTION
## Changes
- Consolidate slug utils: rename `musicSlugify.ts` → `slugUtils.ts`
- Add `formatDatePrefix()` and `slugifyHeadline()` to shared slugUtils
- Posts: generate `YYYY-MM-DD--headline` slugs (matching import format)
- CdOfTheWeek: generate `YYYY-MM-DD--record-slug` format
- Update integrity check to expect date-prefixed slugs
- `bin/migrations/shared/slugify.ts` now re-exports from canonical source
- All 13 affected files updated to import from `slugUtils`

## Testing
- [x] 67 slug-related tests pass (25 slugUtils + 27 integrity + 15 regenerate)
- [x] Full suite: 1472 tests pass, 0 failures
- [x] Lint passes with 0 warnings