### PR TITLE
feat: add PostgresAd read model with feature flag support

### DIFF
--- a/src/config/features.php
+++ b/src/config/features.php
@@ -3,6 +3,7 @@
 return [
     'use_new_cd_of_the_week' => false,
     'use_new_ads' => false,
+    'use_postgres_ads' => false,
     'use_postgres_concerts' => false,
     'use_postgres_ondemand' => false,
     'use_postgres_deejays' => false,

--- a/src/models/AdFactory.php
+++ b/src/models/AdFactory.php
@@ -2,13 +2,28 @@
 
 namespace YNotRadio\Models;
 
+require_once __DIR__ . '/FeatureManager.php';
 require_once __DIR__ . '/Ad.php';
 require_once __DIR__ . '/implementations/SqlAd.php';
+require_once __DIR__ . '/implementations/PostgresAd.php';
+require_once __DIR__ . '/../lib/Database.php';
 
+use YNotRadio\Models\FeatureManager;
 use YNotRadio\Models\Implementations\SqlAd;
+use YNotRadio\Models\Implementations\PostgresAd;
+use YNotRadio\Lib\Database;
 
 class AdFactory {
     public static function create($db) {
+        if (FeatureManager::isEnabled('use_postgres_ads')) {
+            try {
+                $pgDb = Database::getPostgres();
+                return new PostgresAd($pgDb);
+            } catch (\PDOException $e) {
+                error_log("PostgreSQL connection failed for ads, falling back to MySQL: " . $e->getMessage());
+                return new SqlAd($db);
+            }
+        }
         return new SqlAd($db);
     }
 } 

--- a/src/models/implementations/PostgresAd.php
+++ b/src/models/implementations/PostgresAd.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace YNotRadio\Models\Implementations;
+
+use YNotRadio\Models\Ad;
+use PDO;
+use PDOException;
+
+/**
+ * PostgreSQL implementation of the Ad model
+ * Reads from Neon PostgreSQL database created by Payload CMS
+ */
+class PostgresAd implements Ad {
+    private PDO $db;
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+    }
+
+    /**
+     * Get the Cloudinary base URL for constructing image URLs
+     * @return string The Cloudinary base URL
+     */
+    private function getCloudinaryBaseUrl(): string {
+        $cloudName = getenv('CLOUDINARY_CLOUD_NAME');
+        if (!$cloudName) {
+            error_log('PostgresAd: CLOUDINARY_CLOUD_NAME environment variable not set');
+            return '';
+        }
+        return "https://res.cloudinary.com/{$cloudName}/image/upload";
+    }
+
+    /**
+     * Build SQL CASE expression for pic_url with Cloudinary transformations
+     * @return string The SQL CASE expression
+     */
+    private function buildPicUrlCase(): string {
+        $cloudinaryBase = $this->getCloudinaryBaseUrl();
+        $transformations = 'c_fill,w_300,h_250,q_auto,f_auto';
+
+        return "CASE 
+            WHEN m.filename IS NOT NULL AND m.filename != '' 
+            THEN '{$cloudinaryBase}/{$transformations}/' || m.filename
+            ELSE COALESCE(a.image_url, '')
+        END as pic_url";
+    }
+
+    /**
+     * Get a specific ad by ID (regardless of status)
+     *
+     * @param int $id The ID of the ad to retrieve
+     * @return array|null The ad data or null if not found
+     */
+    public function getById(int $id): ?array {
+        $picUrlCase = $this->buildPicUrlCase();
+
+        $stmt = $this->db->prepare("
+            SELECT 
+                a.id,
+                a.name,
+                a.start_date,
+                a.end_date,
+                {$picUrlCase},
+                a.web_url,
+                a.priority,
+                CASE WHEN a._status = 'published' THEN 'n' ELSE 'y' END as deleted
+            FROM ads a
+            LEFT JOIN media m ON a.image_id = m.id
+            WHERE a.id = :id
+        ");
+
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+
+        if (!$result) {
+            return null;
+        }
+
+        return $this->formatRow($result);
+    }
+
+    /**
+     * Get all published ads, ordered by priority
+     *
+     * @param int $limit Optional limit on number of results
+     * @return array Array of ad entries
+     */
+    public function getAll(int $limit = 64): array {
+        $picUrlCase = $this->buildPicUrlCase();
+
+        $stmt = $this->db->prepare("
+            SELECT 
+                a.id,
+                a.name,
+                a.start_date,
+                a.end_date,
+                {$picUrlCase},
+                a.web_url,
+                a.priority,
+                'n' as deleted
+            FROM ads a
+            LEFT JOIN media m ON a.image_id = m.id
+            WHERE a._status = 'published'
+            ORDER BY a.priority ASC
+            LIMIT :limit
+        ");
+
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $this->formatResults($stmt->fetchAll());
+    }
+
+    /**
+     * Get currently active ads (published, within date range)
+     *
+     * @return array Array of currently running ad entries
+     */
+    public function getCurrent(): array {
+        $picUrlCase = $this->buildPicUrlCase();
+
+        $stmt = $this->db->prepare("
+            SELECT 
+                a.id,
+                a.name,
+                a.start_date,
+                a.end_date,
+                {$picUrlCase},
+                a.web_url,
+                a.priority,
+                'n' as deleted
+            FROM ads a
+            LEFT JOIN media m ON a.image_id = m.id
+            WHERE a._status = 'published'
+              AND a.start_date <= NOW()
+              AND a.end_date >= NOW()
+            ORDER BY a.priority ASC
+        ");
+
+        $stmt->execute();
+
+        return $this->formatResults($stmt->fetchAll());
+    }
+
+    /**
+     * Add a new ad
+     * Note: This is a read-only implementation for PostgreSQL
+     *
+     * @param array $data The ad data
+     * @return int The ID of the newly created entry
+     * @throws \RuntimeException Always throws exception
+     */
+    public function add(array $data): int {
+        throw new \RuntimeException(
+            'Write operations are not supported in the PostgreSQL read model. ' .
+            'Please use Payload CMS admin interface or API for creating ads.'
+        );
+    }
+
+    /**
+     * Update an existing ad
+     * Note: This is a read-only implementation for PostgreSQL
+     *
+     * @param int $id The ID of the ad to update
+     * @param array $data The updated ad data
+     * @return bool Whether the update was successful
+     * @throws \RuntimeException Always throws exception
+     */
+    public function update(int $id, array $data): bool {
+        throw new \RuntimeException(
+            'Write operations are not supported in the PostgreSQL read model. ' .
+            'Please use Payload CMS admin interface or API for updating ads.'
+        );
+    }
+
+    /**
+     * Delete an ad
+     * Note: This is a read-only implementation for PostgreSQL
+     *
+     * @param int $id The ID of the ad to delete
+     * @return bool Whether the deletion was successful
+     * @throws \RuntimeException Always throws exception
+     */
+    public function delete(int $id): bool {
+        throw new \RuntimeException(
+            'Write operations are not supported in the PostgreSQL read model. ' .
+            'Please use Payload CMS admin interface or API for deleting ads.'
+        );
+    }
+
+    /**
+     * Update the order/priority of an ad
+     * Note: This is a read-only implementation for PostgreSQL
+     *
+     * @param int $id The ID of the ad
+     * @param int $priority The new priority value
+     * @return bool Whether the update was successful
+     * @throws \RuntimeException Always throws exception
+     */
+    public function updateOrder(int $id, int $priority): bool {
+        throw new \RuntimeException(
+            'Write operations are not supported in the PostgreSQL read model. ' .
+            'Please use Payload CMS admin interface or API for updating ad order.'
+        );
+    }
+
+    /**
+     * Format PostgreSQL timestamp to MySQL date format (YYYY-MM-DD)
+     *
+     * @param string $timestamp PostgreSQL timestamp
+     * @return string MySQL date format
+     */
+    private function formatDate(string $timestamp): string {
+        $date = new \DateTime($timestamp);
+        return $date->format('Y-m-d');
+    }
+
+    /**
+     * Format a single row to match MySQL output format
+     *
+     * @param array $row Raw database row
+     * @return array Formatted row
+     */
+    private function formatRow(array $row): array {
+        $row['start_date'] = $this->formatDate($row['start_date']);
+        $row['end_date'] = $this->formatDate($row['end_date']);
+        return $row;
+    }
+
+    /**
+     * Format results array to match MySQL output format
+     *
+     * @param array $results Raw database results
+     * @return array Formatted results
+     */
+    private function formatResults(array $results): array {
+        return array_map(function ($row) {
+            return $this->formatRow($row);
+        }, $results);
+    }
+}

--- a/src/tests/Models/PostgresAdTest.php
+++ b/src/tests/Models/PostgresAdTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace YNotRadio\Tests\Models;
+
+use YNotRadio\Tests\TestCase;
+use YNotRadio\Models\Implementations\PostgresAd;
+use PDO;
+use PDOStatement;
+
+/**
+ * Tests for PostgresAd read-only operations
+ *
+ * Tests PostgreSQL ad operations using PDO:
+ * - getById: Retrieve ad by ID with field mapping
+ * - getAll: Retrieve published ads with limit
+ * - getCurrent: Retrieve active ads within date range
+ * - Write operations throw RuntimeException
+ */
+class PostgresAdTest extends TestCase
+{
+    private PostgresAd $ad;
+    private PDO $mockDb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb = $this->createMock(PDO::class);
+        $this->ad = new PostgresAd($this->mockDb);
+    }
+
+    /**
+     * Sample raw row as returned by the Postgres query
+     */
+    private function sampleRow(): array
+    {
+        return [
+            'id' => 1,
+            'name' => 'Test Ad',
+            'start_date' => '2025-01-01 00:00:00+00',
+            'end_date' => '2025-12-31 23:59:59+00',
+            'pic_url' => 'https://example.com/ad.jpg',
+            'web_url' => 'https://example.com',
+            'priority' => 5,
+            'deleted' => 'n',
+        ];
+    }
+
+    /**
+     * Test getById returns formatted ad when found
+     */
+    public function testGetByIdReturnsFormattedAd(): void
+    {
+        $raw = $this->sampleRow();
+
+        $mockStmt = $this->createMock(PDOStatement::class);
+        $mockStmt->expects($this->once())
+            ->method('execute')
+            ->with(['id' => 1])
+            ->willReturn(true);
+
+        $mockStmt->expects($this->once())
+            ->method('fetch')
+            ->willReturn($raw);
+
+        $this->mockDb->expects($this->once())
+            ->method('prepare')
+            ->willReturn($mockStmt);
+
+        $result = $this->ad->getById(1);
+
+        $this->assertIsArray($result);
+        $this->assertSame(1, $result['id']);
+        $this->assertSame('Test Ad', $result['name']);
+        $this->assertSame('2025-01-01', $result['start_date']);
+        $this->assertSame('2025-12-31', $result['end_date']);
+        $this->assertSame('https://example.com/ad.jpg', $result['pic_url']);
+        $this->assertSame('https://example.com', $result['web_url']);
+        $this->assertSame(5, $result['priority']);
+        $this->assertSame('n', $result['deleted']);
+    }
+
+    /**
+     * Test getById returns null when ad not found
+     */
+    public function testGetByIdReturnsNullWhenNotFound(): void
+    {
+        $mockStmt = $this->createMock(PDOStatement::class);
+        $mockStmt->expects($this->once())
+            ->method('execute')
+            ->willReturn(true);
+
+        $mockStmt->expects($this->once())
+            ->method('fetch')
+            ->willReturn(false);
+
+        $this->mockDb->expects($this->once())
+            ->method('prepare')
+            ->willReturn($mockStmt);
+
+        $result = $this->ad->getById(999);
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test getAll returns formatted ads with limit binding
+     */
+    public function testGetAllReturnsFormattedAds(): void
+    {
+        $rows = [
+            $this->sampleRow(),
+            array_merge($this->sampleRow(), [
+                'id' => 2,
+                'name' => 'Second Ad',
+                'priority' => 10,
+            ]),
+        ];
+
+        $mockStmt = $this->createMock(PDOStatement::class);
+        $mockStmt->expects($this->once())
+            ->method('bindValue')
+            ->with(':limit', 20, PDO::PARAM_INT);
+
+        $mockStmt->expects($this->once())
+            ->method('execute')
+            ->willReturn(true);
+
+        $mockStmt->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn($rows);
+
+        $this->mockDb->expects($this->once())
+            ->method('prepare')
+            ->willReturn($mockStmt);
+
+        $results = $this->ad->getAll(20);
+
+        $this->assertCount(2, $results);
+        $this->assertSame('2025-01-01', $results[0]['start_date']);
+        $this->assertSame('2025-12-31', $results[0]['end_date']);
+        $this->assertSame('Second Ad', $results[1]['name']);
+    }
+
+    /**
+     * Test getCurrent returns active ads filtered by date
+     */
+    public function testGetCurrentReturnsActiveAds(): void
+    {
+        $rows = [$this->sampleRow()];
+
+        $mockStmt = $this->createMock(PDOStatement::class);
+        $mockStmt->expects($this->once())
+            ->method('execute')
+            ->willReturn(true);
+
+        $mockStmt->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn($rows);
+
+        $this->mockDb->expects($this->once())
+            ->method('prepare')
+            ->with($this->callback(function (string $sql) {
+                return str_contains($sql, "a._status = 'published'")
+                    && str_contains($sql, 'a.start_date <= NOW()')
+                    && str_contains($sql, 'a.end_date >= NOW()');
+            }))
+            ->willReturn($mockStmt);
+
+        $results = $this->ad->getCurrent();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('2025-01-01', $results[0]['start_date']);
+    }
+
+    /**
+     * Test add throws RuntimeException
+     */
+    public function testAddThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Write operations are not supported');
+        $this->ad->add(['name' => 'test']);
+    }
+
+    /**
+     * Test update throws RuntimeException
+     */
+    public function testUpdateThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Write operations are not supported');
+        $this->ad->update(1, ['name' => 'test']);
+    }
+
+    /**
+     * Test delete throws RuntimeException
+     */
+    public function testDeleteThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Write operations are not supported');
+        $this->ad->delete(1);
+    }
+
+    /**
+     * Test updateOrder throws RuntimeException
+     */
+    public function testUpdateOrderThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Write operations are not supported');
+        $this->ad->updateOrder(1, 5);
+    }
+}


### PR DESCRIPTION
## Changes
- Added `src/models/implementations/PostgresAd.php` — read-only PDO model with Cloudinary image URL construction
- Updated `src/models/AdFactory.php` — checks `use_postgres_ads` feature flag with MySQL fallback
- Added `use_postgres_ads => false` to `src/config/features.php` (no existing flags changed)
- Added `src/tests/Models/PostgresAdTest.php` — 8 PHPUnit tests

## Testing
- [x] All 8 PHP tests passing
- [x] No feature flags changed — new flag defaults to false