### PR TITLE
fix: realign legacy custom_text post slugs to match MySQL permalinks

### DIFF
--- a/bin/migrations/fixCustomTextSlugs.ts
+++ b/bin/migrations/fixCustomTextSlugs.ts
@@ -1,0 +1,110 @@
+/**
+ * Realign legacy custom_text post slugs in Postgres so they match the
+ * MySQL permalink (e.g. "donate", "quarantine-takeovers"). Earlier import
+ * runs prefixed slugs with a YYYY-MM-DD-- prefix which broke legacy PHP
+ * lookups in donate.php, the quarantine.php redirect, etc.
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Command } from 'commander';
+import mysql from 'mysql2/promise';
+import { getPayloadClient } from './shared/payloadClient';
+import { getLegacyDbConfig } from '../../config/databases';
+import { createLogger } from './shared/logger';
+
+const logger = createLogger('FixCustomTextSlugs');
+
+interface Options {
+  env: 'dev' | 'prod';
+  dryRun: boolean;
+}
+
+async function run(options: Options) {
+  logger.info(`Starting slug realignment (env=${options.env}, dryRun=${options.dryRun})`);
+
+  const cfg = getLegacyDbConfig();
+  const conn = await mysql.createConnection({
+    host: cfg.host,
+    port: cfg.port,
+    user: cfg.user,
+    password: cfg.password,
+    database: cfg.database,
+  });
+
+  const [rows] = await conn.execute<any[]>(
+    "SELECT id, permalink FROM custom_texts WHERE permalink IS NOT NULL AND permalink != '' AND status = 'active'",
+  );
+  await conn.end();
+
+  process.env.PAYLOAD_MIGRATING = 'true';
+  const payload = await getPayloadClient(options.env);
+
+  let updated = 0;
+  let alreadyOk = 0;
+  let notFound = 0;
+  let conflicts = 0;
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const r of rows) {
+    const legacyId = (r.id as number) + 10000;
+    const target = r.permalink as string;
+
+    // eslint-disable-next-line no-await-in-loop
+    const found = await payload.find({
+      collection: 'posts',
+      where: { legacyId: { equals: legacyId } },
+      limit: 1,
+    });
+    const post = found.docs[0];
+    if (!post) {
+      notFound++;
+    } else if (post.slug === target) {
+      alreadyOk++;
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      const conflict = await payload.find({
+        collection: 'posts',
+        where: { slug: { equals: target } },
+        limit: 1,
+      });
+      if (conflict.docs[0] && conflict.docs[0].id !== post.id) {
+        logger.warn(
+          `Conflict: post ${post.id} (legacyId ${legacyId}) wants slug "${target}" but it's already used by post ${conflict.docs[0].id}`,
+        );
+        conflicts++;
+      } else {
+        logger.info(
+          `Updating post ${post.id}: "${post.slug}" → "${target}" (legacyId ${legacyId})`,
+        );
+        if (!options.dryRun) {
+          // eslint-disable-next-line no-await-in-loop
+          await payload.update({
+            collection: 'posts',
+            id: post.id,
+            data: { slug: target },
+          });
+        }
+        updated++;
+      }
+    }
+  }
+
+  logger.info(
+    `Done. updated=${updated} alreadyOk=${alreadyOk} notFound=${notFound} conflicts=${conflicts}`,
+  );
+}
+
+const program = new Command();
+program
+  .option('--env <env>', 'dev or prod', 'dev')
+  .option('--dry-run', 'do not write changes', false)
+  .action(async (opts) => {
+    try {
+      await run({ env: opts.env, dryRun: !!opts.dryRun });
+      process.exit(0);
+    } catch (e) {
+      logger.error('Failed:', e);
+      process.exit(1);
+    }
+  });
+program.parse(process.argv);


### PR DESCRIPTION
## Changes

Adds `bin/migrations/fixCustomTextSlugs.ts` to repair legacy custom-text posts whose slugs were imported with a `YYYY-MM-DD--` prefix (e.g. `2000-01-01--support-y-not-radio` instead of `donate`).

Legacy PHP pages — `donate.php`, the `quarantine.php` redirect, and any page that does `findByPermalink()` — were returning the **'Oh, No!'** 404 fallback on the Postgres-backed site because they look up posts by the bare permalink.

The script walks every active `custom_text` in MySQL, finds the matching post in Payload by `legacyId`, and rewrites the slug to the original permalink. Supports `--dry-run` and detects conflicts.

## Verification

- ✅ Dry run on dev Neon: 34 candidates, 0 conflicts
- ✅ Live run on dev Neon: 34 posts updated
- ✅ `donate.php` now renders the full Support Y-Not Radio page (donation tiers, T-shirts, full Y-Not Sessions catalog)
- ✅ `/pages.php?page=quarantine-takeovers` resolves to content
- ✅ `yarn lint bin/migrations/fixCustomTextSlugs.ts` passes

## Screenshot

Donate page after fix:


cc @tj-nicolaides — needed for tomorrow's cutover. Closes/addresses #600 and #601.