### PR TITLE
fix(actions): allow gh-aw upgrade workflow to push workflow lock updates

### DIFF
--- a/.github/workflows/gh-aw-upgrade.yml
+++ b/.github/workflows/gh-aw-upgrade.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   upgrade:


### PR DESCRIPTION
## Changes
- add workflows: write to .github/workflows/gh-aw-upgrade.yml permissions
- allow automated gh-aw upgrade pushes that modify workflow lock files

## Verification
- [x] yarn lint exits 0
- [x] yarn test exits 0
- [x] yarn build exits 0