### PR TITLE
fix: mobile front-page story order without breaking desktop layout

### DIFF
--- a/e2e/front-page-headlines.spec.ts
+++ b/e2e/front-page-headlines.spec.ts
@@ -119,3 +119,93 @@ test.describe('Front-page headline font sizes', () => {
     expect(postgresCount).toBeGreaterThan(0);
   });
 });
+
+/**
+ * Regression coverage for the front-page two-column story layout.
+ *
+ * History: PR #670 replaced the two-column DOM with a CSS Grid container,
+ * which forced row-aligned heights on desktop (visual regression). PR #672
+ * reverted that. This suite locks in the desired behaviour:
+ *
+ *  - Desktop (≥960px): two columns flow independently — at least one
+ *    (left, right) pair of feature-boxes has DIFFERENT y-positions
+ *    (would fail under a row-major CSS grid).
+ *  - Mobile (≤959px): feature-boxes render in strict priority order,
+ *    achieved via `display: contents` on the column wrappers + inline
+ *    flex `order` on each `.feature-box`.
+ */
+test.describe('Front-page story layout', () => {
+  type Box = { x: number; y: number; priority: number };
+
+  async function getStoryBoxes(page: import('@playwright/test').Page): Promise<Box[]> {
+    return page.evaluate(() => {
+      const els = document.querySelectorAll('.stories-container .feature-box');
+      return Array.from(els).map((el) => {
+        const r = (el as HTMLElement).getBoundingClientRect();
+        return {
+          x: Math.round(r.x),
+          y: Math.round(r.y),
+          priority: Number((el as HTMLElement).dataset.priority ?? '0'),
+        };
+      });
+    });
+  }
+
+  (['mysql', 'postgres'] as const).forEach((backend) => {
+    const url = backend === 'postgres'
+      ? `${LEGACY_BASE_URL}/?ff=use_postgres_stories`
+      : `${LEGACY_BASE_URL}/`;
+
+    test.describe(`${backend} backend`, () => {
+      test.describe('desktop @ 1440×900 — independent column flow', () => {
+        test.use({ viewport: { width: 1440, height: 900 } });
+
+        test('feature-boxes form two columns whose heights are NOT row-aligned', async ({
+          page,
+        }) => {
+          await gotoPhp(page, url);
+          await expect(page.locator('.stories-container .feature-box').first()).toBeVisible();
+
+          const boxes = await getStoryBoxes(page);
+          expect(boxes.length).toBeGreaterThanOrEqual(2);
+
+          // Exactly two distinct x-positions (two columns).
+          const xs = [...new Set(boxes.map((b) => b.x))].sort((a, b) => a - b);
+          expect(xs.length).toBe(2);
+
+          // Independent column flow: at least one (left, right) pair must have
+          // different y-positions. Under a row-major CSS grid (the PR #670
+          // regression) every left/right pair would share a y. We assert that
+          // the second left-column box and the second right-column box do NOT
+          // share the same y — the column heights flow independently.
+          const left = boxes.filter((b) => b.x === xs[0]).sort((a, b) => a.y - b.y);
+          const right = boxes.filter((b) => b.x === xs[1]).sort((a, b) => a.y - b.y);
+          expect(left.length).toBeGreaterThanOrEqual(2);
+          expect(right.length).toBeGreaterThanOrEqual(2);
+          expect(Math.abs(left[1].y - right[1].y)).toBeGreaterThan(5);
+        });
+      });
+
+      test.describe('mobile @ 375×800 — strict priority order', () => {
+        test.use({ viewport: { width: 375, height: 800 } });
+
+        test('feature-boxes render top-to-bottom in ascending priority', async ({ page }) => {
+          await gotoPhp(page, url);
+          await expect(page.locator('.stories-container .feature-box').first()).toBeVisible();
+
+          const boxes = await getStoryBoxes(page);
+          expect(boxes.length).toBeGreaterThanOrEqual(2);
+
+          // All in a single column on mobile.
+          const xs = [...new Set(boxes.map((b) => b.x))];
+          expect(xs.length).toBe(1);
+
+          // Sorted by visual y-position, priorities must be strictly ascending.
+          const visualOrder = [...boxes].sort((a, b) => a.y - b.y).map((b) => b.priority);
+          const sortedAsc = [...visualOrder].sort((a, b) => a - b);
+          expect(visualOrder).toEqual(sortedAsc);
+        });
+      });
+    });
+  });
+});

