### PR TITLE
Add e2e regression tests for Postgres-backed PHP pages

### DIFF
--- a/e2e/postgres-pages.spec.ts
+++ b/e2e/postgres-pages.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { checkForPhpErrors } from './utils/test-helpers';
+
+/**
+ * Regression coverage for the Postgres-backed PHP pages exercised in PR #584
+ * (fix/postgres-readiness). These tests guard against the specific defects
+ * we shipped fixes for so they cannot silently regress:
+ *
+ *   - PostgresOnDemand.php parse error from unescaped `order` in a SQL
+ *     identifier (also used in paginated listings).
+ *   - PostgresCdOfTheWeek.php "error loading" caused by an `_status IN
+ *     ('published','draft')` filter that surfaced unmigrated drafts.
+ *   - DJs page rendering stub names like "DJ #123" when the migrator
+ *     left placeholder People rows.
+ *
+ * Pages are accessed via the `?ff=use_postgres_<name>` feature flag query
+ * param, which sets a cookie consumed by `\FeatureFlags`.
+ */
+
+const LEGACY_BASE_URL = process.env.LEGACY_BASE_URL || 'http://localhost:8080';
+
+// Use 'domcontentloaded' instead of 'networkidle' — ondemand pages embed
+// audio players whose network requests never go idle.
+async function gotoPhp(page: import('@playwright/test').Page, url: string) {
+  const response = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  return response?.status() ?? null;
+}
+
+const POSTGRES_PAGES = [
+  { path: 'concerts.php', flag: 'use_postgres_concerts' },
+  { path: 'cdoftheweek.php', flag: 'use_postgres_cdoftheweek' },
+  { path: 'deejays.php', flag: 'use_postgres_deejays' },
+  { path: 'ondemand.php', flag: 'use_postgres_ondemand' },
+] as const;
+
+test.describe('Postgres-backed PHP pages', () => {
+  POSTGRES_PAGES.forEach(({ path, flag }) => {
+    test(`${path} loads with no PHP errors`, async ({ page }) => {
+      const url = `${LEGACY_BASE_URL}/${path}?ff=${flag}`;
+      const status = await gotoPhp(page, url);
+      expect(status).toBe(200);
+      const errors = checkForPhpErrors(await page.content());
+      expect(errors, `Found PHP errors on ${path}: ${errors.join(', ')}`).toEqual([]);
+    });
+  });
+
+  // Regression: ondemand parse error was inside the paginated SQL, so we
+  // exercise the first few pages explicitly.
+  [1, 2, 3].forEach((pageNum) => {
+    test(`ondemand.php page ${pageNum} renders without parse error`, async ({ page }) => {
+      const url = `${LEGACY_BASE_URL}/ondemand.php?ff=use_postgres_ondemand&page=${pageNum}`;
+      const status = await gotoPhp(page, url);
+      expect(status).toBe(200);
+      const content = await page.content();
+      expect(content).not.toContain('Parse error');
+      expect(content).not.toContain('syntax error');
+    });
+  });
+
+  test('deejays.php does not render stub "DJ #N" placeholder names', async ({ page }) => {
+    const url = `${LEGACY_BASE_URL}/deejays.php?ff=use_postgres_deejays`;
+    const status = await gotoPhp(page, url);
+    expect(status).toBe(200);
+    const stubMatches = await page.locator('h2', { hasText: /^DJ #\d+$/ }).count();
+    expect(stubMatches).toBe(0);
+  });
+
+  test('cdoftheweek.php main panel does not show "error loading" fallback', async ({ page }) => {
+    const url = `${LEGACY_BASE_URL}/cdoftheweek.php?ff=use_postgres_cdoftheweek`;
+    const status = await gotoPhp(page, url);
+    expect(status).toBe(200);
+    // Scope to the main panel (first .row) to avoid false matches in the
+    // "see other reviews" archive section.
+    const mainPanel = page.locator('.row').first();
+    await expect(mainPanel).not.toContainText(/error loading the CD of the Week/i);
+  });
+});


### PR DESCRIPTION
## Changes

Adds `e2e/postgres-pages.spec.ts` with regression coverage for the defects fixed in #584:

- **ondemand.php parse error** (unescaped reserved-word identifiers in paginated SQL) — asserts pages 1-3 render without `Parse error` / `syntax error`.
- **cdoftheweek.php "error loading" fallback** (caused by surfacing unmigrated drafts) — asserts the main panel does not render the fallback text.
- **deejays.php stub "DJ #N" names** (unmigrated People rows) — asserts no `<h2>` matches \`/^DJ #\d+\$/\`.
- **Smoke loop** over all 4 Postgres-backed PHP pages asserting 200 + no PHP error patterns (`Fatal error`, `Parse error`, `Warning:`, `SQLSTATE`, etc.).

Pages are exercised via the \`?ff=use_postgres_<name>\` feature flag, so the tests target the PostgreSQL read models specifically. They run against the legacy PHP site at \`LEGACY_BASE_URL\` (default \`http://localhost:8080\`).

> Note: this branch is based on \`fix/postgres-readiness\` (#584). Merge order should be #584 first, then this. Once #584 lands, this rebases cleanly onto master.

## Verification

- [x] \`yarn eslint e2e/postgres-pages.spec.ts\` exits 0
- [x] All 9 tests pass locally against \`http://localhost:8080\`

\`\`\`
✓  1  concerts.php loads with no PHP errors (4.9s)
✓  2  cdoftheweek.php loads with no PHP errors (3.5s)
✓  3  deejays.php loads with no PHP errors (2.4s)
✓  4  ondemand.php loads with no PHP errors (2.2s)
✓  5  ondemand.php page 1 renders without parse error (1.6s)
✓  6  ondemand.php page 2 renders without parse error (1.6s)
✓  7  ondemand.php page 3 renders without parse error (2.0s)
✓  8  deejays.php does not render stub "DJ #N" placeholder names (1.2s)
✓  9  cdoftheweek.php main panel does not show "error loading" fallback (1.2s)

9 passed (20.9s)
\`\`\`

## Follow-up (not in this PR)

Adding \`postgres-pages\` to the CI \`testMatch\` regex in \`playwright.config.ts\` would run these in Buildkite. Holding off until #584 merges so master is green.