### PR TITLE
fix: PostgresSchedule + PostgresCustomText fatal — missing wrapInBlock

### DIFF
--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -3,6 +3,7 @@
 namespace YNotRadio\Models\Implementations;
 
 use YNotRadio\Models\CustomText;
+use YNotRadio\Models\Concerns\ConvertsLexicalToHtml;
 use PDO;
 
 /**
@@ -10,6 +11,8 @@ use PDO;
  * Reads from Neon PostgreSQL database (posts collection, type='custom_text')
  */
 class PostgresCustomText implements CustomText {
+    use ConvertsLexicalToHtml;
+
     private PDO $db;
 
     // Lexical text format bit flags

--- a/src/models/implementations/PostgresSchedule.php
+++ b/src/models/implementations/PostgresSchedule.php
@@ -3,6 +3,7 @@
 namespace YNotRadio\Models\Implementations;
 
 use YNotRadio\Models\Schedule;
+use YNotRadio\Models\Concerns\ConvertsLexicalToHtml;
 use PDO;
 use PDOException;
 
@@ -11,6 +12,8 @@ use PDOException;
  * Reads from Neon PostgreSQL database created by Payload CMS
  */
 class PostgresSchedule implements Schedule {
+    use ConvertsLexicalToHtml;
+
     private PDO $db;
 
     // Lexical text format bit flags


### PR DESCRIPTION
## Changes

- Both `PostgresSchedule` and `PostgresCustomText` had local Lexical→HTML methods calling `$this->wrapInBlock()` but never defined the method, causing a fatal whenever a paragraph node was rendered.
- Imported the existing `ConvertsLexicalToHtml` trait (already used by `PostgresStory`, `PostgresOnDemand`, `PostgresCdOfTheWeek`, and now `PostgresDeejay` via #624).
- PHP class methods take precedence over trait methods, so the local `convertLexicalNodeToHtml` continues to run; only the missing `wrapInBlock` helper is inherited.

## Bug

```
Fatal error: Call to undefined method YNotRadio\Models\Implementations\PostgresSchedule::wrapInBlock()
in PostgresSchedule.php:454
```

This blocked `/schedule.php` entirely on the Postgres-backed site — a cutover blocker not previously filed as an issue.

## Verification

- `/schedule.php` on localhost:8080 against dev Neon now renders the full weekly schedule with no errors.
- Screenshot: `tmp/fix-schedule.png`

cc @tj-nicolaides