### PR TITLE
deploy: preserve production USE_POSTGRES_* flag values on deploy

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -29,12 +29,61 @@ rsync -avz --delete \
     --rsync-path="sudo rsync" \
     src/ ynotradio:~/htdocs/
 
-# Copy the .env file from root .env.php to server .env
-echo "🔑 Copying .env file..."
+# Copy the .env file from root .env.php to server .env, preserving
+# production's USE_POSTGRES_* feature flag values. Content managers
+# control these flags directly on the server; without this merge, every
+# deploy would clobber them with whatever the developer happens to have
+# locally (the regression that prompted this script change).
+echo "🔑 Merging .env (preserving production USE_POSTGRES_* flags)..."
+mkdir -p tmp
+MERGED_ENV="tmp/.env.deploy.$$"
+REMOTE_FLAGS_FILE="tmp/.env.remote-flags.$$"
+trap 'rm -f "$MERGED_ENV" "$REMOTE_FLAGS_FILE"' EXIT
+
+ssh ynotradio 'sudo grep "^USE_POSTGRES_" /opt/bitnami/apache/htdocs/.env 2>/dev/null' > "$REMOTE_FLAGS_FILE" || true
+
+if [ ! -s "$REMOTE_FLAGS_FILE" ]; then
+    echo "  ⚠️  No remote .env found (or no USE_POSTGRES_* flags in it). Pushing local .env.php as-is."
+    cp .env.php "$MERGED_ENV"
+else
+    echo "  Preserving the following production flag values:"
+    sed 's/^/    /' "$REMOTE_FLAGS_FILE"
+    awk '
+        NR == FNR {
+            idx = index($0, "=")
+            if (idx > 0) remote[substr($0, 1, idx-1)] = substr($0, idx+1)
+            next
+        }
+        {
+            idx = index($0, "=")
+            if (idx > 0) {
+                k = substr($0, 1, idx-1)
+                if (k in remote) {
+                    print k "=" remote[k]
+                    delete remote[k]
+                    next
+                }
+            }
+            print
+        }
+        END {
+            # Any production flags that no longer exist in local .env.php are
+            # dropped intentionally (e.g., when a feature flag is retired).
+            for (k in remote) {
+                print "  ℹ️  dropping " k " (no longer defined in .env.php)" > "/dev/stderr"
+            }
+        }
+    ' "$REMOTE_FLAGS_FILE" .env.php > "$MERGED_ENV"
+fi
+
+# Back up the current production .env before overwriting, so a botched
+# deploy can be reverted with a one-line ssh command.
+ssh ynotradio 'sudo cp /opt/bitnami/apache/htdocs/.env /opt/bitnami/apache/htdocs/.env.predeploy 2>/dev/null || true'
+
 rsync -avz \
     --chmod=F644 \
     --rsync-path="sudo rsync" \
-    .env.php ynotradio:~/htdocs/.env
+    "$MERGED_ENV" ynotradio:~/htdocs/.env
 
 # Run composer install on the server with correct permissions
 echo "📦 Running composer install on server..."

--- a/docs/DEPLOYMENT_SAFETY.md
+++ b/docs/DEPLOYMENT_SAFETY.md
@@ -8,39 +8,31 @@ This checklist ensures the production PHP site remains stable and can roll back 
 
 ## Pre-Deployment Checks
 
-### 1. Verify Feature Flags (MOST IMPORTANT)
+### 1. Feature Flags Are Server-Managed
 
-Check the production `.env` file (deployed from `.env.php` via `bin/deploy.sh`):
+As of the `bin/deploy.sh` merge-instead-of-replace change, deploys
+**preserve** whatever `USE_POSTGRES_*` values are currently in the
+production `.env`. Your local `.env.php` flag values are ignored at
+deploy time — only secrets and other config keys are pushed.
 
-```bash
-ssh ynotradio 'cat ~/htdocs/.env | grep USE_POSTGRES'
-```
-
-**MUST be:**
-
-```
-USE_POSTGRES_CONCERTS=false
-USE_POSTGRES_ONDEMAND=false
-USE_POSTGRES_DEEJAYS=false
-USE_POSTGRES_MUSIC=false
-USE_POSTGRES_STORIES=false
-USE_POSTGRES_CDOFTHEWEEK=false
-USE_POSTGRES_SCHEDULE=false
-USE_POSTGRES_CUSTOMTEXT=false
-```
-
-❌ **If ANY are `true`, STOP. Production will break.**
-
-### 2. Verify Local Changes Don't Include Postgres Flags
+To inspect or change a flag, edit the production `.env` directly:
 
 ```bash
-# In your local repo, before deploying
-git diff main .env.php | grep USE_POSTGRES
+ssh ynotradio 'sudo cat /opt/bitnami/apache/htdocs/.env | grep USE_POSTGRES'
+
+# To flip a flag:
+ssh ynotradio 'sudo sed -i "s/^USE_POSTGRES_FOO=.*/USE_POSTGRES_FOO=true/" /opt/bitnami/apache/htdocs/.env'
 ```
 
