### PR TITLE
Fix Payload admin URLs defaulting to localhost in production

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -104,6 +104,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-dev_postgres_password_not_secret}
       - POSTGRES_SSL_MODE=disable
       - USE_POSTGRES_SCHEDULE=false
+      # Payload admin links (browser-accessible URL)
+      - PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000
       # Auth0 dummy config
       - AUTH0_DOMAIN=test.auth0.com
       - AUTH0_CLIENT_ID=test-client-id

--- a/src/functions/payload_fns.php
+++ b/src/functions/payload_fns.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../lib/Database.php';
  * Return the Payload admin base URL (no trailing slash), e.g. "http://localhost:3000/admin".
  */
 function get_payload_admin_url(): string {
-    $base = $_ENV['PAYLOAD_PUBLIC_SERVER_URL'] ?? getenv('PAYLOAD_PUBLIC_SERVER_URL') ?: 'http://localhost:3000';
+    $base = $_ENV['PAYLOAD_PUBLIC_SERVER_URL'] ?? getenv('PAYLOAD_PUBLIC_SERVER_URL') ?: 'https://ynotradio-admin.netlify.app';
     return rtrim($base, '/') . '/admin';
 }
 


### PR DESCRIPTION
## Changes

- Changed `get_payload_admin_url()` fallback from `http://localhost:3000` to `https://ynotradio-admin.netlify.app`
- Added `PAYLOAD_PUBLIC_SERVER_URL` to phpfpm env in `docker-compose.e2e.yml` so e2e tests still use localhost

Local dev unaffected — `.env.local` already sets `PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000`.

Also added the var to `.env.php` locally (not tracked) so next `bin/deploy.sh` will push it to production.

Fixes cross-links added in #414.

## Verification

- [x] `yarn lint` — no PHP files linted, no changes to lintable code
- [x] Confirmed `.env.local` overrides default for local dev
- [x] Confirmed `docker-compose.e2e.yml` sets explicit value for e2e