### PR TITLE
fix(netlify): re-add 'yes |' to unblock Payload migrate on CI

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,10 @@
 [build]
-  command = "yarn validate:migrations && yarn payload:migrate && yarn build"
+  # `yes |` auto-accepts Payload's "dev mode detected" interactive prompt,
+  # which defaults to No on non-interactive CI and silently skips pending
+  # migrations (causing the build to hang until Netlify times out).
+  # `--forceAcceptWarning` alone does NOT suppress this specific prompt.
+  # Do not remove the `yes |` prefix.
+  command = "yarn validate:migrations && yes | yarn payload:migrate && yarn build"
   publish = ".next"
   ignore = "./scripts/netlify-ignore.sh"
 


### PR DESCRIPTION
## Problem

Master has been failing every Netlify deploy since 01:43 UTC on 2026-05-04 (after the prod-Postgres cutover) with:

> Failed during stage 'building site': Command did not finish within the time limit

## Root cause

`netlify.toml` runs `yarn payload:migrate` (`payload migrate --forceAcceptWarning`). When Payload detects a `dev` push record (batch `-1`) in `payload_migrations`, it prompts interactively. `--forceAcceptWarning` does **not** suppress this specific prompt. With no stdin on Netlify CI, the command hangs until Netlify kills it.

This was previously fixed by commit `d5570e3` (Apr 7) which prefixed the migrate command with `yes |`. PR #487 (squash-merge `2a23ef3`, Mar 26) was branched from before that fix and silently dropped it on merge — squash-merge doesn't surface this as a conflict.

The regression was latent for ~6 weeks because the prod Neon DB had no `dev` push record. The cutover earlier tonight added one, and every deploy has hung since.

## Fix

Restore `yes |` and add an explanatory comment block ("Do not remove") so a future stale-branch squash-merge can't quietly drop it again.

```diff
-  command = "yarn validate:migrations && yarn payload:migrate && yarn build"
+  command = "yarn validate:migrations && yes | yarn payload:migrate && yarn build"
```

## Verification

- Latest successful master build (`70faeb2`, before the cutover added the dev push record): 393s — well under Netlify's limit.
- Once merged this should restore green deploys for both master and all open preview branches (including #637).

This is a one-line config change; no app code touched. Screenshot N/A.