### PR TITLE
Add label-triggered PR-to-prod deploy pipeline

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -7,6 +7,7 @@ Pipeline configurations for Y-Not Radio CI/CD.
 - **`pipeline.yml`** - Entry-point gate: checks for code changes, uploads `pipeline-ci.yml` if found, or skips for doc-only PRs
 - **`pipeline-ci.yml`** - Full CI steps: quality checks → tests → build → E2E (uploaded dynamically by `pipeline.yml`)
 - **`pipeline-deploy-legacy.yml`** - Legacy PHP site deploy: manual unblock gate → rsync + composer deploy to production (uploaded alongside `pipeline-ci.yml` on master pushes)
+- **`pipeline-deploy-pr.yml`** - PR-to-production deploy: triggered via Buildkite REST API by `.github/workflows/deploy-pr-on-label.yml` when a PR is labeled `deploy-to-prod` (no CI gate, no branch filter — deploys exactly the PR head SHA)
 - **`build-images.yml`** - Docker image building → GHCR (triggers on push to main)
 - **`scheduled-db-sync.yml`** - Weekly prod→dev Neon branch reset (Monday 2 AM UTC, safety net)
 - **`nightly-gap-report.yml`** - Nightly import + gap report + dev branch reset: imports from prod MySQL → Neon, resets dev branch from prod, posts import summary and gap report
@@ -112,14 +113,38 @@ Automatically appended to every master-push build by `check-changes.sh`. No sepa
 
 **Required secrets** (add via Buildkite UI → Pipeline Settings → Secrets):
 
-| Secret | Description |
-|---|---|
-| `DEPLOY_SSH_KEY` | SSH private key for the production server (`bitnami` user) |
-| `DEPLOY_SSH_HOST` | Production server hostname or IP address |
+| Secret                   | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| `DEPLOY_SSH_KEY`         | SSH private key for the production server (`bitnami` user)           |
+| `DEPLOY_SSH_HOST`        | Production server hostname or IP address                             |
 | `DEPLOY_SSH_KNOWN_HOSTS` | Known-hosts entry for the server (get with `ssh-keyscan <hostname>`) |
-| `ENV_PHP_CONTENTS` | Full contents of the production `.env.php` file |
+| `ENV_PHP_CONTENTS`       | Full contents of the production `.env.php` file                      |
 
 > **Note:** `bin/deploy.sh` and `bin/pre-deploy.sh` continue to work unchanged for local manual deploys.
+
+### PR-to-Production Deploy Pipeline
+
+Lets you deploy any PR's head commit to production by applying the
+`deploy-to-prod` label on GitHub. Skips CI and branch filters — use with care.
+
+**One-time setup:**
+
+1. New Buildkite pipeline: "Y-Not Radio - Deploy PR"
+   - Slug: `y-not-radio-deploy-pr` (must match the slug used by the GitHub workflow)
+   - Repository: `https://github.com/ynotradio/site`
+   - Configuration path: `.buildkite/pipeline-deploy-pr.yml`
+   - Disable webhooks (this pipeline is triggered exclusively via the REST API)
+   - Add the same four `DEPLOY_*` / `ENV_PHP_CONTENTS` secrets as the legacy deploy pipeline
+2. Create a Buildkite REST API token with `write_builds` scope
+3. Add it to the GitHub repo as the `BUILDKITE_API_TOKEN` Actions secret
+4. Create the `deploy-to-prod` label in the GitHub repo
+
+**How it works:**
+
+1. Apply the `deploy-to-prod` label to any open PR
+2. `.github/workflows/deploy-pr-on-label.yml` POSTs to the Buildkite REST API to create a build at the PR head SHA
+3. The Buildkite pipeline runs `deploy-legacy.sh` (same script as the master deploy)
+4. The workflow removes the label so re-applying re-triggers the deploy, and comments on the PR with the build URL
 
 ## Troubleshooting
 

--- a/.buildkite/pipeline-deploy-legacy.yml
+++ b/.buildkite/pipeline-deploy-legacy.yml
@@ -32,5 +32,9 @@ steps:
       - docker#v5.11.0:
           image: "composer:2"
           propagate-environment: true
+          # Required: deploy-legacy.sh shells out to `buildkite-agent secret get`
+          # to read DEPLOY_SSH_KEY/DEPLOY_SSH_HOST/DEPLOY_SSH_KNOWN_HOSTS/ENV_PHP_CONTENTS.
+          # docker plugin v5 defaults this to false; without it the script exits 127.
+          mount-buildkite-agent: true
     agents:
       queue: "default"

