### PR TITLE
Fix front page showing deleted MySQL stories from Postgres

### DIFF
--- a/bin/migrations/importPosts.test.ts
+++ b/bin/migrations/importPosts.test.ts
@@ -314,6 +314,91 @@ describe('importPosts', () => {
       });
     });
 
+    it('should set showOnFrontPage=true for non-deleted stories', async () => {
+      const { importPost } = await import('./importPosts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-id-123' });
+
+      const post: Post = {
+        id: 1,
+        headline: 'Active Story',
+        start_date: '2024-01-01',
+        end_date: '2024-12-31',
+        content: '<p>content</p>',
+        image_url: '',
+        priority: 0,
+        deleted: 'n',
+        source: 'story',
+      };
+
+      await importPost(mockPayload as Payload, post);
+
+      expect(mockPayload.create).toHaveBeenCalledWith({
+        collection: 'posts',
+        data: expect.objectContaining({
+          showOnFrontPage: true,
+        }),
+      });
+    });
+
+    it('should set showOnFrontPage=false for deleted stories', async () => {
+      const { importPost } = await import('./importPosts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-id-123' });
+
+      const post: Post = {
+        id: 1,
+        headline: 'Deleted Story',
+        start_date: '2024-01-01',
+        end_date: '2024-12-31',
+        content: '<p>content</p>',
+        image_url: '',
+        priority: 0,
+        deleted: 'y',
+        source: 'story',
+      };
+
+      await importPost(mockPayload as Payload, post);
+
+      expect(mockPayload.create).toHaveBeenCalledWith({
+        collection: 'posts',
+        data: expect.objectContaining({
+          showOnFrontPage: false,
+          _status: 'published',
+        }),
+      });
+    });
+
+    it('should set showOnFrontPage=false for uppercase-deleted stories', async () => {
+      const { importPost } = await import('./importPosts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-id-123' });
+
+      const post: Post = {
+        id: 1,
+        headline: 'Deleted Story',
+        start_date: '2024-01-01',
+        end_date: '2024-12-31',
+        content: '<p>content</p>',
+        image_url: '',
+        priority: 0,
+        deleted: 'Y',
+        source: 'story',
+      };
+
+      await importPost(mockPayload as Payload, post);
+
+      expect(mockPayload.create).toHaveBeenCalledWith({
+        collection: 'posts',
+        data: expect.objectContaining({
+          showOnFrontPage: false,
+        }),
+      });
+    });
+
     it('should handle HTML in headline for slug generation', async () => {
       const { importPost } = await import('./importPosts');
 
@@ -621,6 +706,129 @@ describe('importPosts', () => {
 
       expect(stats.errors).toBe(1);
       expect(stats.refreshed).toBe(0);
+    });
+  });
+
+  describe('syncDeletedFromFrontPage', () => {
+    it('should remove posts not active in MySQL from Postgres front page', async () => {
+      const { syncDeletedFromFrontPage } = await import('./importPosts');
+
+      mockPayload.update = vi.fn().mockResolvedValue({});
+      // Front-page posts: legacyIds 10, 20, 30
+      (mockPayload.find as Mock).mockResolvedValueOnce({
+        docs: [
+          { id: 'pg-1', legacyId: 10 },
+          { id: 'pg-2', legacyId: 20 },
+          { id: 'pg-3', legacyId: 30 },
+        ],
+        hasNextPage: false,
+      });
+
+      const mockMysql = {
+        // Only legacyId 10 is active in MySQL (20, 30 are missing/deleted)
+        query: vi.fn().mockResolvedValue([[{ id: 10 }]]),
+      };
+
+      const stats = await syncDeletedFromFrontPage(mockMysql, mockPayload as Payload);
+
+      expect(stats.fixed).toBe(2);
+      expect(mockPayload.update).toHaveBeenCalledWith({
+        collection: 'posts',
+        id: 'pg-2',
+        data: { showOnFrontPage: false },
+      });
+      expect(mockPayload.update).toHaveBeenCalledWith({
+        collection: 'posts',
+        id: 'pg-3',
+        data: { showOnFrontPage: false },
+      });
+    });
+
+    it('should do nothing when no front-page posts exist', async () => {
+      const { syncDeletedFromFrontPage } = await import('./importPosts');
+
+      (mockPayload.find as Mock).mockResolvedValueOnce({
+        docs: [],
+        hasNextPage: false,
+      });
+
+      const mockMysql = { query: vi.fn() };
+
+      const stats = await syncDeletedFromFrontPage(mockMysql, mockPayload as Payload);
+
+      expect(stats.fixed).toBe(0);
+      expect(mockMysql.query).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when all stories are active in MySQL', async () => {
+      const { syncDeletedFromFrontPage } = await import('./importPosts');
+
+      (mockPayload.find as Mock).mockResolvedValueOnce({
+        docs: [{ id: 'pg-1', legacyId: 10 }],
+        hasNextPage: false,
+      });
+
+      const mockMysql = {
+        // legacyId 10 is active
+        query: vi.fn().mockResolvedValue([[{ id: 10 }]]),
+      };
+
+      const stats = await syncDeletedFromFrontPage(mockMysql, mockPayload as Payload);
+
+      expect(stats.fixed).toBe(0);
+    });
+
+    it('should paginate through all front-page posts', async () => {
+      const { syncDeletedFromFrontPage } = await import('./importPosts');
+
+      mockPayload.update = vi.fn().mockResolvedValue({});
+      // Page 1
+      (mockPayload.find as Mock).mockResolvedValueOnce({
+        docs: [{ id: 'pg-1', legacyId: 10 }],
+        hasNextPage: true,
+      });
+      // Page 2
+      (mockPayload.find as Mock).mockResolvedValueOnce({
+        docs: [{ id: 'pg-2', legacyId: 20 }],
+        hasNextPage: false,
+      });
+
+      const mockMysql = {
+        // Neither is active in MySQL
+        query: vi.fn().mockResolvedValue([[]]),
+      };
+
+      const stats = await syncDeletedFromFrontPage(mockMysql, mockPayload as Payload);
+
+      expect(stats.fixed).toBe(2);
+      expect(mockPayload.find).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle custom texts with offset IDs (>= 10000)', async () => {
+      const { syncDeletedFromFrontPage } = await import('./importPosts');
+
+      mockPayload.update = vi.fn().mockResolvedValue({});
+      (mockPayload.find as Mock).mockResolvedValueOnce({
+        docs: [
+          { id: 'pg-1', legacyId: 788 },   // real story
+          { id: 'pg-2', legacyId: 10001 },  // custom text (offset ID)
+        ],
+        hasNextPage: false,
+      });
+
+      const mockMysql = {
+        // Only legacyId 788 exists in stories table; 10001 doesn't exist
+        query: vi.fn().mockResolvedValue([[{ id: 788 }]]),
+      };
+
+      const stats = await syncDeletedFromFrontPage(mockMysql, mockPayload as Payload);
+
+      expect(stats.fixed).toBe(1);
+      expect(mockPayload.update).toHaveBeenCalledWith({
+        collection: 'posts',
+        id: 'pg-2',
+        data: { showOnFrontPage: false },
+      });
     });
   });
 });

