### PR TITLE
fix(buildkite): fetch deploy secrets on CI pipeline runs

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -46,7 +46,7 @@ fi
 # plugin's container via propagate-environment. The new `buildkite-agent
 # secret get` API needs the per-job Unix socket which isn't mounted into
 # plugin containers, so it can't run inside docker.
-if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == *"deploy"* ]]; then
+if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == *"deploy"* ]] || [[ "${BUILDKITE_STEP_KEY:-}" == *"deploy"* ]]; then
   DEPLOY_SSH_KEY=$(buildkite-agent secret get DEPLOY_SSH_KEY 2>/dev/null || true)
   DEPLOY_SSH_KNOWN_HOSTS=$(buildkite-agent secret get DEPLOY_SSH_KNOWN_HOSTS 2>/dev/null || true)
   DEPLOY_SSH_HOST=$(buildkite-agent secret get DEPLOY_SSH_HOST 2>/dev/null || true)


### PR DESCRIPTION
## Why build 1361 failed

When PR #656 merged, master built on the `y-not-radio-ci` pipeline. `check-changes.sh` then uploaded the deploy step from `pipeline-deploy-legacy.yml`, but that step **runs as part of `y-not-radio-ci`**, so `BUILDKITE_PIPELINE_SLUG=y-not-radio-ci` (not `*deploy*`).

The pre-command hook only fetched `DEPLOY_SSH_KEY` & friends when the slug matched `*deploy*`, so it skipped them, and `deploy-legacy.sh` exited with `DEPLOY_SSH_KEY env var missing`.

## Fix

Also match on `BUILDKITE_STEP_KEY=deploy-legacy` (or any step whose key contains `deploy`). One-line change.

## Verification

The `pipeline-deploy-pr.yml` slug is `y-not-radio-deploy-pr` so it still matches the slug branch — label-triggered deploys keep working. After this merges, re-running build 1361 (or any future master push) will pick up the secrets correctly.