--- a/.buildkite/pipeline-deploy-pr.yml
+++ b/.buildkite/pipeline-deploy-pr.yml
@@ -1,0 +1,25 @@
+# PR-to-Production Deploy Pipeline
+#
+# Triggered via the Buildkite REST API by the GitHub Actions workflow
+# .github/workflows/deploy-pr-on-label.yml when a PR is labeled
+# `deploy-to-prod`. The workflow passes the PR's head SHA so this pipeline
+# deploys exactly that commit — no CI gate, no branch filter.
+#
+# Configure the Buildkite pipeline (e.g. y-not-radio-deploy-pr) to read
+# its steps from this file. Reuses deploy-legacy.sh so the deploy logic
+# stays in one place.
+#
+# Required Buildkite secrets (same as pipeline-deploy-legacy.yml):
+#   DEPLOY_SSH_KEY, DEPLOY_SSH_HOST, DEPLOY_SSH_KNOWN_HOSTS, ENV_PHP_CONTENTS
+
+steps:
+  - label: ":rocket: Deploy PR to Production"
+    key: "deploy-pr"
+    command: "bash .buildkite/scripts/deploy-legacy.sh"
+    plugins:
+      - docker#v5.11.0:
+          image: "composer:2"
+          propagate-environment: true
+          mount-buildkite-agent: true
+    agents:
+      queue: "default"

--- a/.github/workflows/deploy-pr-on-label.yml
+++ b/.github/workflows/deploy-pr-on-label.yml
@@ -1,0 +1,90 @@
+name: Deploy PR to production
+
+# When a PR is labeled `deploy-to-prod`, trigger a Buildkite build on the
+# y-not-radio-deploy-pr pipeline at the PR's head SHA. The label is
+# removed afterward so re-applying it triggers another deploy.
+#
+# Requires the repo secret BUILDKITE_API_TOKEN (Buildkite REST API token
+# with `write_builds` scope, scoped to the y-not-radio-deploy-pr pipeline).
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  deploy:
+    if: github.event.label.name == 'deploy-to-prod'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Buildkite deploy build
+        id: trigger
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          payload=$(jq -n \
+            --arg commit "$PR_SHA" \
+            --arg branch "$PR_REF" \
+            --arg message "Deploy PR #${PR_NUMBER}: ${PR_TITLE} (labeled by @${ACTOR})" \
+            --arg author_name "$PR_USER" \
+            --arg author_email "${PR_USER}@users.noreply.github.com" \
+            --arg pr "$PR_NUMBER" \
+            '{commit: $commit, branch: $branch, message: $message,
+              author: {name: $author_name, email: $author_email},
+              env: {DEPLOY_PR_NUMBER: $pr}}')
+          response=$(curl -fsS -X POST \
+            "https://api.buildkite.com/v2/organizations/tj-nicolaides/pipelines/y-not-radio-deploy-pr/builds" \
+            -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          web_url=$(echo "$response" | jq -r '.web_url')
+          echo "Triggered Buildkite build: $web_url"
+          echo "web_url=$web_url" >> "$GITHUB_OUTPUT"
+
+      - name: Remove deploy label
+        if: always() && steps.trigger.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'deploy-to-prod',
+            });
+
+      - name: Comment on PR
+        if: steps.trigger.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          BUILD_URL: ${{ steps.trigger.outputs.web_url }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `🚀 Production deploy triggered for this PR's head commit.\n\nBuildkite build: ${process.env.BUILD_URL}`,
+            });
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `❌ Failed to trigger production deploy from label. Check the workflow run for details.`,
+            });


### PR DESCRIPTION
## Changes

- **New `.buildkite/pipeline-deploy-pr.yml`** — single-step pipeline that runs `deploy-legacy.sh` against whatever commit the Buildkite REST API was given. No CI gate, no branch filter — caller controls what gets deployed.
- **New `.github/workflows/deploy-pr-on-label.yml`** — when a PR is labeled `deploy-to-prod`, POSTs to the Buildkite REST API to trigger the pipeline at the PR head SHA, then removes the label (so re-applying re-triggers) and comments on the PR with the build URL.
- **Fix `pipeline-deploy-legacy.yml`** — add `mount-buildkite-agent: true` to the docker plugin. Without it `deploy-legacy.sh`'s `buildkite-agent secret get` calls exit 127 inside the composer container.
- **Update `.buildkite/README.md`** — documents the new pipeline, required secrets (`BUILDKITE_API_TOKEN` Actions secret + the four `DEPLOY_*`/`ENV_PHP_CONTENTS` Buildkite secrets), the `deploy-to-prod` label, and the trigger-and-cleanup flow.

## Verification

- YAML files lint cleanly; pipeline reuses the already-tested `deploy-legacy.sh`.
- Manual end-to-end test requires the Buildkite pipeline + API token to exist (one-time setup is in the README diff).
- No code paths in the running site change. CI on this PR exercises the GitHub Actions workflow's syntax.

## Setup checklist (after merge)

- [ ] Create Buildkite pipeline `y-not-radio-deploy-pr` pointing at `.buildkite/pipeline-deploy-pr.yml`, webhooks disabled, with the four deploy secrets.
- [ ] Create Buildkite REST API token (`write_builds` scope) and add as `BUILDKITE_API_TOKEN` repo secret.
- [ ] Create `deploy-to-prod` label on this repo.