--- a/bin/migrations/importPosts.ts
+++ b/bin/migrations/importPosts.ts
@@ -225,6 +225,89 @@ async function syncActiveStories(
 }
 
 /**
+ * Sync front-page visibility: ensures only stories that are currently active
+ * and non-deleted in MySQL have showOnFrontPage=true in Postgres.
+ *
+ * Catches: soft-deleted stories, hard-deleted stories (no longer in MySQL),
+ * and custom texts that were incorrectly imported with showOnFrontPage=true.
+ */
+async function syncDeletedFromFrontPage(
+  mysqlConnection: any,
+  payload: Payload,
+): Promise<{ fixed: number }> {
+  const stats = { fixed: 0 };
+
+  // Paginate through all Postgres posts that are on the front page with a legacyId
+  const allFrontPagePosts: { pgId: string; legacyId: number }[] = [];
+  let page = 1;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await payload.find({
+      collection: 'posts',
+      where: {
+        showOnFrontPage: { equals: true },
+        legacyId: { exists: true },
+      },
+      limit: 100,
+      page,
+    });
+
+    for (const doc of result.docs as any[]) {
+      if (doc.legacyId) {
+        allFrontPagePosts.push({ pgId: doc.id, legacyId: doc.legacyId });
+      }
+    }
+
+    if (!result.hasNextPage) break;
+    page += 1;
+  }
+
+  if (allFrontPagePosts.length === 0) return stats;
+
+  logger.info(
+    `[sync-deleted] Checking ${allFrontPagePosts.length} front-page posts against MySQL`,
+  );
+
+  // Batch-query MySQL for which legacy IDs are active (non-deleted) stories
+  const legacyIds = allFrontPagePosts.map((r) => r.legacyId);
+  const [activeRows] = await mysqlConnection.query(
+    "SELECT id FROM stories WHERE id IN (?) AND deleted = 'n'",
+    [legacyIds],
+  );
+
+  const activeSet = new Set((activeRows as any[]).map((r: any) => r.id));
+
+  // Any front-page post NOT in the active MySQL set should be removed
+  const toFix = allFrontPagePosts.filter(({ legacyId }) => !activeSet.has(legacyId));
+
+  if (toFix.length === 0) {
+    logger.info('[sync-deleted] All front-page posts are active in MySQL');
+    return stats;
+  }
+
+  logger.info(
+    `[sync-deleted] ${toFix.length} posts to remove from front page (not active in MySQL)`,
+  );
+
+  for (const { pgId, legacyId } of toFix) {
+    try {
+      await payload.update({
+        collection: 'posts',
+        id: pgId,
+        data: { showOnFrontPage: false },
+      });
+      stats.fixed += 1;
+      logger.info(`[sync-deleted] ✓ Post legacyId=${legacyId} removed from front page`);
+    } catch (error) {
+      logger.error(`[sync-deleted] ✗ Post legacyId=${legacyId} update failed`, error as Error);
+    }
+  }
+
+  return stats;
+}
+
+/**
  * Check if a post with the given legacy ID already exists
  */
 async function postExists(payload: Payload, legacyId: number): Promise<boolean> {
@@ -350,7 +433,8 @@ async function importPost(payload: Payload, post: Post): Promise<'success' | 'sk
       imageUrl: post.image_url, // Store original image URL as fallback
       linkUrl: post.link_url, // Store link URL for story image click target
       priority: post.priority || 0,
-      showOnFrontPage: post.source === 'story', // Stories appear on front page, custom texts don't
+      showOnFrontPage: post.source === 'story'
+        && post.deleted?.toLowerCase() !== 'y', // Deleted stories stay published but off front page
       legacyId: post.id,
       migratedAt: new Date().toISOString(),
       _status: 'published' as const, // Set status to published so posts are immediately visible
@@ -420,6 +504,10 @@ async function importPosts(options: ImportOptions): Promise<void> {
       logger.info(
         `[sync-active] Done: ${syncStats.refreshed} refreshed, ${syncStats.unchanged} unchanged, ${syncStats.errors} errors`,
       );
+
+      // Phase 1b: remove deleted MySQL stories from the Postgres front page
+      const deletedStats = await syncDeletedFromFrontPage(mysqlConnection, payload);
+      logger.info(`[sync-deleted] Done: ${deletedStats.fixed} removed from front page`);
     }
 
     // Phase 2: import new records (standard flow)
@@ -488,5 +576,5 @@ if (isMainModule()) {
 }
 
 export {
-  importPosts, parseArgs, importPost, storyHash, syncActiveStories,
+  importPosts, parseArgs, importPost, storyHash, syncActiveStories, syncDeletedFromFrontPage,
 };


### PR DESCRIPTION
## Changes

- Fix `importPost()` to set `showOnFrontPage: false` for deleted MySQL stories
- Add `syncDeletedFromFrontPage()`: queries active MySQL stories and removes anything NOT in that set from the Postgres front page
- Wired into `--sync-active` flow as "Phase 1b" (runs before story refresh)
- 8 new tests (35 total, all passing)

## Root Cause

The nightly import unconditionally set `showOnFrontPage: true` for all stories, including deleted ones. Over time, hundreds of inactive stories accumulated on the front page.

## Verification

Ran against prod MySQL → prod Neon:
- 168 posts removed from front page
- localhost:8080 and ynotradio.net now show identical 9 posts

```
=== localhost:8080 ===              === ynotradio.net ===
CD of The Week                      CD of The Week
Follow Y-Not Radio on MixCloud      Follow Y-Not Radio on MixCloud
Modern Rock Madness                 Modern Rock Madness
Rodney Anonymous Tells You How..    Rodney Anonymous Tells You How..
Support Y-Not Radio                 Support Y-Not Radio
Win Luna Tickets                    Win Luna Tickets
Words With Nerds                    Words With Nerds
Y-Not On Demand                     Y-Not On Demand
Yumi Zouma Y-Not Radio Takeover    Yumi Zouma Y-Not Radio Takeover
```

- [x] `yarn test` — 35/35 passing
- [x] `yarn lint` — exits 0
- [x] Parity verified against production
