### PR TITLE
fix(cdotw): restore 200x200 featured CD images (regressed in #704)

### DIFF
--- a/src/cdoftheweek.php
+++ b/src/cdoftheweek.php
@@ -63,8 +63,9 @@ function renderCdCoverImage(string $imageUrl, ?string $artistUrl, string $altTex
 
                 $lastIndex = count($latestCds) - 1;
                 foreach ($latestCds as $i => $cd) {
+                    $displayCd = $cdOfTheWeek->getById((int) $cd['id']) ?: $cd;
                     $coverImage = renderCdCoverImage(
-                        $cd['cd_pic_url'],
+                        $displayCd['cd_pic_url'],
                         $cd['band'] ?? null,
                         $cd['artist'] . ' - ' . $cd['title'] . ' album cover'
                     );


### PR DESCRIPTION
## Summary
- PR #701 originally resolved featured CDs via `getById()` (200×200 images)
- PR #704's refactor dropped that back to `getAll()` (100×100 thumbnails)
- Restores the `getById()` resolution so the main CD of the Week page shows full-size artwork, matching the behavior when viewing a specific CD via `?id=`

## Test plan
- Visit `/cdoftheweek.php` — featured CD image should be 200×200
- Visit `/cdoftheweek.php?id=1081` — image should also be 200×200
- Archive thumbnails at the bottom should remain 100×100

🤖 Co-created with Claude via Claude Code