### PR TITLE
fix: carry over note field when cloning shows and harden duplicate unique fields

### DIFF
--- a/payload/src/collections/Artists.ts
+++ b/payload/src/collections/Artists.ts
@@ -73,6 +73,9 @@ export const Artists: CollectionConfig = {
       name: 'musicbrainzId',
       type: 'text',
       unique: true,
+      hooks: {
+        beforeDuplicate: [() => null],
+      },
       admin: {
         position: 'sidebar',
         description:

--- a/payload/src/collections/Records.ts
+++ b/payload/src/collections/Records.ts
@@ -109,6 +109,9 @@ export const Records: CollectionConfig = {
       name: 'musicbrainzId',
       type: 'text',
       unique: true,
+      hooks: {
+        beforeDuplicate: [() => null],
+      },
       admin: {
         position: 'sidebar',
         description:

--- a/payload/src/collections/Songs.ts
+++ b/payload/src/collections/Songs.ts
@@ -106,6 +106,9 @@ export const Songs: CollectionConfig = {
       name: 'musicbrainzId',
       type: 'text',
       unique: true,
+      hooks: {
+        beforeDuplicate: [() => null],
+      },
       admin: {
         position: 'sidebar',
         description:

--- a/payload/src/collections/YearEndPollResults.test.ts
+++ b/payload/src/collections/YearEndPollResults.test.ts
@@ -103,6 +103,25 @@ describe('YearEndPollResults', () => {
     expect(slugField?.unique).toBe(true);
   });
 
+  it('adds a unique suffix when duplicating slug values', () => {
+    const fields = flattenRowFields(YearEndPollResults.fields as Record<string, unknown>[]);
+    const slugField = fields.find((f) => f.name === 'slug') as {
+      hooks?: {
+        beforeDuplicate?: Array<(args: { value: unknown }) => string>;
+      };
+    };
+    const duplicateSlug = slugField?.hooks?.beforeDuplicate?.[0];
+
+    expect(duplicateSlug).toBeTypeOf('function');
+
+    const firstDuplicate = duplicateSlug?.({ value: 'top225of2025' });
+    const secondDuplicate = duplicateSlug?.({ value: 'top225of2025' });
+
+    expect(firstDuplicate).toMatch(/^top225of2025-copy-/);
+    expect(secondDuplicate).toMatch(/^top225of2025-copy-/);
+    expect(firstDuplicate).not.toBe(secondDuplicate);
+  });
+
   it('has sections as a required blocks field', () => {
     const fields = flattenRowFields(YearEndPollResults.fields as Record<string, unknown>[]);
     const sectionsField = fields.find((f) => f.name === 'sections') as {

--- a/payload/src/collections/YearEndPollResults.ts
+++ b/payload/src/collections/YearEndPollResults.ts
@@ -1,5 +1,6 @@
-import type { Block, CollectionConfig } from 'payload';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
+import { randomUUID } from 'node:crypto';
+import type { Block, CollectionConfig } from 'payload';
 import { hasRole } from '../utils/auth';
 
 /**
@@ -349,7 +350,7 @@ export const YearEndPollResults: CollectionConfig = {
       required: true,
       unique: true,
       hooks: {
-        beforeDuplicate: [({ value }) => `${String(value)}-copy`],
+        beforeDuplicate: [({ value }) => `${String(value)}-copy-${randomUUID().slice(0, 8)}`],
       },
       admin: {
         position: 'sidebar',

--- a/payload/src/collections/YearEndPollResults.ts
+++ b/payload/src/collections/YearEndPollResults.ts
@@ -348,6 +348,9 @@ export const YearEndPollResults: CollectionConfig = {
       type: 'text',
       required: true,
       unique: true,
+      hooks: {
+        beforeDuplicate: [({ value }) => `${String(value)}-copy`],
+      },
       admin: {
         position: 'sidebar',
         description: 'URL identifier (e.g., "top225of2025")',

--- a/payload/src/collections/collectionSchema.test.ts
+++ b/payload/src/collections/collectionSchema.test.ts
@@ -22,27 +22,51 @@ import { Venues } from './Venues';
 import { YearEndPollResults } from './YearEndPollResults';
 
 type FieldRecord = Record<string, unknown>;
+type SlugHelperAdmin = {
+  components?: {
+    Field?: {
+      path?: string;
+    };
+  };
+};
+
+const RECURSIVE_FIELD_TYPES = new Set(['row', 'collapsible', 'group']);
+
+function isSlugHelperField(field: FieldRecord): boolean {
+  if (field.name !== 'slug') {
+    return false;
+  }
+
+  const admin = field.admin as SlugHelperAdmin | undefined;
+
+  return admin?.components?.Field?.path === '@payloadcms/next/client#SlugField';
+}
+
+function shouldRecurseIntoFields(field: FieldRecord): boolean {
+  return Array.isArray(field.fields)
+    && typeof field.type === 'string'
+    && RECURSIVE_FIELD_TYPES.has(field.type);
+}
 
 // Recursively collect fields with unique: true. Recurses into layout containers
 // (row, collapsible, group) but not into array/blocks where unique is meaningless.
+// Payload's slugField() helper is excluded because it expands to a generated row
+// wrapper and handles slug generation separately from explicit schema fields.
 function findUniqueFields(
   fields: FieldRecord[],
   path = '',
 ): Array<{ path: string; field: FieldRecord }> {
   return fields.flatMap((field) => {
     const name = typeof field.name === 'string' ? field.name : null;
-    const currentPath = name ? (path ? `${path}.${name}` : name) : path;
-    const result: Array<{ path: string; field: FieldRecord }> = [];
+    const currentPath = name ? [path, name].filter(Boolean).join('.') : path;
+    const uniqueFields = field.unique === true && name && !isSlugHelperField(field)
+      ? [{ path: currentPath, field }]
+      : [];
+    const nestedFields = shouldRecurseIntoFields(field)
+      ? findUniqueFields(field.fields as FieldRecord[], currentPath)
+      : [];
 
-    if (field.unique === true && name) {
-      result.push({ path: currentPath, field });
-    }
-
-    if (Array.isArray(field.fields)) {
-      result.push(...findUniqueFields(field.fields as FieldRecord[], currentPath));
-    }
-
-    return result;
+    return [...uniqueFields, ...nestedFields];
   });
 }
 
@@ -75,20 +99,18 @@ describe('Collection schema invariants', () => {
     // Add a beforeDuplicate hook so duplication doesn't silently break on the
     // unique constraint. See legacyIdField for the pattern:
     //   hooks: { beforeDuplicate: [() => null] }        // clears the value (optional fields)
-    //   hooks: { beforeDuplicate: [({ value }) => `${value}-copy`] } // transforms it (required fields)
-    const violations: string[] = [];
+    //   hooks: { beforeDuplicate: [({ value }) => `${String(value)}-copy`] } // transforms it
+    const violations = allCollections
+      .filter(({ config }) => !config.admin?.disableDuplicate)
+      .flatMap(({ name, config }) => (
+        findUniqueFields(config.fields as FieldRecord[]).flatMap(({ path, field }) => {
+          const hooks = field.hooks as Record<string, unknown[]> | undefined;
+          const hasHook = Array.isArray(hooks?.beforeDuplicate) && hooks.beforeDuplicate.length > 0;
 
-    for (const { name, config } of allCollections) {
-      if (config.admin?.disableDuplicate) continue;
-
-      for (const { path, field } of findUniqueFields(config.fields as FieldRecord[])) {
-        const hooks = field.hooks as Record<string, unknown[]> | undefined;
-        const hasHook = Array.isArray(hooks?.beforeDuplicate) && hooks.beforeDuplicate.length > 0;
-        if (!hasHook) {
-          violations.push(`${name}.${path}`);
-        }
-      }
-    }
+          return hasHook ? [] : [`${name}.${path}`];
+        })
+      ))
+      .sort();
 
     expect(violations).toEqual([]);
   });

--- a/payload/src/collections/collectionSchema.test.ts
+++ b/payload/src/collections/collectionSchema.test.ts
@@ -99,7 +99,7 @@ describe('Collection schema invariants', () => {
     // Add a beforeDuplicate hook so duplication doesn't silently break on the
     // unique constraint. See legacyIdField for the pattern:
     //   hooks: { beforeDuplicate: [() => null] }        // clears the value (optional fields)
-    //   hooks: { beforeDuplicate: [({ value }) => `${String(value)}-copy`] } // transforms it
+    //   hooks: { beforeDuplicate: [({ value }) => `${String(value)}-copy-${Date.now()}`] } // transforms it
     const violations = allCollections
       .filter(({ config }) => !config.admin?.disableDuplicate)
       .flatMap(({ name, config }) => (

--- a/payload/src/collections/collectionSchema.test.ts
+++ b/payload/src/collections/collectionSchema.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { CollectionConfig } from 'payload';
+import { Ads } from './Ads';
+import { Artists } from './Artists';
+import { CdOfTheWeek } from './CdOfTheWeek';
+import { Concerts } from './Concerts';
+import { DJs } from './DJs';
+import { MadnessBands } from './MadnessBands';
+import { MadnessMatchEvents } from './MadnessMatchEvents';
+import { MadnessMatches } from './MadnessMatches';
+import { MadnessTournaments } from './MadnessTournaments';
+import { MadnessVotes } from './MadnessVotes';
+import { Media } from './Media';
+import { OnDemand } from './OnDemand';
+import { People } from './People';
+import { Posts } from './Posts';
+import { Records } from './Records';
+import { Shows } from './Shows';
+import { Songs } from './Songs';
+import { Users } from './Users';
+import { Venues } from './Venues';
+import { YearEndPollResults } from './YearEndPollResults';
+
+type FieldRecord = Record<string, unknown>;
+
+// Recursively collect fields with unique: true. Recurses into layout containers
+// (row, collapsible, group) but not into array/blocks where unique is meaningless.
+function findUniqueFields(
+  fields: FieldRecord[],
+  path = '',
+): Array<{ path: string; field: FieldRecord }> {
+  return fields.flatMap((field) => {
+    const name = typeof field.name === 'string' ? field.name : null;
+    const currentPath = name ? (path ? `${path}.${name}` : name) : path;
+    const result: Array<{ path: string; field: FieldRecord }> = [];
+
+    if (field.unique === true && name) {
+      result.push({ path: currentPath, field });
+    }
+
+    if (Array.isArray(field.fields)) {
+      result.push(...findUniqueFields(field.fields as FieldRecord[], currentPath));
+    }
+
+    return result;
+  });
+}
+
+const allCollections: Array<{ name: string; config: CollectionConfig }> = [
+  { name: 'Ads', config: Ads },
+  { name: 'Artists', config: Artists },
+  { name: 'CdOfTheWeek', config: CdOfTheWeek },
+  { name: 'Concerts', config: Concerts },
+  { name: 'DJs', config: DJs },
+  { name: 'MadnessBands', config: MadnessBands },
+  { name: 'MadnessMatchEvents', config: MadnessMatchEvents },
+  { name: 'MadnessMatches', config: MadnessMatches },
+  { name: 'MadnessTournaments', config: MadnessTournaments },
+  { name: 'MadnessVotes', config: MadnessVotes },
+  { name: 'Media', config: Media },
+  { name: 'OnDemand', config: OnDemand },
+  { name: 'People', config: People },
+  { name: 'Posts', config: Posts },
+  { name: 'Records', config: Records },
+  { name: 'Shows', config: Shows },
+  { name: 'Songs', config: Songs },
+  { name: 'Users', config: Users },
+  { name: 'Venues', config: Venues },
+  { name: 'YearEndPollResults', config: YearEndPollResults },
+];
+
+describe('Collection schema invariants', () => {
+  it('every unique field has a beforeDuplicate hook to avoid constraint violations on duplicate', () => {
+    // When you add a unique: true field to any collection, this test will fail.
+    // Add a beforeDuplicate hook so duplication doesn't silently break on the
+    // unique constraint. See legacyIdField for the pattern:
+    //   hooks: { beforeDuplicate: [() => null] }        // clears the value (optional fields)
+    //   hooks: { beforeDuplicate: [({ value }) => `${value}-copy`] } // transforms it (required fields)
+    const violations: string[] = [];
+
+    for (const { name, config } of allCollections) {
+      if (config.admin?.disableDuplicate) continue;
+
+      for (const { path, field } of findUniqueFields(config.fields as FieldRecord[])) {
+        const hooks = field.hooks as Record<string, unknown[]> | undefined;
+        const hasHook = Array.isArray(hooks?.beforeDuplicate) && hooks.beforeDuplicate.length > 0;
+        if (!hasHook) {
+          violations.push(`${name}.${path}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/payload/src/collections/collectionSchema.test.ts
+++ b/payload/src/collections/collectionSchema.test.ts
@@ -99,7 +99,7 @@ describe('Collection schema invariants', () => {
     // Add a beforeDuplicate hook so duplication doesn't silently break on the
     // unique constraint. See legacyIdField for the pattern:
     //   hooks: { beforeDuplicate: [() => null] }        // clears the value (optional fields)
-    //   hooks: { beforeDuplicate: [({ value }) => `${String(value)}-copy-${Date.now()}`] } // transforms it
+    //   hooks: { beforeDuplicate: [({ value }) => `${String(value)}-copy-${randomUUID()}`] } // transforms it
     const violations = allCollections
       .filter(({ config }) => !config.admin?.disableDuplicate)
       .flatMap(({ name, config }) => (

--- a/payload/src/features/show-cloner/hooks/useShowCloner.test.ts
+++ b/payload/src/features/show-cloner/hooks/useShowCloner.test.ts
@@ -1,7 +1,18 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import type { Field } from 'payload';
+import { Shows } from '../../../collections/Shows';
 import { useShowCloner } from './useShowCloner';
 import type { Show } from '../types';
+
+function collectFieldNames(fields: Field[]): string[] {
+  return fields.flatMap((field) => {
+    const nested = 'fields' in field && Array.isArray(field.fields)
+      ? collectFieldNames(field.fields as Field[])
+      : [];
+    return 'name' in field ? [field.name as string, ...nested] : nested;
+  });
+}
 
 const makeShow = (overrides: Partial<Show> = {}): Show => ({
   id: '1',
@@ -21,6 +32,19 @@ const shows: Show[] = [
 describe('useShowCloner', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('accounts for every Shows field — add new fields to cloned or excluded list', () => {
+    // When you add a field to the Shows collection this test will fail.
+    // Decide whether the new field should be copied to cloned shows and add it
+    // to the appropriate list below, then update useShowCloner.ts accordingly.
+    const cloned = new Set(['date', 'startTime', 'endTime', 'name', 'host', 'note']);
+    const excluded = new Set(['legacyId', 'migratedAt']); // not meaningful on a fresh clone
+
+    const unaccounted = collectFieldNames(Shows.fields as Field[])
+      .filter((f) => !cloned.has(f) && !excluded.has(f));
+
+    expect(unaccounted).toEqual([]);
   });
 
   it('starts with idle state', () => {

--- a/payload/src/features/show-cloner/hooks/useShowCloner.test.ts
+++ b/payload/src/features/show-cloner/hooks/useShowCloner.test.ts
@@ -194,6 +194,45 @@ describe('useShowCloner', () => {
     expect(fetchedBodies[0].host).toBeUndefined();
   });
 
+  it('clones the note field when present', async () => {
+    const fetchedBodies: { note?: unknown }[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, opts?: RequestInit) => {
+      fetchedBodies.push(JSON.parse(opts?.body as string));
+      return { ok: true, json: async () => ({}) };
+    });
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+    const lexicalNote = { root: { children: [{ type: 'paragraph', children: [{ type: 'text', text: 'Best Of episode' }] }] } };
+    const showWithNote: Show[] = [
+      makeShow({ id: '1', date: '2024-01-15', note: lexicalNote }),
+    ];
+    const { result } = renderHook(() => useShowCloner(showWithNote, onComplete));
+
+    await act(async () => {
+      await result.current.cloneShows('2024-01-15', '2024-01-15', '2024-02-05');
+    });
+
+    expect(fetchedBodies[0].note).toEqual(lexicalNote);
+  });
+
+  it('omits note from payload when note is absent', async () => {
+    const fetchedBodies: { note?: unknown }[] = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, opts?: RequestInit) => {
+      fetchedBodies.push(JSON.parse(opts?.body as string));
+      return { ok: true, json: async () => ({}) };
+    });
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+    const showWithoutNote: Show[] = [
+      makeShow({ id: '1', date: '2024-01-15', note: undefined }),
+    ];
+    const { result } = renderHook(() => useShowCloner(showWithoutNote, onComplete));
+
+    await act(async () => {
+      await result.current.cloneShows('2024-01-15', '2024-01-15', '2024-02-05');
+    });
+
+    expect(fetchedBodies[0].note).toBeUndefined();
+  });
+
   it('sets error on fetch failure', async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network failure'));
     const onComplete = vi.fn().mockResolvedValue(undefined);

--- a/payload/src/features/show-cloner/hooks/useShowCloner.ts
+++ b/payload/src/features/show-cloner/hooks/useShowCloner.ts
@@ -70,9 +70,9 @@ export const useShowCloner = (shows: Show[], onComplete: () => Promise<void>) =>
               newShow.host = !Number.isNaN(numericId) ? numericId : hostId;
             }
           }
-          // Note: Rich text (Lexical) note field is not cloned because it contains complex
-          // nested node structures with internal IDs that may cause issues if duplicated.
-          // Users can add notes manually to cloned shows if needed.
+          if (show.note) {
+            newShow.note = show.note;
+          }
 
           return fetch('/api/shows', {
             method: 'POST',

--- a/payload/src/features/show-cloner/types.ts
+++ b/payload/src/features/show-cloner/types.ts
@@ -54,4 +54,5 @@ export interface NewShowPayload {
   endTime: string;
   name?: string;
   host?: number | string;
+  note?: unknown;
 }


### PR DESCRIPTION
The note (rich text) field was intentionally excluded from cloning
with an unwarranted concern about Lexical internal node IDs. Payload
regenerates node keys on load, so the JSON can be passed through
directly. Added tests for both the present and absent note cases.

Also added schema-level safeguards for `unique: true` fields used by
Payload duplication so duplicate actions do not fail on unique
constraints. Required unique fields now provide an explicit
`beforeDuplicate` transform, including a unique suffix for repeated
Year End Poll Results slug duplicates, and tests cover both the schema
invariant and the repeated-duplicate slug behavior.

Co-Authored-By: Claude Sonnet 4.6