### PR TITLE
Auto-deploy master pushes to production

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -6,7 +6,7 @@ Pipeline configurations for Y-Not Radio CI/CD.
 
 - **`pipeline.yml`** - Entry-point gate: checks for code changes, uploads `pipeline-ci.yml` if found, or skips for doc-only PRs
 - **`pipeline-ci.yml`** - Full CI steps: quality checks → tests → build → E2E (uploaded dynamically by `pipeline.yml`)
-- **`pipeline-deploy-legacy.yml`** - Legacy PHP site deploy: manual unblock gate → rsync + composer deploy to production (uploaded alongside `pipeline-ci.yml` on master pushes)
+- **`pipeline-deploy-legacy.yml`** - Legacy PHP site deploy: rsync + composer deploy to production, runs automatically after CI passes on master pushes (uploaded alongside `pipeline-ci.yml`)
 - **`pipeline-deploy-pr.yml`** - PR-to-production deploy: triggered via Buildkite REST API by `.github/workflows/deploy-pr-on-label.yml` when a PR is labeled `deploy-to-prod` (no CI gate, no branch filter — deploys exactly the PR head SHA)
 - **`build-images.yml`** - Docker image building → GHCR (triggers on push to main)
 - **`scheduled-db-sync.yml`** - Weekly prod→dev Neon branch reset (Monday 2 AM UTC, safety net)
@@ -101,10 +101,10 @@ Automatically appended to every master-push build by `check-changes.sh`. No sepa
 1. Merge a PR to `master` in the GitHub app (works from mobile 📱)
 2. Buildkite picks up the push, runs full CI (`pipeline-ci.yml`)
 3. The deploy pipeline (`pipeline-deploy-legacy.yml`) is uploaded at the same time
-4. A **block step** ("🚀 Deploy legacy site to production?") pauses the deploy until you manually unblock it from the Buildkite web UI or mobile app
-5. After unblocking, the deploy step (via `.buildkite/scripts/deploy-legacy.sh`):
+4. Once `eslint`, `vitest`, `php-lint`, and `php-test` all pass, the deploy step runs automatically — no manual unblock. (A red CI build blocks the deploy via `depends_on`.)
+5. The deploy step (via `.buildkite/scripts/deploy-legacy.sh`):
    - Installs `rsync` and `openssh-client` in the `composer:2` container
-   - Fetches `DEPLOY_SSH_KEY`, `DEPLOY_SSH_HOST`, `DEPLOY_SSH_KNOWN_HOSTS`, and `ENV_PHP_CONTENTS` from Buildkite secrets
+   - Reads `DEPLOY_SSH_KEY`, `DEPLOY_SSH_HOST`, `DEPLOY_SSH_KNOWN_HOSTS`, and `ENV_PHP_CONTENTS` from env vars (fetched in the agent's pre-command hook from Buildkite secrets)
    - Runs `composer install --no-dev` locally in `src/`
    - Creates a timestamped backup of `htdocs` on the server (keeps latest 15)
    - Rsyncs `src/` to `~/htdocs/` on the production server

--- a/.buildkite/pipeline-deploy-legacy.yml
+++ b/.buildkite/pipeline-deploy-legacy.yml
@@ -1,32 +1,26 @@
 # Legacy PHP Site — Production Deploy Pipeline
 #
 # Uploaded alongside pipeline-ci.yml for non-PR (master push) builds by
-# check-changes.sh. The block step depends on all CI checks passing, so
-# it only becomes unblockable after a green build.
-#
-# Mobile workflow: merge PR in GitHub app → CI runs → tap "Unblock" in
-# Buildkite app → deploy runs automatically.
+# check-changes.sh. The deploy step depends on all CI checks passing,
+# so a red CI build blocks the deploy automatically. There's no manual
+# unblock gate — green master == prod deploy. (Same model as the
+# label-triggered PR deploy in pipeline-deploy-pr.yml.)
 #
 # Required Buildkite secrets (set via Buildkite UI → Pipelines → Secrets):
 #   DEPLOY_SSH_KEY          — SSH private key for the production server
 #   DEPLOY_SSH_HOST         — Production server hostname or IP
 #   DEPLOY_SSH_KNOWN_HOSTS  — Known-hosts entry (get with: ssh-keyscan <hostname>)
-#   ENV_PHP_CONTENTS        — Full contents of the production .env.php file
+#   ENV_PHP_CONTENTS        — Full contents of the production .env file
 
 steps:
-  - block: ":rocket: Deploy legacy site to production?"
-    key: "deploy-legacy-gate"
+  - label: ":rocket: Deploy Legacy PHP Site"
+    key: "deploy-legacy"
+    branches: "master"
     depends_on:
       - "eslint"
       - "vitest"
       - "php-lint"
       - "php-test"
-    branches: "master"
-
-  - label: ":rocket: Deploy Legacy PHP Site"
-    key: "deploy-legacy"
-    depends_on: "deploy-legacy-gate"
-    branches: "master"
     command: "bash .buildkite/scripts/deploy-legacy.sh"
     plugins:
       - docker#v5.11.0:

--- a/payload/src/collections/Posts.test.ts
+++ b/payload/src/collections/Posts.test.ts
@@ -153,6 +153,7 @@ describe('Posts', () => {
       editor?: { _config?: { features?: (args: { defaultFeatures: unknown[] }) => unknown[] } };
     };
 
+    // eslint-disable-next-line no-underscore-dangle -- Payload uses `_config` internally
     const featuresCallback = contentField?.editor?._config?.features;
     expect(typeof featuresCallback).toBe('function');
 


### PR DESCRIPTION
## Changes

Drops the manual unblock gate from `pipeline-deploy-legacy.yml`. Master pushes now auto-deploy to production once CI is green.

- The deploy step still `depends_on` `eslint`, `vitest`, `php-lint`, `php-test`, so a red CI build blocks the deploy automatically.
- This matches the label-triggered PR deploy pipeline (`pipeline-deploy-pr.yml`) — same proven path as build #5 that just shipped #654.
- README updated to remove references to the unblock step.

## Verification

- [x] yaml diff is just removing the `block` step + reparenting the deploy step's `depends_on` to the CI keys directly
- [x] Will be exercised live the next time this PR (or any other) merges to master

## Why no screenshot

This is a Buildkite-only config change with no visible UI. The next master deploy itself will be the proof.

Co-authored-by: Copilot