### PR TITLE
feat(dj): make displayName editable in Payload admin

### DIFF
--- a/payload/src/collections/DJs.test.ts
+++ b/payload/src/collections/DJs.test.ts
@@ -53,12 +53,12 @@ describe('DJs', () => {
     expect(deleteFn({ req: { user: { role: 'dj' } } })).toBe(false);
   });
 
-  it('has displayName as a sidebar field', () => {
+  it('has displayName as an editable sidebar field', () => {
     const fields = flattenRowFields(DJs.fields as Record<string, unknown>[]);
     const displayNameField = fields.find((f) => f.name === 'displayName');
     expect(displayNameField?.type).toBe('text');
     expect((displayNameField?.admin as Record<string, unknown>)?.position).toBe('sidebar');
-    expect((displayNameField?.admin as Record<string, unknown>)?.readOnly).toBe(true);
+    expect((displayNameField?.admin as Record<string, unknown>)?.readOnly).toBeUndefined();
   });
 
   it('has person as a hasMany relationship to people', () => {
@@ -99,9 +99,7 @@ describe('DJs', () => {
   it('shows the DJ Order tool in the before-list slot', () => {
     const components = DJs.admin?.components as Record<string, unknown> | undefined;
     expect(components?.beforeList).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('DJsListHeader'),
-      ]),
+      expect.arrayContaining([expect.stringContaining('DJsListHeader')]),
     );
   });
 

--- a/payload/src/collections/DJs.ts
+++ b/payload/src/collections/DJs.ts
@@ -40,9 +40,8 @@ export const DJs: CollectionConfig = {
       type: 'text',
       admin: {
         position: 'sidebar',
-        readOnly: true,
         description:
-          'Shown on the website — generated automatically from the linked person name(s)',
+          'Shown on the website — auto-generated from linked person name(s), but can be overridden',
       },
     },
     {

--- a/payload/src/collections/hooks/displayNameHooks.test.ts
+++ b/payload/src/collections/hooks/displayNameHooks.test.ts
@@ -24,6 +24,17 @@ describe('DJs displayName beforeChange hook', () => {
     };
   });
 
+  it('should preserve manually entered displayName', async () => {
+    const result = await generateDJDisplayName({
+      data: { displayName: 'Custom DJ Name', person: [1] },
+      req: createMockReq(mockPayload),
+      operation: 'update',
+    });
+
+    expect(result.displayName).toBe('Custom DJ Name');
+    expect(mockPayload.find).not.toHaveBeenCalled();
+  });
+
   it('should generate displayName from single person', async () => {
     (mockPayload.find as ReturnType<typeof vi.fn>).mockResolvedValue({
       docs: [{ id: 1, name: 'John Doe' }],
@@ -109,7 +120,10 @@ describe('DJs displayName beforeChange hook', () => {
 
   it('should handle person with null name, joining non-null names', async () => {
     (mockPayload.find as ReturnType<typeof vi.fn>).mockResolvedValue({
-      docs: [{ id: 1, name: null }, { id: 2, name: 'Jane Smith' }],
+      docs: [
+        { id: 1, name: null },
+        { id: 2, name: 'Jane Smith' },
+      ],
     });
 
     const result = await generateDJDisplayName({

--- a/payload/src/collections/hooks/displayNameHooks.ts
+++ b/payload/src/collections/hooks/displayNameHooks.ts
@@ -3,37 +3,38 @@ import type { CollectionBeforeChangeHook } from 'payload';
 export const generateDJDisplayName: CollectionBeforeChangeHook = async ({ data, req }) => {
   const updatedData = data;
 
-  if (updatedData.person && Array.isArray(updatedData.person) && updatedData.person.length > 0) {
-    const personIds = updatedData.person.map(
-      (p: unknown) => (typeof p === 'object' && p !== null && 'id' in p ? (p as { id: unknown }).id : p),
-    );
+  // Respect manually entered display names; only auto-generate when empty
+  if (!updatedData.displayName) {
+    if (updatedData.person && Array.isArray(updatedData.person) && updatedData.person.length > 0) {
+      const personIds = updatedData.person.map((p: unknown) => (typeof p === 'object' && p !== null && 'id' in p ? (p as { id: unknown }).id : p));
 
-    try {
-      const people = await req.payload.find({
-        collection: 'people',
-        where: {
-          id: {
-            in: personIds,
+      try {
+        const people = await req.payload.find({
+          collection: 'people',
+          where: {
+            id: {
+              in: personIds,
+            },
           },
-        },
-        limit: personIds.length,
-      });
+          limit: personIds.length,
+        });
 
-      if (people.docs.length > 0) {
-        updatedData.displayName = people.docs.map(
-          (p: { name?: unknown }) => String(p.name || ''),
-        ).join(', ');
-      }
-    } catch (error) {
-      if (process.env.NODE_ENV !== 'production') {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching person names for DJ:', error);
+        if (people.docs.length > 0) {
+          updatedData.displayName = people.docs
+            .map((p: { name?: unknown }) => String(p.name || ''))
+            .join(', ');
+        }
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.error('Error fetching person names for DJ:', error);
+        }
       }
     }
-  }
 
-  if (!updatedData.displayName) {
-    updatedData.displayName = `DJ #${updatedData.id || 'New'}`;
+    if (!updatedData.displayName) {
+      updatedData.displayName = `DJ #${updatedData.id || 'New'}`;
+    }
   }
 
   return updatedData;
@@ -44,13 +45,19 @@ export const generateMusicDisplayName = (entityType: 'Song' | 'Record'): Collect
   let artistName = '';
 
   if (updatedData.artist) {
-    if (typeof updatedData.artist === 'object' && (updatedData.artist as { name?: string }).name) {
+    if (
+      typeof updatedData.artist === 'object'
+        && (updatedData.artist as { name?: string }).name
+    ) {
       artistName = (updatedData.artist as { name: string }).name;
     } else {
       try {
         const artist = await req.payload.findByID({
           collection: 'artists',
-          id: typeof updatedData.artist === 'object' ? (updatedData.artist as { id: unknown }).id : updatedData.artist,
+          id:
+              typeof updatedData.artist === 'object'
+                ? (updatedData.artist as { id: unknown }).id
+                : updatedData.artist,
         });
         if (artist) {
           artistName = artist.name;


### PR DESCRIPTION
## Summary
Previously the DJ `displayName` was `readOnly` and auto-generated from linked person names. This change allows admins to override it directly.

## Changes
- **DJs collection** (`payload/src/collections/DJs.ts`): Removed `readOnly: true` from the `displayName` field; updated description to indicate it can be overridden.
- **`generateDJDisplayName` hook** (`payload/src/collections/hooks/displayNameHooks.ts`): Now only auto-generates the `displayName` when the field is empty, preserving any manually entered value.
- **Tests**: Updated schema test to expect the field to be editable, and added a unit test for the hook verifying that custom display names are preserved.

## Test plan
- [x] `payload/src/collections/DJs.test.ts` passes
- [x] `payload/src/collections/hooks/displayNameHooks.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)