### PR TITLE
fix(collections): fix duplicate for entities with unique legacyId field

### DIFF
--- a/payload/src/collections/Ads.ts
+++ b/payload/src/collections/Ads.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { normalizeFieldToNoon } from './hooks/showDateHooks';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const Ads: CollectionConfig = {
   slug: 'ads',
@@ -105,17 +106,7 @@ export const Ads: CollectionConfig = {
         description: 'Display order — higher numbers appear first. Same priority sorts by date.',
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/CdOfTheWeek.ts
+++ b/payload/src/collections/CdOfTheWeek.ts
@@ -3,6 +3,7 @@ import { slugField } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { setCdOfTheWeekSlugFromRecord, cdSlugify } from './hooks/slugUtils';
+import { legacyIdField } from './shared/legacyIdField';
 
 const syncRecordText: FieldHook = async ({ siblingData, req }) => {
   const raw = (siblingData as { record?: unknown }).record;
@@ -116,17 +117,7 @@ export const CdOfTheWeek: CollectionConfig = {
         description: 'The review text shown on the website',
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/Concerts.ts
+++ b/payload/src/collections/Concerts.ts
@@ -11,6 +11,7 @@ import type { SerializedEditorState } from 'lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { convertConcertTitleToHtml, convertConcertTitleToPlain } from '../utils/concertTitle';
 import { normalizeDateToNoon } from './hooks/showDateHooks';
+import { legacyIdField } from './shared/legacyIdField';
 
 type ConcertSiblingData = {
   title?: SerializedEditorState | null;
@@ -173,17 +174,7 @@ export const Concerts: CollectionConfig = {
         placeholder: 'https://',
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/DJs.ts
+++ b/payload/src/collections/DJs.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { generateDJDisplayName } from './hooks/displayNameHooks';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const DJs: CollectionConfig = {
   slug: 'djs',
@@ -119,17 +120,7 @@ export const DJs: CollectionConfig = {
         },
       ],
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/Media.ts
+++ b/payload/src/collections/Media.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import type { CollectionConfig } from 'payload';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
+import { legacyIdField } from './shared/legacyIdField';
 
 const mediaDir = path.resolve(process.cwd(), 'payload', 'media');
 
@@ -82,16 +83,7 @@ export const Media: CollectionConfig = {
         condition: adminOnlyCondition,
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/OnDemand.ts
+++ b/payload/src/collections/OnDemand.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig, FieldHook } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
+import { legacyIdField } from './shared/legacyIdField';
 
 const syncArtistsText: FieldHook = async ({ siblingData, req }) => {
   const raw = (siblingData as { artists?: unknown[] }).artists ?? [];
@@ -194,17 +195,7 @@ export const OnDemand: CollectionConfig = {
         },
       ],
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/People.ts
+++ b/payload/src/collections/People.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { slugField } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const People: CollectionConfig = {
   slug: 'people',
@@ -60,17 +61,7 @@ export const People: CollectionConfig = {
         position: 'sidebar',
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/Posts.ts
+++ b/payload/src/collections/Posts.ts
@@ -5,6 +5,7 @@ import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { EmbedFeature } from '../features/embed';
 import { normalizeFieldToNoon } from './hooks/showDateHooks';
 import { postSlugify } from './hooks/slugUtils';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const Posts: CollectionConfig = {
   slug: 'posts',
@@ -142,17 +143,7 @@ export const Posts: CollectionConfig = {
           'Display order on the front page — higher numbers appear first. Same priority sorts by date.',
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/Records.ts
+++ b/payload/src/collections/Records.ts
@@ -3,6 +3,7 @@ import { slugField } from 'payload';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { generateMusicDisplayName } from './hooks/displayNameHooks';
 import { musicSlugify, generateMusicSlugBeforeChangeHook } from './hooks/slugUtils';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const Records: CollectionConfig = {
   slug: 'records',
@@ -118,17 +119,7 @@ export const Records: CollectionConfig = {
         },
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/Shows.ts
+++ b/payload/src/collections/Shows.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { normalizeShowDate } from './hooks/showDateHooks';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const Shows: CollectionConfig = {
   slug: 'shows',
@@ -100,17 +101,7 @@ export const Shows: CollectionConfig = {
         description: 'Notes shown alongside this time slot (e.g., "Best Of" episode, guest DJ)',
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/Songs.ts
+++ b/payload/src/collections/Songs.ts
@@ -4,6 +4,7 @@ import { hasRole, adminOnlyCondition } from '../utils/auth';
 import { generateMusicDisplayName } from './hooks/displayNameHooks';
 import { normalizeDateToNoon } from './hooks/showDateHooks';
 import { musicSlugify, generateMusicSlugBeforeChangeHook } from './hooks/slugUtils';
+import { legacyIdField } from './shared/legacyIdField';
 
 export const Songs: CollectionConfig = {
   slug: 'songs',
@@ -116,17 +117,7 @@ export const Songs: CollectionConfig = {
         },
       },
     },
-    {
-      name: 'legacyId',
-      type: 'number',
-      unique: true,
-      admin: {
-        position: 'sidebar',
-        readOnly: true,
-        description: 'Original MySQL ID for migration tracking',
-        condition: adminOnlyCondition,
-      },
-    },
+    legacyIdField,
     {
       name: 'migratedAt',
       type: 'date',

--- a/payload/src/collections/shared/legacyIdField.ts
+++ b/payload/src/collections/shared/legacyIdField.ts
@@ -1,0 +1,28 @@
+import type { Field } from 'payload';
+import { adminOnlyCondition } from '../../utils/auth';
+
+/**
+ * Shared legacyId field definition for collections migrated from MySQL.
+ *
+ * The `unique: true` constraint is needed for migration tracking, but it
+ * prevents duplication because Payload's default beforeDuplicate hook for
+ * unique number fields returns `undefined` — which the hook runner ignores,
+ * preserving the original value and violating the unique constraint.
+ *
+ * The `beforeDuplicate` hook explicitly returns `null` so the duplicated
+ * document gets no legacyId (multiple NULLs are allowed in unique indexes).
+ */
+export const legacyIdField: Field = {
+  name: 'legacyId',
+  type: 'number',
+  unique: true,
+  admin: {
+    position: 'sidebar',
+    readOnly: true,
+    description: 'Original MySQL ID for migration tracking',
+    condition: adminOnlyCondition,
+  },
+  hooks: {
+    beforeDuplicate: [() => null],
+  },
+};


### PR DESCRIPTION
## Problem

Duplicating any entity with a `legacyId` field (e.g., Shows, Concerts, DJs, Songs, etc.) fails with:

> "The following field is invalid: legacyId"

This affects all 10 collections that have a `legacyId` field: Shows, Ads, Concerts, CdOfTheWeek, DJs, OnDemand, People, Records, Posts, Songs, and Media.

## Root Cause

Payload's `setDefaultBeforeDuplicate` assigns an automatic `beforeDuplicate` field hook for unique `number` fields that returns `undefined` (intending to clear the value). However, the `beforeDuplicate` hook runner only applies results that are **not** `undefined`:

```js
if (typeof hookResult !== 'undefined') {
    siblingDoc[field.name] = hookResult;
}
```

Since the default hook returns `undefined`, the original `legacyId` value is **preserved** in the copy, violating the `unique: true` constraint.

## Fix

Created a shared `legacyIdField` definition (`payload/src/collections/shared/legacyIdField.ts`) with a `beforeDuplicate` hook that returns `null` instead of `undefined`. Since `typeof null !== 'undefined'` is `true`, the hook runner applies it correctly, clearing the value on duplicate. `null` is valid for a non-required unique number column (multiple NULLs are allowed in unique indexes).

Replaced the inline `legacyId` field definitions in all 10 collections with the shared definition.