### PR TITLE
fix(actions): make gh-aw upgrade workflow valid

### DIFF
--- a/.github/workflows/gh-aw-upgrade.yml
+++ b/.github/workflows/gh-aw-upgrade.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   upgrade:


### PR DESCRIPTION
## Changes
- replace invalid workflows: write permission key with valid actions: write in .github/workflows/gh-aw-upgrade.yml
- restore workflow parsing/execution for this workflow file

## Verification
- [x] yarn lint exits 0
- [x] yarn test exits 0
- [x] yarn build exits 0