### PR TITLE
fix: remove top margin on .feature-box h3 to prevent disconnected header gap

### DIFF
--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -202,7 +202,7 @@ nav a:hover {
   color: white;
   font-size: 14px;
   line-height: 1.4;
-  margin: 10px 0;
+  margin: 0 0 10px;
   padding: 3px 6px;
   text-shadow: 0.1em 0.1em black;
   word-break: break-word;


### PR DESCRIPTION
## Changes

- Change `.feature-box h3 { margin: 10px 0 }` → `margin: 0 0 10px` in `src/style/typography.css`.

## Why

PR #605 added `container-type: inline-size` to `.feature-box`. That establishes a new formatting context, which **suppresses margin collapse** between the parent and its first child. The h3's previously-collapsing top margin now renders as a real 10px gap above the red header bar — the feature-box's grey background and box-shadow show all around the header, making each story look like two separately-bordered boxes (red header floating above a grey body) instead of a unified box.

This shipped silently because deploys had been disabled at the manual gate, so #605 only reached prod with the recent auto-deploy.

## Verification

- [x] `yarn lint` exits 0
- [x] `yarn test` exits 0 (2187 passed)
- [x] Visually verified locally — all 8 stories on the home page render with the red header flush to the top of the box again.

## Note for merging

PR #657 (Buildkite hook fix) needs to merge first, otherwise the auto-deploy step on master will fail with the same `DEPLOY_SSH_KEY env var missing` error.

## Screenshot

After (local, with this fix) — header now flush with parent box. Local screenshots `local-fb-fixed-830.png` and `local-home-fixed-full.png` saved in working tree.
