### PR TITLE
Fix legacy header regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ If you prefer local development:
 
 - Clone this repository to your local machine: `git clone git@github.com:ynotradio/site.git`
 - In your terminal, `cd` to the root of this project directory
-- Copy `.env.example` to `.env.local` and configure the environment variables:
+- Copy `.env.example` to `.env.local` and configure the environment variables for Payload/Next.js:
   ```
   cp .env.example .env.local
   ```
+- The legacy PHP Docker service now gets its local-safe defaults from `docker-compose.yml`, so `yarn test:e2e` can rewrite `.env.local` for Payload/Next.js without breaking `http://localhost:8080`.
 - Replace `/src/db/docker/ynot_db.sql` with the latest copy of the YNotRadio.net MySQL database.
 - Run `docker-compose up` to build the Docker images and run the [Apache, PHP and MySQL](https://docs.bitnami.com/containers/how-to/create-amp-environment-containers/) services
 - Once the installation is finished, a site will be available for you to visit at: [http://localhost:8080](http://localhost:8080)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,16 @@ services:
     networks:
       - app-tier
     env_file:
-      - .env.local
+      - .env.example
+    environment:
+      USE_POSTGRES_CONCERTS: 'false'
+      USE_POSTGRES_ONDEMAND: 'false'
+      USE_POSTGRES_DEEJAYS: 'false'
+      USE_POSTGRES_MUSIC: 'false'
+      USE_POSTGRES_STORIES: 'false'
+      USE_POSTGRES_CDOFTHEWEEK: 'false'
+      USE_POSTGRES_SCHEDULE: 'false'
+      USE_POSTGRES_CUSTOMTEXT: 'false'
     volumes:
       - ./src:/app
   apache:

--- a/src/partials/_header.php
+++ b/src/partials/_header.php
@@ -46,12 +46,25 @@ if (strpos($_SERVER['SCRIPT_NAME'] ?? '', '/cp/') !== false) {
       <?php
       // Determine if we're in the /cp directory to adjust paths
       $base_path = (strpos($page_file, 'cp/') !== false || dirname($_SERVER['PHP_SELF']) == '/cp') ? "../" : "";
+      $style_dir = __DIR__ . '/../style/';
+      $style_files = [
+          'grid.css',
+          'typography.css',
+          'table.css',
+          'forms.css',
+          'buttons.css',
+          'classic.css',
+          'classic.date.css',
+          'classic.time.css',
+          'yearendpoll.css',
+      ];
 
-      // Cache busting: append file modification time as query string
-      $css_file = __DIR__ . '/../style/base.css';
-      $css_version = file_exists($css_file) ? filemtime($css_file) : time();
+      foreach ($style_files as $style_file) {
+          $style_path = $style_dir . $style_file;
+          $style_version = file_exists($style_path) ? filemtime($style_path) : time();
+          echo '<link href="' . $base_path . 'style/' . $style_file . '?v=' . $style_version . '" rel="stylesheet" type="text/css" media="all">' . "\n";
+      }
       ?>
-      <link href="<?php echo $base_path; ?>style/base.css?v=<?php echo $css_version; ?>" rel="stylesheet" type="text/css" media="all">
       <?php if ($page_file == "madness.php" || $page_file == "madness_sandbox.php" || $page_file == "madness_view.php") {
     $madness_css = __DIR__ . '/../style/madness.css';
     $madness_version = file_exists($madness_css) ? filemtime($madness_css) : time();
@@ -59,17 +72,27 @@ if (strpos($_SERVER['SCRIPT_NAME'] ?? '', '/cp/') !== false) {
 }
 ?>
 
+      <?php
+      $js_dir = __DIR__ . '/../js/';
+      $common_js_files = [
+          'picker.js',
+          'picker.date.js',
+          'picker.time.js',
+          'legacy.js',
+          'init.js',
+      ];
+      ?>
       <!-- <script type="text/javascript" src="js/jquery-1.7.1.js"></script> -->
       <script type="text/javascript" src="https://code.jquery.com/jquery-1.7.1.min.js"></script>
       <!--http://code.jquery.com/jquery-1.7.1.min.js -->
-
-      <script src="<?php echo $base_path; ?>js/picker.js"></script>
-      <script src="<?php echo $base_path; ?>js/picker.date.js"></script>
-      <script src="<?php echo $base_path; ?>js/picker.time.js"></script>
-      <script src="<?php echo $base_path; ?>js/legacy.js"></script>
-      <script src="<?php echo $base_path; ?>js/init.js"></script>
+      <?php
+      foreach ($common_js_files as $js_file) {
+          $js_path = $js_dir . $js_file;
+          $js_version = file_exists($js_path) ? filemtime($js_path) : time();
+          echo '<script src="' . $base_path . 'js/' . $js_file . '?v=' . $js_version . '"></script>' . "\n";
+      }
+      ?>
       <?php if ($page_file == "madness.php" || $page_file == "madness_sandbox.php" || $page_file == "madness_view.php") {
-    $js_dir = __DIR__ . '/../js/';
     $js_comp_dir = $js_dir . 'components/';
     $bm_v = file_exists($js_comp_dir . 'mrm-bracket-match.js') ? filemtime($js_comp_dir . 'mrm-bracket-match.js') : time();
     $sb_v = file_exists($js_comp_dir . 'mrm-scoreboard.js') ? filemtime($js_comp_dir . 'mrm-scoreboard.js') : time();
@@ -97,7 +120,11 @@ if (strpos($_SERVER['SCRIPT_NAME'] ?? '', '/cp/') !== false) {
 }
 
 ?>
-      <script type="text/javascript" src="<?php echo $base_path; ?>js/common_functions.js"></script>
+      <?php
+      $common_functions_path = $js_dir . 'common_functions.js';
+      $common_functions_version = file_exists($common_functions_path) ? filemtime($common_functions_path) : time();
+      ?>
+      <script type="text/javascript" src="<?php echo $base_path; ?>js/common_functions.js?v=<?php echo $common_functions_version; ?>"></script>
 
     </head>
     <?php

--- a/src/partials/_now_playing.php
+++ b/src/partials/_now_playing.php
@@ -93,17 +93,6 @@ if ($json) {
       overflow: hidden;
     }
 
-    .ynot-np-eyebrow {
-      display: block;
-      font-size: 9px;
-      font-weight: bold;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: #cc3333;
-      text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-      margin-bottom: 3px;
-    }
-
     .ynot-np-track {
       padding-bottom: 4px;
       white-space: nowrap;
@@ -139,7 +128,6 @@ if ($json) {
     </div>
     <ol class="ynot-np-list">
       <li class="ynot-np-track ynot-np-track--current">
-        <span class="ynot-np-eyebrow">Now Playing</span>
         <span class="ynot-np-track-artist"><?php echo htmlspecialchars($artist); ?></span>
         <span class="ynot-np-track-title"><?php echo htmlspecialchars($title); ?></span>
       </li>

--- a/src/style/grid.css
+++ b/src/style/grid.css
@@ -31,7 +31,8 @@
 .row .nine    { grid-column: span 9; }
 .row .ten     { grid-column: span 10; }
 .row .eleven  { grid-column: span 11; }
-.row .twelve  { grid-column: span 12; }
+.row .twelve,
+.row .tweleve { grid-column: span 12; }
 
 /* Clearfix kept for legacy non-grid `.clearfix` containers only.
    NOTE: do NOT add :before/:after to `.row` — they become grid items


### PR DESCRIPTION
## Changes
- remove the extra desktop now-playing label and add per-file asset cache busting for the legacy header
- restore Control Panel full-width layout under the new grid and keep localhost legacy PHP insulated from `.env.local` e2e rewrites

## Verification
- [x] `yarn lint` exits 0
- [x] `yarn test` exits 0
- [x] `yarn build` exits 0
- [x] Playwright screenshot captured locally: `tmp/playwright-cp-logged-in.png`

## Blocker
@tjnicolaides - `yarn test:e2e` still fails broadly in pre-existing suites unrelated to these legacy fixes: 79 failed / 54 passed / 13 skipped, concentrated in collections, Modern Rock Madness, payload integration, show cloner, and year-end poll tests.

Supersedes #580 because GitGuardian scanned the earlier branch history.