### PR TITLE
Fix bracket dark mode: replace hardcoded colors with theme variables

### DIFF
--- a/payload/src/features/mrm-bracket/BracketTree.css
+++ b/payload/src/features/mrm-bracket/BracketTree.css
@@ -42,11 +42,11 @@
   display: block;
   width: 120px;
   height: 40px;
-  border: 1px solid #333;
+  border: 1px solid var(--theme-border-color, #333);
   font-size: 10px;
   margin: 0 0 12px 0;
   text-decoration: none;
-  color: inherit;
+  color: var(--theme-text, inherit);
   overflow: hidden;
   cursor: pointer;
   transition: box-shadow 0.15s;
@@ -101,25 +101,25 @@
 }
 
 .bracket-tree__loser {
-  color: grey;
+  opacity: 0.5;
 }
 
 /* Live match */
 .bracket-tree__cell--live {
-  background: black !important;
-  color: white;
+  background: var(--theme-text, black) !important;
+  color: var(--theme-bg, white);
 }
 
-/* Left regions: gradient left→right, rounded right side */
+/* Left regions: subtle elevation, rounded right side */
 .bracket-tree__region--left .bracket-tree__cell {
-  background: linear-gradient(to right, #fafbfb, #eaebeb);
+  background: var(--theme-elevation-100, #eaebeb);
   border-width: 1px 1px 1px 0;
   border-radius: 0 5px 5px 0;
 }
 
-/* Right regions: gradient right→left, rounded left side */
+/* Right regions: subtle elevation, rounded left side */
 .bracket-tree__region--right .bracket-tree__cell {
-  background: linear-gradient(to left, #fafbfb, #eaebeb);
+  background: var(--theme-elevation-100, #eaebeb);
   border-width: 1px 0 1px 1px;
   border-radius: 5px 0 0 5px;
 }
@@ -195,12 +195,12 @@
 /* -- Round 3 (Swell 16) with connector lines -- */
 .bracket-tree__region .bracket-tree__round--3 .bracket-tree__cell {
   margin: 0 0 175px 0;
-  border: 1px solid #333;
+  border: 1px solid var(--theme-border-color, #333);
 }
 
 /* Left connector lines */
 .bracket-tree__region--left .bracket-tree__round--3 {
-  border-right: 1px solid #ccc;
+  border-right: 1px solid var(--theme-border-color, #ccc);
   height: 255px;
   left: 230px;
   position: absolute;
@@ -210,7 +210,7 @@
 
 /* Right connector lines */
 .bracket-tree__region--right .bracket-tree__round--3 {
-  border-right: 1px solid #ccc;
+  border-right: 1px solid var(--theme-border-color, #ccc);
   height: 232px;
   left: -230px;
   margin: 43px 0 0 0;
@@ -233,7 +233,7 @@
 }
 
 .bracket-tree__region .bracket-tree__round--4 .bracket-tree__cell {
-  border: 1px solid #333;
+  border: 1px solid var(--theme-border-color, #333);
 }
 
 /* ------------------------------------------------------------------ */
@@ -246,8 +246,8 @@
   left: 252px;
   top: 424px;
   width: 425px;
-  background: linear-gradient(to right, #666, black 50%, #666);
-  border: 1px solid black;
+  background: var(--theme-elevation-150, #333);
+  border: 1px solid var(--theme-border-color, #444);
   border-radius: 5px;
   height: 100px;
   overflow: hidden;
@@ -258,7 +258,7 @@
   border-width: 1px 0 1px 1px !important;
   border-radius: 5px 0 0 5px !important;
   background: transparent !important;
-  color: white;
+  color: var(--theme-text, white);
   float: left;
   left: 20px;
   margin: 30px 0 0 0 !important;
@@ -270,7 +270,7 @@
   border-width: 1px 1px 1px 0 !important;
   border-radius: 0 5px 5px 0 !important;
   background: transparent !important;
-  color: white;
+  color: var(--theme-text, white);
   float: right;
   margin: 30px 0 0 0 !important;
   position: relative;
@@ -279,10 +279,10 @@
 
 /* Championship final */
 .bracket-tree__final {
-  background: linear-gradient(to right, #eaebeb, #fafbfb 50%, #eaebeb) !important;
-  border: 1px solid #333 !important;
+  background: var(--theme-elevation-200, #eaebeb) !important;
+  border: 1px solid var(--theme-border-color, #333) !important;
   border-radius: 5px !important;
-  color: black;
+  color: var(--theme-text, black);
   float: left;
   height: 58px;
   font-size: 12px;


### PR DESCRIPTION
## Changes
- Replace all hardcoded color values in BracketTree.css with Payload `--theme-*` CSS custom properties
- Bracket cells, borders, connector lines, championship section, and final card all now adapt to dark/light admin theme

## Testing
- [x] Lint passes
- [x] Visual inspection in dark mode admin