--- a/src/index.php
+++ b/src/index.php
@@ -17,12 +17,20 @@ $story_groups = $storyModel->getAll();
 ?>
 <div class="row">
   <div class="nine columns">
-    <div class="row">
-      <div class="six columns">
-        <?php display_stories($story_groups[0]) ?>
+    <!--
+      Two-column DOM preserves desktop's independent column flow (each
+      column's heights stack independently). On mobile (≤959px), CSS
+      collapses the .stories-col wrappers via `display: contents` so the
+      .feature-box divs become direct flex children of .stories-container,
+      where the inline `order` style interleaves them back into strict
+      priority order (1, 2, 3, …).
+    -->
+    <div class="stories-container">
+      <div class="stories-col">
+        <?php display_stories($story_groups[0], 0, 2) ?>
       </div>
-      <div class="six columns">
-        <?php display_stories($story_groups[1])?>
+      <div class="stories-col">
+        <?php display_stories($story_groups[1], 1, 2) ?>
       </div>
     </div>
   </div>

--- a/src/models/implementations/PostgresStory.php
+++ b/src/models/implementations/PostgresStory.php
@@ -322,7 +322,15 @@ class PostgresStory implements Story {
                 $url = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
                 $content = $this->convertLexicalChildren($node);
                 return "<a href=\"$url\">$content</a>";
-                
+
+            case 'linebreak':
+                // Soft line breaks (Shift+Enter in the Payload editor) are
+                // emitted as standalone `linebreak` nodes with no children.
+                // Without this case the default arm would call
+                // convertLexicalChildren() and yield an empty string,
+                // collapsing adjacent text runs together.
+                return '<br>';
+
             case 'text':
                 $text = $node['text'] ?? '';
                 $format = $node['format'] ?? 0;

--- a/src/partials/_story_display_helpers.php
+++ b/src/partials/_story_display_helpers.php
@@ -23,14 +23,29 @@ function format_headline_with_breaks($headline)
   return $headline;
 }
 
