### PR TITLE
fix(payload): prevent concert date off-by-one error from timezone shift

### DIFF
--- a/bin/migrations/normalizeConcertDates.ts
+++ b/bin/migrations/normalizeConcertDates.ts
@@ -1,0 +1,68 @@
+/**
+ * Normalize all existing concert dates to noon UTC.
+ *
+ * The normalizeDateToNoon hook ensures NEW concerts are saved at noon UTC,
+ * but older records (imported from MySQL or created before the hook)
+ * may have varying timestamps, causing group-by to split same-day
+ * concerts into separate groups in the admin.
+ *
+ * Run against dev:
+ *   yarn tsx --import ./bin/preload-nextenv-fix.mjs \
+ *     bin/migrations/normalizeConcertDates.ts dev-neon
+ *
+ * Run against prod:
+ *   NODE_ENV=production yarn tsx --import ./bin/preload-nextenv-fix.mjs \
+ *     bin/migrations/normalizeConcertDates.ts prod-neon
+ */
+
+import { normalizeDateToNoon } from '../../payload/src/collections/hooks/showDateHooks';
+import { getPayloadClient } from './shared/payloadClient';
+import { createLogger } from './shared/logger';
+
+const logger = createLogger('NormalizeConcertDates');
+
+async function main() {
+  const target = process.argv[2] || 'dev-neon';
+  logger.info(`Target database: ${target}`);
+
+  const payload = await getPayloadClient(target as any);
+
+  const { docs } = await payload.find({
+    collection: 'concerts',
+    limit: 0,
+    sort: 'date',
+  });
+
+  logger.info(`Found ${docs.length} concerts`);
+
+  let updated = 0;
+  let unchanged = 0;
+
+  for (const doc of docs) {
+    if (doc.date) {
+      const result = (await normalizeDateToNoon({
+        data: { date: doc.date },
+      })) as { date: string };
+      if (result.date !== doc.date) {
+        await payload.update({
+          collection: 'concerts',
+          id: doc.id,
+          data: { date: result.date },
+        });
+        updated++;
+      } else {
+        unchanged++;
+      }
+    } else {
+      unchanged++;
+    }
+  }
+
+  logger.info(`Done: ${updated} updated, ${unchanged} unchanged`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  logger.error(err);
+  process.exit(1);
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,9 +16,22 @@ export function middleware(request: NextRequest) {
     }
   }
 
+  if (pathname === '/admin/collections/concerts') {
+    const hasWhere = Array.from(searchParams.keys()).some((k) => k.startsWith('where'));
+    if (!hasWhere) {
+      const url = request.nextUrl.clone();
+      const today = new Date();
+      today.setUTCHours(0, 0, 0, 0);
+      url.searchParams.set('where[or][0][and][0][date][greater_than_equal]', today.toISOString());
+      url.searchParams.set('sort', 'date');
+      url.searchParams.set('groupBy', 'date');
+      return NextResponse.redirect(url);
+    }
+  }
+
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: '/admin/collections/shows',
+  matcher: ['/admin/collections/shows', '/admin/collections/concerts'],
 };

--- a/payload/src/collections/Concerts.ts
+++ b/payload/src/collections/Concerts.ts
@@ -10,6 +10,7 @@ import {
 import type { SerializedEditorState } from 'lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { convertConcertTitleToHtml, convertConcertTitleToPlain } from '../utils/concertTitle';
+import { normalizeDateToNoon } from './hooks/showDateHooks';
 
 type ConcertSiblingData = {
   title?: SerializedEditorState | null;
@@ -65,6 +66,9 @@ export const Concerts: CollectionConfig = {
     groupBy: true,
   },
   defaultSort: 'date',
+  hooks: {
+    beforeChange: [normalizeDateToNoon],
+  },
   access: {
     read: () => true,
     create: ({ req }) => Boolean(req.user),
@@ -131,6 +135,7 @@ export const Concerts: CollectionConfig = {
         description: 'Concert date',
         date: {
           displayFormat: 'yyyy-MM-dd',
+          pickerAppearance: 'dayOnly',
         },
       },
     },

--- a/payload/src/collections/hooks/showDateHooks.ts
+++ b/payload/src/collections/hooks/showDateHooks.ts
@@ -1,7 +1,7 @@
 import type { CollectionBeforeChangeHook } from 'payload';
 
 /**
- * Normalize a show's date to noon UTC before saving.
+ * Normalize a date field to noon UTC before saving.
  *
  * Payload's dayOnly date picker normalizes dates to noon UTC on the client side
  * (setHours(12 - tzOffset)) to keep the calendar date consistent across timezones.
@@ -9,7 +9,7 @@ import type { CollectionBeforeChangeHook } from 'payload';
  * API or seed scripts are stored consistently, ensuring the admin list date filter
  * (which generates an exact equality query) matches stored values.
  */
-export const normalizeShowDate: CollectionBeforeChangeHook = ({ data }) => {
+export const normalizeDateToNoon: CollectionBeforeChangeHook = ({ data }) => {
   if (data.date) {
     const raw = data.date;
     const date = raw instanceof Date ? raw : new Date(raw as string);
@@ -18,3 +18,6 @@ export const normalizeShowDate: CollectionBeforeChangeHook = ({ data }) => {
   }
   return data;
 };
+
+/** @deprecated Use `normalizeDateToNoon` instead */
+export const normalizeShowDate = normalizeDateToNoon;


### PR DESCRIPTION
## Summary

### Problem
1. Concerts stored at midnight UTC would display a day earlier in admin due to Eastern timezone conversion
2. Existing records with varying timestamps caused group-by to split same-day concerts into multiple group headings despite showing the same displayed date.

### Changes

**`payload/src/collections/Concerts.ts`**
- Added `beforeChange: [normalizeDateToNoon]` hook (same as Shows) to force noon UTC storage
- Added `pickerAppearance: 'dayOnly'` to date field to match Shows
- Renamed `normalizeShowDate` → `normalizeDateToNoon` with backward-compatible alias

**`payload/src/collections/hooks/showDateHooks.ts`**
- Generalized comment and function name to reflect it's used by both Shows and Concerts

**`middleware.ts`**
- Added redirect for `/admin/collections/concerts` to upcoming date-grouped view (same UX as Shows)

**`bin/migrations/normalizeConcertDates.ts`**
- One-time script to normalize all existing concert timestamps to noon UTC so groupBy works correctly

## Test plan
- [x] Unit tests pass (`showDateHooks.test.ts`)
- [x] Data migration ran locally — 4501 of 4516 concerts normalized
- [ ] Run migration against production after merge
- [ ] Verify admin group-by shows one heading per date