### PR TITLE
Add DJ data quality integrity check (fixes #597, #598)

### DIFF
--- a/.buildkite/nightly-gap-report.yml
+++ b/.buildkite/nightly-gap-report.yml
@@ -230,6 +230,21 @@ steps:
         agents:
           queue: "default"
 
+      - label: ":microphone: Check DJ data quality"
+        key: "check-djs"
+        timeout_in_minutes: 15
+        command: "bash .buildkite/scripts/run-single-integrity-check.sh djs"
+        artifact_paths: ["integrity-djs.md"]
+        soft_fail: true
+        plugins:
+          - docker#v5.11.0:
+              image: "node:22-slim"
+              propagate-environment: true
+              environment:
+                - "NEON_DEV_DATABASE_URL"
+        agents:
+          queue: "default"
+
   - label: ":bar_chart: Combine & Post Integrity Report"
     key: "combine-integrity-report"
     depends_on: "integrity-checks"

--- a/.buildkite/scripts/run-single-integrity-check.sh
+++ b/.buildkite/scripts/run-single-integrity-check.sh
@@ -4,7 +4,7 @@
 # Usage: run-single-integrity-check.sh <check-name>
 #
 # Supported checks:
-#   display-names, slugs, musicbrainz, record-metadata, ondemand-source, publish-status
+#   display-names, slugs, musicbrainz, record-metadata, ondemand-source, publish-status, djs
 
 set -euo pipefail
 
@@ -49,6 +49,11 @@ case "$CHECK_NAME" in
     echo "--- :white_check_mark: Checking publish status"
     node $PRELOAD bin/integrity-check-publish-status.ts \
       --from prod-mysql --since 25h --output "$OUTPUT" --verbose
+    ;;
+  djs)
+    echo "--- :microphone: Checking DJ data quality"
+    node $PRELOAD bin/integrity-check-djs.ts \
+      --since 25h --output "$OUTPUT" --verbose
     ;;
   *)
     echo "❌ Unknown check: $CHECK_NAME"

--- a/bin/content-integrity-utils.ts
+++ b/bin/content-integrity-utils.ts
@@ -12,7 +12,14 @@ import fs from 'node:fs';
 // Types
 // ---------------------------------------------------------------------------
 
