### PR TITLE
fix: extend cutover-parity script with concert title + sold-out fixes (already applied to prod Neon)

### DIFF
--- a/bin/migrations/fixDeejaysAdmin.ts
+++ b/bin/migrations/fixDeejaysAdmin.ts
@@ -196,6 +196,210 @@ async function fixEmilyToEm(payload: any, dryRun: boolean): Promise<void> {
   }
 }
 
+/**
+ * Issue: Concert titles + sold-out status parity with prod (ynotradio.net).
+ *
+ * The legacy import left some concerts with NULL/empty `title` (so the public
+ * page shows just the artist names joined) and some with stale `ticket_info`
+ * (mostly missing SOLD OUT badges or stale "Tickets Available"). This applies
+ * the canonical mapping confirmed against legacy production for all currently
+ * visible concerts.
+ *
+ * Match by (date::date, venue.name) so timezone offsets in `concerts.date`
+ * (mixed 00:00 UTC vs 04:00 UTC) don't affect lookup. Idempotent: only writes
+ * when current value differs.
+ */
+interface ConcertFix {
+  date: string; // YYYY-MM-DD
+  venue: string;
+  title?: string;
+  ticketInfo?: string;
+}
+
+const CONCERT_FIXES: ConcertFix[] = [
+  // Title fixes (and combined title/ticket_info where applicable)
+  {
+    date: '2026-05-03',
+    venue: 'Ardmore Music Hall',
+    title: 'Brian Fallon (Sing Us Home After Party)',
+  },
+  { date: '2026-05-09', venue: 'First Unitarian Church', title: 'Gladie w/ Noun' },
+  { date: '2026-05-11', venue: 'Union Transfer', title: 'Iron & Wine' },
+  { date: '2026-05-12', venue: 'The Fillmore', title: 'Courtney Barnett w/ Momma' },
+  { date: '2026-05-15', venue: 'Ukie Club', title: 'Mal Blum and Oceanator' },
+  { date: '2026-05-15', venue: 'Ardmore Music Hall', title: 'Southern Culture on the Skids' },
+  { date: '2026-05-22', venue: 'Union Transfer', title: 'Toadies w/ Local H' },
+  { date: '2026-05-29', venue: 'PhilaMOCA', title: 'Tim Kasher (of Cursive)' },
+  { date: '2026-05-29', venue: "Johnny Brenda's", title: 'Just Mustard & Miss Grit' },
+  { date: '2026-05-31', venue: 'The Fillmore', title: 'Ben Folds and A Piano' },
+  {
+    date: '2026-06-06',
+    venue: 'TLA',
+    title: 'Pete Yorn (Musicforthemorningafter 25th Anniversary / Solo Acoustic)',
+  },
+  { date: '2026-06-08', venue: 'Mann Skyline Stage', title: 'Amyl and The Sniffers' },
+  {
+    date: '2026-06-23',
+    venue: 'Franklin Music Hall',
+    title: 'Black Country, New Road w/ Horsegirl',
+  },
+  {
+    date: '2026-06-23',
+    venue: 'The Fillmore',
+    title: 'Spoon & The Beths',
+    ticketInfo: 'Tickets Available',
+  },
+  { date: '2026-06-25', venue: 'Underground Arts', title: 'of Montreal' },
+  {
+    date: '2026-06-26',
+    venue: 'Mann Center',
+    title: 'The Strokes w/ Thundercat & Hamilton Leithauser',
+    ticketInfo: 'SOLD OUT',
+  },
+  { date: '2026-06-28', venue: 'The Met', title: 'The Human League w/ Soft Cell & Alison Moyet' },
+  { date: '2026-07-10', venue: 'Union Transfer', title: 'American Football w/ IAN SWEET' },
+  {
+    date: '2026-07-10',
+    venue: 'Kung Fu Necktie',
+    title: "Y-Not Radio's Swell 16 Celebration w/ WAAX and The Blackburns",
+  },
+  { date: '2026-07-15', venue: 'Xfinity Mobile Arena', title: 'Tame Impala w/ Djo' },
+  {
+    date: '2026-07-17',
+    venue: 'Borgata Event Center (Atlantic City)',
+    title: '"Weird Al" Yankovic',
+  },
+  {
+    date: '2026-07-17',
+    venue: 'Mann Center',
+    title: 'Death Cab For Cutie w/ Japanese Breakfast',
+    ticketInfo: 'Tickets Available',
+  },
+  { date: '2026-07-23', venue: 'Underground Arts', title: 'Man Man w/ Death Valley Girls' },
+  {
+    date: '2026-07-24',
+    venue: 'Dell Music Center',
+    title: 'Make The World Better Concert w/ Pavement and Ratboys',
+  },
+  {
+    date: '2026-07-25',
+    venue: 'Dell Music Center',
+    title: 'Make The World Better Concert w/ Kurt Vile and They Are Gutting A Body of Water',
+  },
+  { date: '2026-07-28', venue: 'The Met', title: 'Metric w/ Broken Social Scene and Stars' },
+  { date: '2026-08-01', venue: 'The Met', title: 'Tori Amos w/ Bartees Strange' },
+  {
+    date: '2026-08-04',
+    venue: 'Wind Creek Steel Stage (Bethlehem, PA)',
+    title: '"Weird Al" Yankovic',
+  },
+  {
+    date: '2026-08-13',
+    venue: 'Lincoln Financial Field',
+    title: 'Foo Fighters w/ Queens of The Stone Age & Mannequin Pussy',
+  },
+  {
+    date: '2026-09-05',
+    venue: 'Mann Center',
+    title: 'Empire of The Sun',
+    ticketInfo: 'Tickets Available',
+  },
+  {
+    date: '2026-09-06',
+    venue: 'Xfinity Mobile Arena',
+    title: 'Lily Allen (performing West End Girl)',
+    ticketInfo: 'Tickets Available',
+  },
+  {
+    date: '2026-09-29',
+    venue: 'Xfinity Mobile Arena',
+    title: 'Weezer w/ The Shins and Silversun Pickups',
+    ticketInfo: 'Tickets Available',
+  },
+  { date: '2026-11-07', venue: "Johnny Brenda's", title: 'Teen Jesus and The Jean Teasers' },
+  // Ticket-info-only fixes
+  { date: '2026-05-12', venue: 'The Foundry', ticketInfo: 'SOLD OUT' },
+  { date: '2026-05-15', venue: 'Union Transfer', ticketInfo: 'SOLD OUT' },
+  { date: '2026-05-16', venue: 'Union Transfer', ticketInfo: 'SOLD OUT' },
+  { date: '2026-05-17', venue: 'Union Transfer', ticketInfo: 'Tickets Available' },
+  { date: '2026-07-29', venue: 'Freedom Mortgage Pavilion', ticketInfo: 'Tickets Available' },
+  { date: '2026-09-25', venue: 'The Fillmore', ticketInfo: 'Tickets Available' },
+  { date: '2026-09-26', venue: 'The Fillmore', ticketInfo: 'Tickets Available' },
+  { date: '2026-10-12', venue: 'Union Transfer', ticketInfo: 'Tickets Available' },
+  { date: '2026-10-13', venue: 'Union Transfer', ticketInfo: 'Tickets Available' },
+];
+
+async function fixConcertTitlesAndStatuses(payload: any, dryRun: boolean): Promise<void> {
+  const db = payload.db.drizzle.session.client;
+  let updated = 0;
+  let skipped = 0;
+  let missing = 0;
+
+  for (const fix of CONCERT_FIXES) {
+    const { rows } = await db.query(
+      `SELECT c.id, c.title, c.ticket_info
+         FROM concerts c
+         JOIN venues v ON v.id = c.venue_id
+        WHERE c.date::date = $1::date AND v.name = $2 AND c._status = 'published'`,
+      [fix.date, fix.venue],
+    );
+    if (rows.length === 0) {
+      logger.warn(`MISSING concert ${fix.date} @ ${fix.venue} — skipping (legacy import gap).`);
+      missing += 1;
+    } else {
+      if (rows.length > 1) {
+        logger.warn(
+          `Multiple concerts on ${fix.date} @ ${fix.venue} (${rows.length}) — applying to all.`,
+        );
+      }
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const row of rows) {
+        const sets: string[] = [];
+        const params: any[] = [];
+        let p = 1;
+        const label = `concert id=${row.id} (${fix.date} @ ${fix.venue})`;
+
+        if (fix.title !== undefined && row.title !== fix.title) {
+          sets.push(`title = $${p}`);
+          params.push(fix.title);
+          p += 1;
+        }
+        if (fix.ticketInfo !== undefined && row.ticket_info !== fix.ticketInfo) {
+          sets.push(`ticket_info = $${p}`);
+          params.push(fix.ticketInfo);
+          p += 1;
+        }
+
+        if (sets.length === 0) {
+          logger.info(`${label} already correct — skip.`);
+          skipped += 1;
+        } else {
+          const summary = sets
+            .map((s) => s.split(' = ')[0])
+            .map((field) => {
+              if (field === 'title') return `title="${fix.title}" (was: ${row.title === null ? 'NULL' : `"${row.title}"`})`;
+              if (field === 'ticket_info') return `ticket_info="${fix.ticketInfo}" (was: "${row.ticket_info}")`;
+              return field;
+            })
+            .join(', ');
+
+          logger.info(`${label} → ${summary}`);
+          if (!dryRun) {
+            params.push(row.id);
+            await db.query(
+              `UPDATE concerts SET ${sets.join(', ')}, updated_at = NOW() WHERE id = $${p}`,
+              params,
+            );
+          }
+          updated += 1;
+        }
+      }
+    }
+  }
+  logger.info(`Concert fixes: ${updated} updated, ${skipped} already-correct, ${missing} missing.`);
+}
+
 async function run(options: Options) {
   logger.info(`Starting deejays admin fixes (env=${options.env}, dryRun=${options.dryRun})`);
   process.env.PAYLOAD_MIGRATING = 'true';
@@ -204,6 +408,7 @@ async function run(options: Options) {
   await fixJudyPhoto(payload, options.dryRun);
   await fixSortOrderSwap(payload, options.dryRun);
   await fixEmilyToEm(payload, options.dryRun);
+  await fixConcertTitlesAndStatuses(payload, options.dryRun);
   logger.info('Done.');
 }
 

--- a/bin/migrations/shared/payloadClient.ts
+++ b/bin/migrations/shared/payloadClient.ts
@@ -39,24 +39,36 @@ async function findDocBySlug(
 }
 
 function getDatabaseUri(target: PostgresTarget): string {
-  if (target === 'prod-neon') {
+  if (target === 'prod-neon' || target === 'prod') {
     const uri = process.env.NEON_PROD_DATABASE_URL;
-    if (!uri) throw new Error(`Database URI not found for target "${target}". Please set NEON_PROD_DATABASE_URL in .env.local`);
+    if (!uri) {
+      throw new Error(
+        `Database URI not found for target "${target}". Please set NEON_PROD_DATABASE_URL in .env.local`,
+      );
+    }
     return uri;
   }
-  if (target === 'dev-neon') {
+  if (target === 'dev-neon' || target === 'dev') {
     const uri = process.env.NEON_DEV_DATABASE_URL;
-    if (!uri) throw new Error(`Database URI not found for target "${target}". Please set NEON_DEV_DATABASE_URL in .env.local`);
+    if (!uri) {
+      throw new Error(
+        `Database URI not found for target "${target}". Please set NEON_DEV_DATABASE_URL in .env.local`,
+      );
+    }
     return uri;
   }
   const uri = process.env.NEON_DEV_DATABASE_URL || process.env.DATABASE_URI;
-  if (!uri) throw new Error(`Database URI not found for target "${target}". Please set NEON_DEV_DATABASE_URL or DATABASE_URI in .env.local`);
+  if (!uri) {
+    throw new Error(
+      `Database URI not found for target "${target}". Please set NEON_DEV_DATABASE_URL or DATABASE_URI in .env.local`,
+    );
+  }
   return uri;
 }
 
 export { getDatabaseUri };
 
-export type PostgresTarget = 'local-postgres' | 'prod-neon' | 'dev-neon';
+export type PostgresTarget = 'local-postgres' | 'prod-neon' | 'dev-neon' | 'dev' | 'prod';
 
 /**
  * Get the Payload instance configured for the specified target database
@@ -64,6 +76,12 @@ export type PostgresTarget = 'local-postgres' | 'prod-neon' | 'dev-neon';
  * @param target - 'prod-neon' for production Neon, 'local-postgres' for local/dev
  */
 export async function getPayloadClient(target: PostgresTarget = 'prod-neon'): Promise<Payload> {
+  // NOTE: Scripts that call this must run with
+  //   `yarn tsx --import ./bin/preload-nextenv-fix.mjs <script>.ts`
+  // Otherwise payload's collection imports transitively load `bin/loadEnv.js`,
+  // which crashes under tsx because of an @next/env default-export interop bug.
+  // See bin/preload-nextenv-fix.mjs for the full explanation.
+
   // Load environment variables from .env.local with override
   dotenv.config({
     path: path.resolve(process.cwd(), '.env.local'),
@@ -93,10 +111,7 @@ export async function getPayloadClient(target: PostgresTarget = 'prod-neon'): Pr
  * Find or create an artist by name
  * Returns the artist ID
  */
-export async function findOrCreateArtist(
-  payload: Payload,
-  name: string,
-): Promise<number> {
+export async function findOrCreateArtist(payload: Payload, name: string): Promise<number> {
   // Strip HTML tags from name
   const cleanName = stripHtmlTags(name);
 
@@ -158,7 +173,9 @@ export async function findOrCreateArtist(
     logger.debug(`Created artist: ${cleanName}`);
     return newArtist.id;
   } catch (error: any) {
-    logger.debug(`Error creating artist "${name}": status=${error.status}, errors=${JSON.stringify(error.data?.errors)}`);
+    logger.debug(
+      `Error creating artist "${name}": status=${error.status}, errors=${JSON.stringify(error.data?.errors)}`,
+    );
 
     const isMbidError = isFieldError(error, 'musicbrainzId');
     const isSlugError = isFieldError(error, 'slug');
@@ -172,7 +189,9 @@ export async function findOrCreateArtist(
         limit: 1,
       });
       if (retryExisting.docs.length > 0) {
-        logger.debug(`Found existing artist after race condition: "${name}" (id: ${retryExisting.docs[0].id})`);
+        logger.debug(
+          `Found existing artist after race condition: "${name}" (id: ${retryExisting.docs[0].id})`,
+        );
         return retryExisting.docs[0].id;
       }
     }
@@ -219,10 +238,7 @@ export async function findOrCreateArtist(
  * Find or create a venue by name
  * Returns the venue ID
  */
-export async function findOrCreateVenue(
-  payload: Payload,
-  name: string,
-): Promise<number> {
+export async function findOrCreateVenue(payload: Payload, name: string): Promise<number> {
   // Strip HTML tags from name
   const cleanName = stripHtmlTags(name);
 
@@ -328,10 +344,7 @@ export async function findOrCreatePerson(
  * Find a DJ by legacy ID
  * Returns the DJ ID or null if not found
  */
-export async function findDJByLegacyId(
-  payload: Payload,
-  legacyId: number,
-): Promise<number | null> {
+export async function findDJByLegacyId(payload: Payload, legacyId: number): Promise<number | null> {
   const existing = await payload.find({
     collection: 'djs',
     where: { legacyId: { equals: legacyId } },
@@ -363,10 +376,7 @@ export async function findOrCreateRecord(
   const existing = await payload.find({
     collection: 'records',
     where: {
-      and: [
-        { title: { equals: title } },
-        { artist: { equals: artistId } },
-      ],
+      and: [{ title: { equals: title } }, { artist: { equals: artistId } }],
     },
     limit: 1,
   });
@@ -398,7 +408,9 @@ export async function findOrCreateRecord(
       try {
         const artist = await payload.findByID({ collection: 'artists', id: artistId });
         artistName = artist?.name || '';
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
 
       const slug = generateMusicSlug(artistName, title);
       const id = await findDocBySlug(payload, 'records', slug);
@@ -514,7 +526,9 @@ export async function findOrCreateSong(
         try {
           const artist = await payload.findByID({ collection: 'artists', id: artistId });
           artistName = artist?.name || '';
-        } catch { /* ignore */ }
+        } catch {
+          /* ignore */
+        }
       }
 
       const slug = generateMusicSlug(artistName, cleanTitle);


### PR DESCRIPTION
## Changes

Extends `bin/migrations/fixDeejaysAdmin.ts` with `fixConcertTitlesAndStatuses()`, which folds the 42 manual concert fixes (33 titles + 9 ticket_info) into the same idempotent migration script that already handles the deejays-page parity fixes.

Lookup is by `(date::date, venue.name)` so timezone offsets in `concerts.date` (mixed 00:00 UTC vs 04:00 UTC after import) don't cause misses. Each row only writes if the current value differs. Safe to re-run.

Also fixes a silent bug in `payloadClient.getDatabaseUri()`: passing `--env prod` was falling through the `if/else` and using the dev DB URL. Added `'dev'` / `'prod'` as accepted `PostgresTarget` aliases. Removed an in-script `@next/env` interop hack and pointed at the existing `bin/preload-nextenv-fix.mjs` (scripts must run with `tsx --import ./bin/preload-nextenv-fix.mjs ...`).

## Status

Already applied to **prod Neon**:

- `Concert fixes: 42 updated, 0 already-correct, 0 missing.`

Re-run dry-run on prod afterwards confirms idempotency:

- `Concert fixes: 0 updated, 42 already-correct, 0 missing.`

Dev Neon was already correct (script was a no-op there).

## Verification

- [x] `yarn lint` exits 0
- [x] Dry-run + apply on prod Neon both succeed
- [x] Idempotent re-run reports all 42 already-correct

## Screenshot

Not applicable — DB-only change. Cutover smoke-test will use the next deploy of localhost:8080 / ynotradio.net post-cutover.