-function display_stories($stories)
+/**
+ * Render a list of stories.
+ *
+ * Each `.feature-box` is emitted with an inline `style="order:N"` so that
+ * when the wrapping `.stories-container` collapses its column wrappers via
+ * `display: contents` on mobile, flex `order` interleaves stories from the
+ * two priority groups back into strict priority sequence (1, 2, 3, …).
+ *
+ * @param array $stories      Stories to render (in the order they should
+ *                            appear within their column on desktop).
+ * @param int   $order_start  CSS `order` value for the first story.
+ * @param int   $order_step   Increment applied to subsequent stories.
+ */
+function display_stories($stories, $order_start = 0, $order_step = 1)
 {
   for ($i = 0; $i < sizeof($stories); $i++) {
     $info = $stories[$i];
     $formatted_headline = format_headline_with_breaks($info['headline']);
     // Add 'long-headline' class for headlines longer than 35 characters
     $headlineClass = strlen($info['headline']) > 35 ? ' class="long-headline"' : '';
-    echo "<div class=\"feature-box\">" .
+    $order = $order_start + ($i * $order_step);
+    $priority = isset($info['priority']) ? (int) $info['priority'] : '';
+    echo "<div class=\"feature-box\" style=\"order:{$order}\" data-priority=\"{$priority}\">" .
       "<h3{$headlineClass}>" . $formatted_headline . "</h3>\n";
     display_pic($info['pic_url'], $info['pic']);
     echo "<div class=\"clearfix\">" . $info['story'] . "</div>\n</div>";

--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -237,6 +237,38 @@ nav a:hover {
   margin: 0;
 }
 
+/* Front-page two-column story layout.
+   Desktop: flex row of two .stories-col children, each flowing independently
+   (mirrors the legacy `.row > .six.columns` layout — heights are NOT
+   row-aligned, unlike a CSS grid).
+   Mobile: collapse the .stories-col wrappers with `display: contents` so
+   .feature-box becomes a direct flex child of .stories-container, and use
+   the inline `order` style emitted by display_stories() to interleave
+   stories back into strict priority order (1, 2, 3, …). */
+.stories-container {
+  display: flex;
+  align-items: flex-start;
+  margin: 0 -10px;
+}
+
+.stories-col {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0 10px;
+}
+
+@media only screen and (max-width: 959px) {
+  .stories-container {
+    flex-direction: column;
+    align-items: stretch;
+    margin: 0;
+  }
+
+  .stories-col {
+    display: contents;
+  }
+}
+
 .ads {
   padding-top: 10px;
 }

--- a/src/tests/Models/PostgresStoryTest.php
+++ b/src/tests/Models/PostgresStoryTest.php
@@ -346,6 +346,38 @@ class PostgresStoryTest extends TestCase
         $this->assertStringNotContainsString('<p></p>', $html);
     }
 
+    /**
+     * Soft line breaks (Shift+Enter in the Payload editor) emit standalone
+     * `linebreak` nodes interleaved with text siblings inside a paragraph.
+     * Without an explicit converter case they fall through to the default
+     * arm and yield an empty string, collapsing adjacent text runs together
+     * (e.g. "Foo FightersYour Favorite Toy" instead of "Foo Fighters<br>Your
+     * Favorite Toy"). Regression: see CD of the Week front-page story.
+     */
+    public function testLinebreakNodeRendersAsBrBetweenTextRuns(): void
+    {
+        $lexical = json_encode([
+            'root' => [
+                'type' => 'root',
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            ['type' => 'text', 'text' => 'Foo Fighters'],
+                            ['type' => 'linebreak'],
+                            ['type' => 'text', 'text' => 'Your Favorite Toy'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = $this->callConvertLexicalToHtml($lexical);
+
+        $this->assertStringContainsString('Foo Fighters<br>Your Favorite Toy', $html);
+        $this->assertStringNotContainsString('Foo FightersYour Favorite Toy', $html);
+    }
+
     // ─── isValidUrl tests ────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## Problem

On mobile (≤959px), the front page stacked stories in DOM order (1, 3, 5, 7, 2, 4, 6, 8) instead of strict priority order (1, 2, 3, 4, 5, 6, 7, 8) because the legacy two-column layout collapses to a single column on small screens.

PR #670 attempted to fix this with a CSS Grid container but forced row-aligned heights on desktop, eliminating the independent column flow (visual regression — already reverted in PR #672).

## Approach

Keep the two-column DOM (preserves desktop's independent column flow). Wrap it in a flex container, and on mobile collapse the column wrappers via `display: contents` so `.feature-box` becomes a direct flex child of `.stories-container`. Each `.feature-box` carries an inline `order` style derived from its priority position; on mobile, flex `order` interleaves the two groups back into strict priority order. No DOM duplication, no JavaScript.

| Group     | DOM index | Priority | Inline `order` |
|-----------|-----------|----------|----------------|
| group[0]  | 0, 1, 2…  | 1, 3, 5… | 0, 2, 4…       |
| group[1]  | 0, 1, 2…  | 2, 4, 6… | 1, 3, 5…       |

## Verification

- [x] `yarn lint` exits 0
- [x] `yarn test` exits 0 (2222 unit tests pass)
- [x] `yarn test:e2e e2e/front-page-headlines.spec.ts` exits 0 (11/11 pass, including 4 new layout tests across MySQL and Postgres backends)

### New regression tests

In `e2e/front-page-headlines.spec.ts`:
- **Desktop @1440**: assert exactly two distinct x-positions across `.feature-box` AND that the second left/right pair has different y-positions (would fail under a PR-670-style row-aligned grid).
- **Mobile @375**: sort `.feature-box` by visual y-position, assert `data-priority` is strictly ascending.

Both run for MySQL and Postgres backends (the latter via `?ff=use_postgres_stories`).

### Screenshots

Screenshots from local Docker stack at `tmp/fix-desktop-1440.png` and `tmp/fix-mobile-375.png` (attaching in PR comment after creation).