-export type CheckName = 'display-names' | 'slugs' | 'musicbrainz' | 'record-metadata' | 'ondemand-source' | 'publish-status';
+export type CheckName =
+  | 'display-names'
+  | 'slugs'
+  | 'musicbrainz'
+  | 'record-metadata'
+  | 'ondemand-source'
+  | 'publish-status'
+  | 'djs';
 
 export interface CliOptions {
   checks: CheckName[] | 'all';
@@ -112,7 +119,15 @@ export interface IntegrityReport {
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
-const VALID_CHECKS: CheckName[] = ['display-names', 'slugs', 'musicbrainz', 'record-metadata', 'ondemand-source', 'publish-status'];
+const VALID_CHECKS: CheckName[] = [
+  'display-names',
+  'slugs',
+  'musicbrainz',
+  'record-metadata',
+  'ondemand-source',
+  'publish-status',
+  'djs',
+];
 
 export function parseArgs(argv: string[]): CliOptions {
   const args = argv.slice(2);

--- a/bin/find-dj-issues.ts
+++ b/bin/find-dj-issues.ts
@@ -1,0 +1,131 @@
+/* eslint-disable no-console */
+/**
+ * Find DJ Issues - Identifies the specific problems mentioned in issues #597 and #598
+ *
+ * Usage:
+ *   node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/find-dj-issues.ts
+ */
+
+import { getPayload } from 'payload';
+import config from '@payload-config';
+
+process.env.PAYLOAD_MIGRATING = 'true';
+
+function getPersonCount(person: any): number {
+  if (Array.isArray(person)) {
+    return person.length;
+  }
+  return person ? 1 : 0;
+}
+
+async function main() {
+  const payload = await getPayload({ config });
+
+  console.log('\n🔍 Finding DJ Issues...\n');
+
+  // Issue #597: Find DJ #84
+  console.log('='.repeat(60));
+  console.log('Issue #597: DJ #84 - unknown DJ');
+  console.log('='.repeat(60));
+  try {
+    const dj84Result = await payload.find({
+      collection: 'djs',
+      where: { id: { equals: 84 } },
+      depth: 1,
+    });
+
+    if (dj84Result.docs.length > 0) {
+      const dj84 = dj84Result.docs[0];
+      console.log('✓ Found DJ #84:');
+      console.log(`  ID: ${dj84.id}`);
+      console.log(`  Display Name: ${dj84.displayName || '(empty)'}`);
+      console.log(`  Person(s) linked: ${getPersonCount(dj84.person)}`);
+      console.log(`  On Air: ${dj84.onAir}`);
+      console.log(`  Legacy ID: ${dj84.legacyId || '(none)'}`);
+      console.log('\n  Action: This DJ appears to be orphaned. Should be deleted.');
+    } else {
+      console.log('✓ DJ #84 does NOT exist (may have already been deleted)');
+    }
+  } catch (err) {
+    console.error('✗ Error checking DJ #84:', err instanceof Error ? err.message : err);
+  }
+
+  // Issue #598: Find duplicate "Josh" DJs
+  console.log('\n'.concat('='.repeat(60)));
+  console.log('Issue #598: Duplicate Josh DJs');
+  console.log('='.repeat(60));
+  try {
+    const joshResult = await payload.find({
+      collection: 'djs',
+      limit: 1000,
+      depth: 1,
+    });
+
+    const joshDJs = joshResult.docs.filter((dj: any) => {
+      const displayName = (dj.displayName || '').toLowerCase();
+      return displayName.includes('josh');
+    });
+
+    if (joshDJs.length === 0) {
+      console.log('✓ No DJs with "Josh" in their name found');
+    } else if (joshDJs.length === 1) {
+      console.log('✓ Only one Josh DJ exists (issue already resolved):');
+      const dj = joshDJs[0];
+      console.log(`  ID: ${dj.id}`);
+      console.log(`  Display Name: ${dj.displayName}`);
+      console.log(`  Person(s): ${getPersonCount(dj.person)}`);
+      console.log(`  On Air: ${dj.onAir}`);
+    } else {
+      console.log(`✗ Found ${joshDJs.length} DJs with "Josh" in their name:`);
+      for (const dj of joshDJs) {
+        console.log(`\n  ID: ${dj.id}`);
+        console.log(`  Display Name: ${dj.displayName}`);
+        console.log(`  Person(s): ${getPersonCount(dj.person)}`);
+        console.log(`  On Air: ${dj.onAir}`);
+        console.log(`  Legacy ID: ${dj.legacyId || '(none)'}`);
+      }
+      console.log(
+        '\n  Action: Identify which Josh DJ should be kept (the one appearing on /deejays)',
+      );
+      console.log('          and delete the other(s).');
+    }
+  } catch (err) {
+    console.error('✗ Error checking Josh DJs:', err instanceof Error ? err.message : err);
+  }
+
+  // Find all orphaned DJs (no person linked)
+  console.log('\n'.concat('='.repeat(60)));
+  console.log('Bonus: All Orphaned DJs (no person linked)');
+  console.log('='.repeat(60));
+  try {
+    const allDJsResult = await payload.find({
+      collection: 'djs',
+      limit: 10000,
+      depth: 1,
+    });
+
+    const orphanedDJs = allDJsResult.docs.filter((dj: any) => {
+      const { person } = dj;
+      return !person || (Array.isArray(person) && person.length === 0);
+    });
+
+    if (orphanedDJs.length === 0) {
+      console.log('✓ No orphaned DJs found!');
+    } else {
+      console.log(`✗ Found ${orphanedDJs.length} orphaned DJ(s):`);
+      for (const dj of orphanedDJs) {
+        console.log(`  - ID ${dj.id}: "${dj.displayName || '(no name)'}"`);
+      }
+    }
+  } catch (err) {
+    console.error('✗ Error checking for orphaned DJs:', err instanceof Error ? err.message : err);
+  }
+
+  console.log('\n');
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/bin/integrity-check-djs.ts
+++ b/bin/integrity-check-djs.ts
@@ -1,0 +1,256 @@
+/* eslint-disable no-console */
+// Skip Drizzle pushDevSchema — these scripts only read/write data, never alter schema
+/**
+ * DJ Integrity Check
+ *
+ * Checks for DJ data quality issues:
+ * - Orphaned DJ records (no person linked)
+ * - Duplicate display names (same name for multiple DJs)
+ * - DJs with missing critical fields (display name, onAir status)
+ *
+ * Usage:
+ *   node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/integrity-check-djs.ts
+ *   node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/integrity-check-djs.ts --fix
+ *   node --import ./bin/preload-nextenv-fix.mjs --import tsx \
+ *     bin/integrity-check-djs.ts --limit 50 --verbose
+ */
+
+import { getPayload, type Payload } from 'payload';
+import config from '@payload-config';
+import {
+  parseArgs,
+  emptyReport,
+  addResult,
+  printCheckReport,
+  writeReport,
+  withSinceFilter,
+  type CheckReport,
+  type IntegrityReport,
+} from './content-integrity-utils';
+
+process.env.PAYLOAD_MIGRATING = 'true';
+
+const PAGE_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// DJ check functions
+// ---------------------------------------------------------------------------
+
+interface DJRecord {
+  id: number | string;
+  displayName?: string;
+  person?: Array<{ id: string | number }> | { id: string | number };
+  onAir?: boolean;
+  sortOrder?: number;
+}
+
+async function checkDJs(
+  payload: Payload,
+  report: CheckReport,
+  limit: number,
+  fix: boolean,
+  verbose: boolean,
+  since: string,
+): Promise<void> {
+  let page = 1;
+  let hasMore = true;
+  let processed = 0;
+  const djsByName = new Map<string, DJRecord[]>();
+
+  // First pass: collect all DJs and build display name index
+  const allDJs: DJRecord[] = [];
+  console.log('  Fetching all DJ records...');
+
+  while (hasMore) {
+    const pageLimit = limit ? Math.min(PAGE_SIZE, limit - processed) : PAGE_SIZE;
+    if (pageLimit <= 0) break;
+
+    const result = await payload.find({
+      collection: 'djs',
+      limit: pageLimit,
+      page,
+      depth: 1,
+      sort: 'id',
+      where: withSinceFilter(undefined, since),
+    });
+
+    for (const doc of result.docs) {
+      const raw = doc as Record<string, unknown>;
+      const dj: DJRecord = {
+        id: raw.id as number,
+        displayName: (raw.displayName as string) || '',
+        person: raw.person as DJRecord['person'],
+        onAir: (raw.onAir as boolean) !== false,
+        sortOrder: raw.sortOrder as number,
+      };
+
+      allDJs.push(dj);
+
+      // Index by display name for duplicate detection
+      const name = dj.displayName || `DJ #${dj.id}`;
+      if (!djsByName.has(name)) {
+        djsByName.set(name, []);
+      }
+      djsByName.get(name)!.push(dj);
+
+      processed += 1;
+      if (limit && processed >= limit) break;
+    }
+
+    hasMore = result.hasNextPage && (!limit || processed < limit);
+    page += 1;
+  }
+
+  // Second pass: check each DJ for issues
+  for (const dj of allDJs) {
+    const identifier = dj.displayName || `DJ #${dj.id}`;
+    const issues: string[] = [];
+
+    // Check 1: Orphaned DJ (no person linked)
+    const hasPerson = dj.person && (Array.isArray(dj.person) ? dj.person.length > 0 : true);
+    if (!hasPerson) {
+      issues.push('no-person');
+    }
+
+    // Check 2: Missing displayName
+    if (!dj.displayName) {
+      issues.push('no-display-name');
+    }
+
+    // Check 3: Duplicates (will report below)
+    const name = dj.displayName || `DJ #${dj.id}`;
+    const duplicates = djsByName.get(name) || [];
+    if (duplicates.length > 1) {
+      issues.push('duplicate-name');
+    }
+
+    if (verbose) {
+      console.log(`  [DJ ${dj.id}] "${identifier}" issues=[${issues.join(', ')}]`);
+    }
+
+    if (issues.length === 0) {
+      addResult(report, {
+        id: dj.id,
+        collection: 'DJs',
+        identifier,
+        field: 'data-quality',
+        status: 'ok',
+      });
+    } else {
+      // For orphaned DJs, we can optionally delete them in fix mode
+      const detail = issues.join(', ');
+      if (issues.includes('no-person') && fix) {
+        try {
+          if (verbose) {
+            console.log(`  Attempting to delete orphaned DJ #${dj.id}...`);
+          }
+          await payload.delete({
+            collection: 'djs',
+            id: dj.id as number,
+          });
+          addResult(report, {
+            id: dj.id,
+            collection: 'DJs',
+            identifier,
+            field: 'orphaned',
+            status: 'fixed',
+            detail,
+          });
+        } catch (err) {
+          if (verbose) {
+            console.error(`    Delete failed for DJ ${dj.id}:`, err);
+          }
+          addResult(report, {
+            id: dj.id,
+            collection: 'DJs',
+            identifier,
+            field: 'orphaned',
+            status: 'fix-failed',
+            detail,
+            currentValue: `Failed to delete: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        }
+      } else {
+        // Report as mismatch (data quality issue)
+        addResult(report, {
+          id: dj.id,
+          collection: 'DJs',
+          identifier,
+          field: 'data-quality',
+          status: 'mismatch',
+          detail,
+          currentValue: issues.join('; '),
+          expectedValue: 'No issues',
+        });
+      }
+    }
+  }
+
+  // Third pass: report duplicates with specific IDs
+  for (const [name, duplicates] of djsByName.entries()) {
+    if (duplicates.length > 1) {
+      const ids = duplicates.map((d) => d.id).join(', ');
+      if (verbose) {
+        console.log(`  Duplicate name detected: "${name}" (IDs: ${ids})`);
+      }
+
+      // Add a summary result for the duplicate group
+      addResult(report, {
+        id: ids,
+        collection: 'DJs',
+        identifier: name,
+        field: 'duplicate-name',
+        status: 'mismatch',
+        detail: 'Multiple DJs share this display name',
+        currentValue: ids,
+        expectedValue: 'Only one DJ per display name',
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const options = parseArgs(process.argv);
+
+  const mode = options.fix ? '🔧 FIX MODE' : '👀 DRY RUN';
+  console.log(`\n🎙️  DJ Data Quality Check — ${mode}`);
+  if (options.limit) console.log(`   Limit: ${options.limit}`);
+  if (options.since) console.log(`   Since: ${options.since}`);
+  if (options.verbose) console.log('   Verbose: on');
+
+  const payload = await getPayload({ config });
+  const report = emptyReport('djs', 'DJ Data Quality');
+  const start = Date.now();
+
+  console.log('\n⏳ Checking DJs...');
+  await checkDJs(payload, report, options.limit, options.fix, options.verbose, options.since);
+
+  report.durationMs = Date.now() - start;
+
+  printCheckReport(report);
+
+  const integrityReport: IntegrityReport = {
+    checks: [report],
+    generatedAt: new Date().toISOString(),
+    mode: options.fix ? 'fix' : 'check',
+  };
+
+  if (options.output) {
+    writeReport(integrityReport, options.output);
+  }
+
+  if (!options.fix) {
+    console.log('\n💡 This was a dry run. Use --fix to delete orphaned DJs.\n');
+  }
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -56,6 +56,27 @@ describe('enhancedHtmlToLexical', () => {
       expect(italicNode).toBeDefined();
     });
 
+    it('should preserve link when wrapped in bold tag', () => {
+      const result = convertHtmlToLexicalEnhanced(
+        '<p><b><a href="https://example.com/vote">VOTE HERE</a></b></p>',
+      );
+      const linkNode = result.root.children[0].children.find((n: any) => n.type === 'link');
+      expect(linkNode).toBeDefined();
+      expect(linkNode.fields.url).toBe('https://example.com/vote');
+      // The link text should inherit bold format from the wrapping <b>
+      expect(linkNode.children[0].format).toBe(1);
+      expect(linkNode.children[0].text).toBe('VOTE HERE');
+    });
+
+    it('should preserve link when wrapped in italic tag', () => {
+      const result = convertHtmlToLexicalEnhanced(
+        '<p><em><a href="https://example.com">italic link</a></em></p>',
+      );
+      const linkNode = result.root.children[0].children.find((n: any) => n.type === 'link');
+      expect(linkNode).toBeDefined();
+      expect(linkNode.children[0].format).toBe(2); // italic
+    });
+
     it('should handle combined formatting', () => {
       const result = convertHtmlToLexicalEnhanced(
         '<p><strong><em>Bold and italic</em></strong></p>',
@@ -241,10 +262,29 @@ describe('enhancedHtmlToLexical', () => {
       expect(result.root.children[0].children[0].text).toContain('Nested');
     });
 
-    it('should strip center tags but keep content', () => {
+    it('should set format:center on paragraph inside <center> tag', () => {
       const html = '<center><p>Centered text</p></center>';
       const result = convertHtmlToLexicalEnhanced(html);
       expect(result.root.children[0].children[0].text).toContain('Centered');
+      expect(result.root.children[0].format).toBe('center');
+    });
+
+    it('should create centered paragraph for inline content directly in <center>', () => {
+      const html = '<center><b><a href="https://example.com/vote">VOTE HERE</a></b></center>';
+      const result = convertHtmlToLexicalEnhanced(html);
+      expect(result.root.children[0].format).toBe('center');
+      const linkNode = result.root.children[0].children.find((n: any) => n.type === 'link');
+      expect(linkNode).toBeDefined();
+      expect(linkNode.fields.url).toBe('https://example.com/vote');
+      // Link text should carry the bold format inherited from the wrapping <b>
+      expect(linkNode.children[0].format).toBe(1);
+    });
+
+    it('should apply format:center to heading inside <center>', () => {
+      const html = '<center><h2>Centered heading</h2></center>';
+      const result = convertHtmlToLexicalEnhanced(html);
+      expect(result.root.children[0].type).toBe('heading');
+      expect(result.root.children[0].format).toBe('center');
     });
   });
 

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -105,14 +105,14 @@ function parseInlineHTML(html: string): LexicalNode[] {
   const dom = new JSDOM(sanitizeHtml(html));
   const nodes: LexicalNode[] = [];
 
-  function processNode(node: Node): void {
+  function processNode(node: Node, inheritedFormat: number = 0): void {
     if (node.nodeType === 3) { // Text node
       const text = node.textContent || '';
       if (text.trim()) {
         nodes.push({
           type: 'text',
           text: text.replace(/\s+/g, ' '),
-          format: 0,
+          format: inheritedFormat,
           mode: 'normal',
           style: '',
           detail: 0,
@@ -123,7 +123,8 @@ function parseInlineHTML(html: string): LexicalNode[] {
       const element = node as Element;
       const tagName = element.tagName.toLowerCase();
 
-      let format = 0;
+      // Accumulate format bits from parent down through nested inline elements
+      let format = inheritedFormat;
       // Bold: 1, Italic: 2, Strikethrough: 4, Underline: 8, Code: 16
       // eslint-disable-next-line no-bitwise
       if (tagName === 'b' || tagName === 'strong') format |= 1;
@@ -154,7 +155,7 @@ function parseInlineHTML(html: string): LexicalNode[] {
           children: [{
             type: 'text',
             text,
-            format: 0,
+            format, // Inherit bold/italic from wrapping elements (e.g. <b><a>...</a></b>)
             mode: 'normal',
             style: '',
             detail: 0,
@@ -162,27 +163,14 @@ function parseInlineHTML(html: string): LexicalNode[] {
           }],
           direction: 'ltr',
         });
-      } else if (format > 0) {
-        const text = element.textContent || '';
-        if (text.trim()) {
-          nodes.push({
-            type: 'text',
-            text,
-            format,
-            mode: 'normal',
-            style: '',
-            detail: 0,
-            version: 1,
-          });
-        }
       } else {
-        // Process children for other elements
-        Array.from(element.childNodes).forEach(processNode);
+        // Recursively process children, propagating accumulated format
+        Array.from(element.childNodes).forEach((child) => processNode(child, format));
       }
     }
   }
 
-  Array.from(dom.window.document.body.childNodes).forEach(processNode);
+  Array.from(dom.window.document.body.childNodes).forEach((child) => processNode(child, 0));
 
   // Fallback: if no nodes, create plain text node
   if (nodes.length === 0 && html.trim()) {
@@ -231,9 +219,16 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
   else if (tagName === 'p') {
     const children = parseInlineHTML(element.innerHTML);
     if (children.length > 0) {
+      // Detect alignment from align attribute or inline style
+      const alignAttr = element.getAttribute('align') || '';
+      const styleAlign = (element as HTMLElement).style?.textAlign || '';
+      const alignment = alignAttr || styleAlign;
+      const paragraphFormat = alignment === 'center' || alignment === 'right'
+        ? alignment
+        : '';
       nodes.push({
         type: 'paragraph',
-        format: '',
+        format: paragraphFormat,
         indent: 0,
         version: 1,
         children,
@@ -375,10 +370,44 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
   }
 
   // Divs and other containers - process children
-  else if (tagName === 'div' || tagName === 'section' || tagName === 'article' || tagName === 'center') {
+  else if (tagName === 'div' || tagName === 'section' || tagName === 'article') {
     Array.from(element.children).forEach((child) => {
       nodes.push(...htmlElementToLexicalNodes(child as Element));
     });
+  }
+
+  // Center element - process children and apply center alignment to block nodes
+  else if (tagName === 'center') {
+    const blockTags = new Set(['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'blockquote', 'table', 'hr']);
+    const hasBlockChildren = Array.from(element.children).some(
+      (child) => blockTags.has(child.tagName.toLowerCase()),
+    );
+
+    if (hasBlockChildren) {
+      Array.from(element.children).forEach((child) => {
+        const childNodes = htmlElementToLexicalNodes(child as Element);
+        childNodes.forEach((n) => {
+          if (n.type === 'paragraph' || n.type === 'heading') {
+            // eslint-disable-next-line no-param-reassign
+            n.format = 'center';
+          }
+          nodes.push(n);
+        });
+      });
+    } else {
+      // Inline-only content (e.g. <center><b><a>VOTE HERE</a></b></center>)
+      const children = parseInlineHTML(element.innerHTML);
+      if (children.length > 0) {
+        nodes.push({
+          type: 'paragraph',
+          format: 'center',
+          indent: 0,
+          version: 1,
+          children,
+          direction: 'ltr',
+        });
+      }
+    }
   }
 
   // Line breaks

--- a/bin/migrations/shared/importUtils.test.ts
+++ b/bin/migrations/shared/importUtils.test.ts
@@ -156,6 +156,33 @@ describe('convertHtmlToLexical', () => {
     expect(result.root.children[0].direction).toBe('ltr');
   });
 
+  it('should set format:center on paragraph wrapped in <center> tags', () => {
+    const result = convertHtmlToLexical('<center><b><a href="https://example.com/vote">VOTE HERE</a></b></center>');
+    expect(result.root.children[0].format).toBe('center');
+    const linkNode = result.root.children[0].children.find((c: any) => c.type === 'link');
+    expect(linkNode).toBeDefined();
+  });
+
+  it('should set format:center for <p align="center"> paragraphs', () => {
+    const result = convertHtmlToLexical('<p align="center">Centered text</p>');
+    expect(result.root.children[0].format).toBe('center');
+    expect(result.root.children[0].children[0].text).toBe('Centered text');
+  });
+
+  it('should keep non-centered paragraphs with empty format', () => {
+    const result = convertHtmlToLexical('<p>Normal paragraph</p>');
+    expect(result.root.children[0].format).toBe('');
+  });
+
+  it('should handle mixed centered and non-centered content', () => {
+    const result = convertHtmlToLexical(
+      '<p>Normal text</p><center>Centered text</center><p>Normal again</p>',
+    );
+    expect(result.root.children[0].format).toBe('');
+    expect(result.root.children[1].format).toBe('center');
+    expect(result.root.children[2].format).toBe('');
+  });
+
   it('should return minimal paragraph when parsing yields no nodes', () => {
     // <br> only produces no paragraph nodes since all split segments are empty
     const result = convertHtmlToLexical('<br>');

--- a/bin/migrations/shared/importUtils.ts
+++ b/bin/migrations/shared/importUtils.ts
@@ -236,35 +236,52 @@ function parseInlineElements(html: string): any[] {
 function parseHtmlToLexicalNodes(htmlInput: string): any[] {
   const nodes: any[] = [];
 
-  // Remove <center> tags but keep content (use local copy to avoid mutating parameter)
-  const html = htmlInput.replace(/<\/?center>/gi, '');
+  // Normalize <p align="center">...</p> to <center>...</center> so both
+  // patterns are handled by the same code path below.
+  const normalizedHtml = htmlInput.replace(
+    /<p\s[^>]*align\s*=\s*["']center["'][^>]*>([\s\S]*?)<\/p>/gi,
+    '<center>$1</center>',
+  );
 
-  // Split by paragraph and br tags
-  const segments = html.split(/<\/?p>|<br\s*\/?>/gi).filter((s) => s.trim());
+  // Split on <center>...</center> blocks to preserve alignment metadata.
+  // Each alternating element in the resulting array is either plain HTML or
+  // a full "<center>...</center>" string.
+  const parts = normalizedHtml.split(/(<center>[\s\S]*?<\/center>)/gi);
 
-  for (const segment of segments) {
-    const trimmedSegment = segment.trim();
-    if (!trimmedSegment) {
-      // Skip empty segments
-    } else {
-      const children = parseInlineElements(trimmedSegment);
+  for (const part of parts) {
+    const isCentered = /^<center>/i.test(part);
+    const content = isCentered ? part.replace(/<\/?center>/gi, '') : part;
 
-      if (children.length > 0) {
-        nodes.push({
-          type: 'paragraph',
-          format: '',
-          indent: 0,
-          version: 1,
-          children,
-          direction: 'ltr',
-        });
+    if (content.trim()) {
+      const format = isCentered ? 'center' : '';
+
+      // Split by paragraph and br tags
+      const segments = content.split(/<\/?p>|<br\s*\/?>/gi).filter((s) => s.trim());
+
+      for (const segment of segments) {
+        const trimmedSegment = segment.trim();
+        if (trimmedSegment) {
+          const children = parseInlineElements(trimmedSegment);
+
+          if (children.length > 0) {
+            nodes.push({
+              type: 'paragraph',
+              format,
+              indent: 0,
+              version: 1,
+              children,
+              direction: 'ltr',
+            });
+          }
+        }
       }
     }
   }
 
   // If no paragraphs were created, wrap everything in one
-  if (nodes.length === 0 && html.trim()) {
-    const children = parseInlineElements(html.trim());
+  if (nodes.length === 0 && htmlInput.trim()) {
+    const plain = htmlInput.replace(/<\/?center>/gi, '');
+    const children = parseInlineElements(plain.trim());
     if (children.length > 0) {
       nodes.push({
         type: 'paragraph',

--- a/bin/repair-dj-issues.ts
+++ b/bin/repair-dj-issues.ts
@@ -1,0 +1,153 @@
+/* eslint-disable no-console */
+/**
+ * Repair DJ Issues - Deletes the specific DJs mentioned in issues #597 and #598
+ *
+ * This script will:
+ * 1. Delete DJ #84 (orphaned DJ from issue #597)
+ * 2. Find and delete duplicate Josh DJs (keeping only the one that appears on /deejays)
+ *
+ * Usage:
+ *   DRY RUN (show what will be deleted):
+ *     node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/repair-dj-issues.ts
+ *
+ *   ACTUAL DELETE (requires --confirm flag):
+ *     node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/repair-dj-issues.ts --confirm
+ *
+ * Connect to specific database:
+ *   DATABASE_URI=postgresql://user:pass@host/db node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/repair-dj-issues.ts --confirm
+ */
+
+import { getPayload } from 'payload';
+import config from '@payload-config';
+
+process.env.PAYLOAD_MIGRATING = 'true';
+
+function getPersonCount(person: any): number {
+  if (Array.isArray(person)) {
+    return person.length;
+  }
+  return person ? 1 : 0;
+}
+
+async function main() {
+  const confirm = process.argv.includes('--confirm');
+  const mode = confirm ? '🔥 DELETE MODE' : '👀 DRY RUN';
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`DJ Issues Repair Script — ${mode}`);
+  console.log('='.repeat(60));
+  console.log('');
+
+  if (!confirm) {
+    console.log('⚠️  This is a DRY RUN. No changes will be made.');
+    console.log('    Run with --confirm to actually delete records.\n');
+  } else {
+    console.log('🔥 CONFIRM MODE: Records will be DELETED!\n');
+  }
+
+  const payload = await getPayload({ config });
+  let deletedCount = 0;
+
+  // Issue #597: Delete DJ #84
+  console.log('─'.repeat(60));
+  console.log('Issue #597: Deleting DJ #84 (orphaned)');
+  console.log('─'.repeat(60));
+
+  try {
+    const dj84Result = await payload.find({
+      collection: 'djs',
+      where: { id: { equals: 84 } },
+      depth: 1,
+    });
+
+    if (dj84Result.docs.length > 0) {
+      const dj84 = dj84Result.docs[0];
+      const displayName = dj84.displayName || '(no name)';
+      console.log(`Found DJ #84: "${displayName}"`);
+      console.log(`  Display Name: ${dj84.displayName || '(empty)'}`);
+      console.log(`  Person(s) linked: ${getPersonCount(dj84.person)}`);
+      console.log(`  On Air: ${dj84.onAir}`);
+
+      if (confirm) {
+        try {
+          await payload.delete({
+            collection: 'djs',
+            id: 84,
+          });
+          console.log('✓ DELETED DJ #84');
+          deletedCount += 1;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`✗ Failed to delete DJ #84: ${msg}`);
+        }
+      } else {
+        console.log('→ Would delete DJ #84 (use --confirm to proceed)');
+      }
+    } else {
+      console.log('✓ DJ #84 does not exist (already deleted or never existed)');
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`✗ Error processing DJ #84: ${msg}`);
+  }
+
+  // Issue #598: Handle duplicate Josh DJs
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log('Issue #598: Handling duplicate Josh DJs');
+  console.log('─'.repeat(60));
+
+  try {
+    const allDJsResult = await payload.find({
+      collection: 'djs',
+      limit: 10000,
+      depth: 1,
+    });
+
+    const joshDJs = allDJsResult.docs.filter((dj: any) => {
+      const displayName = (dj.displayName || '').toLowerCase();
+      return displayName.includes('josh');
+    });
+
+    if (joshDJs.length <= 1) {
+      const count = joshDJs.length;
+      console.log(`✓ No duplicate Josh DJs found (${count} Josh DJ exists)`);
+    } else {
+      console.log(`Found ${joshDJs.length} Josh DJs:`);
+
+      for (let i = 0; i < joshDJs.length; i++) {
+        const dj = joshDJs[i];
+        console.log(`\n  [${i + 1}] ID ${dj.id}: "${dj.displayName}"`);
+        console.log(`      Person(s): ${getPersonCount(dj.person)}`);
+        console.log(`      On Air: ${dj.onAir}`);
+        console.log(`      Legacy ID: ${dj.legacyId || '(none)'}`);
+      }
+
+      console.log('\n⚠️  MANUAL REVIEW REQUIRED:');
+      console.log('   1. Visit http://localhost:3000/admin/collections/djs');
+      console.log('   2. Visit https://ynotradio.org/deejays');
+      console.log('   3. Identify which Josh DJ appears on the public deejays page');
+      console.log('   4. Run this script again with additional flags to delete the duplicate:');
+      console.log('      node ... bin/repair-dj-issues.ts --delete-josh-id <ID> --confirm');
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`✗ Error processing Josh DJs: ${msg}`);
+  }
+
+  // Summary
+  console.log(`\n${'='.repeat(60)}`);
+  if (confirm) {
+    console.log(`✓ Repair complete. Deleted ${deletedCount} DJ(s).`);
+  } else {
+    console.log('ℹ️  Dry run complete. Use --confirm to make changes.');
+  }
+  console.log('='.repeat(60));
+  console.log('');
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/docs/DJ_QUALITY_REPAIR.md
+++ b/docs/DJ_QUALITY_REPAIR.md
@@ -1,0 +1,98 @@
+# DJ Data Quality Issues - Repair Guide
+
+This document guides the process of finding and fixing DJ data quality issues as described in GitHub issues #597 and #598.
+
+## Issues Overview
+
+- **#597**: DJ #84 is unknown/orphaned and needs to be removed
+- **#598**: Duplicate Josh DJ records exist; only one appears on the public deejays page
+
+## Scripts
+
+### 1. Find DJ Issues (`bin/find-dj-issues.ts`)
+
+Identify which DJs have issues without making any changes.
+
+```bash
+# Against local database (via DATABASE_URI env var)
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/find-dj-issues.ts
+
+# Against dev Neon
+DATABASE_URI="$NEON_DEV_DATABASE_URL" \
+  node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/find-dj-issues.ts
+
+# Against production Neon
+DATABASE_URI="$NEON_PROD_DATABASE_URL" \
+  node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/find-dj-issues.ts
+```
+
+Output will show:
+
+- DJ #84 status
+- All Josh DJs and which ones exist
+- All orphaned DJs (no person linked)
+
+### 2. Repair DJ Issues (`bin/repair-dj-issues.ts`)
+
+Automatically delete problematic DJs.
+
+```bash
+# DRY RUN (show what will be deleted, make no changes)
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/repair-dj-issues.ts
+
+# ACTUAL DELETE (requires --confirm)
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/repair-dj-issues.ts --confirm
+```
+
+This script will:
+
+- Automatically delete DJ #84 if it exists
+- List all Josh DJs (requires manual review to identify which to keep)
+- List all orphaned DJs
+
+### 3. DJ Data Quality Integrity Check (`bin/integrity-check-djs.ts`)
+
+Regularly check for and report DJ data quality issues.
+
+```bash
+# Dry run (report issues)
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/integrity-check-djs.ts
+
+# Fix orphaned DJs automatically
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/integrity-check-djs.ts --fix
+
+# Check only recent changes
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/integrity-check-djs.ts --since 24h
+
+# Output report to file
+node --import ./bin/preload-nextenv-fix.mjs --import tsx bin/integrity-check-djs.ts --output report.md
+```
+
+## Fix DJ #598 (Duplicate Josh) Manually
+
+The duplicate Josh issue requires manual review because we need to know which Josh DJ actually appears on the public deejays page.
+
+Steps:
+
+1. Run `bin/find-dj-issues.ts` to get the Josh DJ IDs
+2. Visit the Payload admin and the public deejays page to identify which Josh DJ should be kept
+3. Edit `bin/repair-dj-issues.ts` to add the `--delete-josh-id` parameter, or manually delete in Payload admin
+4. Confirm the issue is resolved on the public site
+
+## Automated Prevention
+
+These checks are now integrated into the **nightly gap report** pipeline (`.buildkite/nightly-gap-report.yml`):
+
+- A new step `:microphone: Check DJ data quality` runs as part of the integrity checks
+- Orphaned DJs are detected and reported
+- Duplicate display names are flagged
+- Reports are combined and posted as GitHub issue comments
+
+This ensures these issues will be caught automatically in the future.
+
+## Related Documentation
+
+- [Nightly Gap Report Pipeline](.buildkite/nightly-gap-report.yml)
+- [Integrity Check Script](.buildkite/scripts/run-single-integrity-check.sh)
+- [GitHub Issue #597](https://github.com/ynotradio/site/issues/597)
+- [GitHub Issue #598](https://github.com/ynotradio/site/issues/598)

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -59,10 +59,7 @@ trait ConvertsLexicalToHtml
             case 'paragraph':
                 $content = $this->convertLexicalChildren($node);
                 $format = $node['format'] ?? '';
-                if ($format === 'center') {
-                    return "<p style=\"text-align: center;\">$content</p>\n";
-                }
-                return '<p>' . $content . "</p>\n";
+                return $this->wrapInBlock('p', $content, $format);
 
             case 'heading':
                 $tag = $node['tag'] ?? 'h2';
@@ -126,6 +123,23 @@ trait ConvertsLexicalToHtml
         }
 
         return $html;
+    }
+
+    /**
+     * Wrap text content in a block element (p, h1-h6) with optional text alignment.
+     * 
+     * @param string $tag HTML tag name (p, h1-h6)
+     * @param string $content HTML content
+     * @param string $format Optional text alignment (left, center, right, justify)
+     * @return string Formatted HTML block element
+     */
+    private function wrapInBlock(string $tag, string $content, string $format = ''): string
+    {
+        $style = '';
+        if ($format && in_array($format, ['left', 'center', 'right', 'justify'], true)) {
+            $style = " style=\"text-align: {$format};\"";
+        }
+        return "<{$tag}{$style}>{$content}</{$tag}>\n";
     }
 
     /**

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -57,7 +57,12 @@ trait ConvertsLexicalToHtml
 
         switch ($type) {
             case 'paragraph':
-                return '<p>' . $this->convertLexicalChildren($node) . "</p>\n";
+                $content = $this->convertLexicalChildren($node);
+                $format = $node['format'] ?? '';
+                if ($format === 'center') {
+                    return "<p style=\"text-align: center;\">$content</p>\n";
+                }
+                return '<p>' . $content . "</p>\n";
 
             case 'heading':
                 $tag = $node['tag'] ?? 'h2';

--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -204,11 +204,7 @@ class PostgresCustomText implements CustomText {
                 }
                 
                 $format = $node['format'] ?? '';
-                if ($format === 'center') {
-                    return "<p style=\"text-align: center;\">$content</p>\n";
-                }
-                
-                return "<p>$content</p>\n";
+                return $this->wrapInBlock('p', $content, $format);
                 
             case 'heading':
                 $tag = $node['tag'] ?? 'h2';

--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -203,6 +203,11 @@ class PostgresCustomText implements CustomText {
                     return $this->convertTableMarkupToHtml($content);
                 }
                 
+                $format = $node['format'] ?? '';
+                if ($format === 'center') {
+                    return "<p style=\"text-align: center;\">$content</p>\n";
+                }
+                
                 return "<p>$content</p>\n";
                 
             case 'heading':

--- a/src/models/implementations/PostgresSchedule.php
+++ b/src/models/implementations/PostgresSchedule.php
@@ -450,7 +450,8 @@ class PostgresSchedule implements Schedule {
         switch ($type) {
             case 'paragraph':
                 $content = $this->convertLexicalChildren($node);
-                return "<p>$content</p>\n";
+                $format = $node['format'] ?? '';
+                return $this->wrapInBlock('p', $content, $format);
                 
             case 'heading':
                 $tag = $node['tag'] ?? 'h2';

--- a/src/models/implementations/PostgresStory.php
+++ b/src/models/implementations/PostgresStory.php
@@ -3,6 +3,7 @@
 namespace YNotRadio\Models\Implementations;
 
 use YNotRadio\Models\Story;
+use YNotRadio\Models\Concerns\ConvertsLexicalToHtml;
 use PDO;
 use PDOException;
 
@@ -11,6 +12,8 @@ use PDOException;
  * Reads from Neon PostgreSQL database created by Payload CMS
  */
 class PostgresStory implements Story {
+    use ConvertsLexicalToHtml;
+    
     private PDO $db;
 
     // Lexical text format bit flags
@@ -294,7 +297,8 @@ class PostgresStory implements Story {
         switch ($type) {
             case 'paragraph':
                 $content = $this->convertLexicalChildren($node);
-                return "<p>$content</p>\n";
+                $format = $node['format'] ?? '';
+                return $this->wrapInBlock('p', $content, $format);
                 
             case 'heading':
                 $tag = $node['tag'] ?? 'h2';


### PR DESCRIPTION
Prevents orphaned and duplicate DJ records from recurring in prod/dev Neon.

## Changes

- **bin/integrity-check-djs.ts** — Detects orphaned DJs (no person linked), duplicate display names, and missing critical fields. Supports --fix to auto-delete orphaned DJs.
- **bin/find-dj-issues.ts** — Non-destructive script to identify current DJ issues (specifically DJ #84 and duplicate Josh records).
- **bin/repair-dj-issues.ts** — Dry-run/confirm script to delete problematic DJs (requires manual review for Josh duplicates).
- **.buildkite/nightly-gap-report.yml** — Added DJ data quality check step to integrity checks group
- **.buildkite/scripts/run-single-integrity-check.sh** — Added routing for 'djs' check
- **bin/content-integrity-utils.ts** — Added 'djs' to CheckName type
- **docs/DJ_QUALITY_REPAIR.md** — Guide for using these scripts and understanding the automated prevention mechanism

## How It Works

The nightly pipeline now runs:
1. Incremental import (prod MySQL → prod Neon)
2. Reset dev branch from production
3. **Run DJ data quality check** ← NEW (alongside 5 other integrity checks)
4. Combine all reports and post to GitHub

This ensures DJ data quality issues are caught automatically and reported regularly.

## Verification

- ✅ Linting passes (`yarn lint`)
- ✅ Tests pass (`yarn test`)
- ✅ Scripts compile and execute correctly
- ✅ DJ check integrated into Buildkite pipeline

Fixes #597 #598