-**Should return nothing** (no changes to postgres flags)
+A full pre-deploy backup is automatically saved to
+`/opt/bitnami/apache/htdocs/.env.predeploy` on every deploy, so you
+can roll back the env file with one command if a deploy goes wrong:
 
-### 3. Check Database Connections
+```bash
+ssh ynotradio 'sudo cp /opt/bitnami/apache/htdocs/.env.predeploy /opt/bitnami/apache/htdocs/.env'
+```
+
+### 2. Check Database Connections
 
 **Production PHP must connect to:**
 
@@ -52,7 +44,7 @@ ssh ynotradio 'cat ~/htdocs/.env | grep DB_HOST'
 
 **Should be:** Production MySQL hostname (NOT `mysql` or `localhost`)
 
-### 4. Verify No Payload/Next.js Files in PHP Directory
+### 3. Verify No Payload/Next.js Files in PHP Directory
 
 ```bash
 ssh ynotradio 'ls ~/htdocs/.env* 2>/dev/null'


### PR DESCRIPTION
## Problem

`bin/deploy.sh` line 37 unconditionally rsynced the developer's local `.env.php` over production's `/opt/bitnami/apache/htdocs/.env` on every deploy. Production feature flag values were therefore whatever the last deployer happened to have on disk — and since `.env.php.example` ships with all `USE_POSTGRES_*` flags `false`, any developer who recreated their `.env.php` from the template would silently roll prod back to all-MySQL on their next deploy.

This is exactly what happened on May 4 (`.env.bak3` on prod) and again on May 8 (only `MUSIC=true` survived because PR #654 happened to flip it back). Content managers reported the regression today.

## Fix

Change the deploy step to **merge** instead of replace:

1. Fetch the current production `USE_POSTGRES_*` lines via ssh.
2. Build a merged `.env` locally that uses local `.env.php` as the base for all keys EXCEPT `USE_POSTGRES_*`, which take their value from prod.
3. Rsync the merged file to the server.

Edge cases handled:

- **First deploy to a server with no `.env`:** falls back to plain copy of local `.env.php`.
- **New flag added locally but not yet on prod:** added with the local default value.
- **Flag retired from local but still on prod:** dropped, with a `stderr` notice so the operator sees it.

Also adds a `.env.predeploy` backup written on every deploy, so a botched env push can be reverted with one ssh command:

```bash
ssh ynotradio 'sudo cp /opt/bitnami/apache/htdocs/.env.predeploy /opt/bitnami/apache/htdocs/.env'
```

## Verification

Dry-ran the merge logic against current prod state. Local `.env.php` has all flags `true`; prod has `STORIES`/`SCHEDULE`/`CUSTOMTEXT` = `false`. The diff between merged-output and local `.env.php` is exactly those three lines and nothing else — secrets, comments, ordering all preserved:

```
< USE_POSTGRES_STORIES=false       (from prod, preserved)
> USE_POSTGRES_STORIES=true        (local, ignored)
< USE_POSTGRES_SCHEDULE=false
> USE_POSTGRES_SCHEDULE=true
< USE_POSTGRES_CUSTOMTEXT=false
> USE_POSTGRES_CUSTOMTEXT=true
```

`bash -n bin/deploy.sh` passes (no shellcheck installed in the dev env, but script syntax is valid).

## Docs

`docs/DEPLOYMENT_SAFETY.md`: removed the obsolete "all flags must be `false` locally before deploying" pre-deploy gate; added a section explaining flags are now server-managed, including the rollback command.

## Related

- Restored prod flags manually before this PR (already live): `CONCERTS`/`ONDEMAND`/`DEEJAYS`/`MUSIC`/`CDOFTHEWEEK`/`MADNESS`=true; `STORIES`/`SCHEDULE`/`CUSTOMTEXT`=false.
- Original incident traced to: `.env.bak3` (May 4 10:43, all-false reset) and partial restore on May 8 (only `MUSIC` flipped back via #654).
