### PR TITLE
Fix OnDemand video links opening in same tab

### DIFF
--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -82,7 +82,10 @@ trait ConvertsLexicalToHtml
                 $rawUrl = $node['url'] ?? ($node['fields']['url'] ?? '');
                 $url = $this->isSafeLexicalUrl($rawUrl) ? $rawUrl : '#';
                 $url = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
-                return "<a href=\"$url\">" . $this->convertLexicalChildren($node) . '</a>';
+                $fields = is_array($node['fields'] ?? null) ? $node['fields'] : [];
+                $newTab = (bool)($fields['newTab'] ?? false);
+                $target = $newTab ? ' target="_blank" rel="noopener noreferrer"' : '';
+                return "<a href=\"$url\"$target>" . $this->convertLexicalChildren($node) . '</a>';
 
             case 'linebreak':
                 return "<br>\n";

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace YNotRadio\Tests\Models\Concerns;
+
+use PHPUnit\Framework\TestCase;
+use YNotRadio\Models\Concerns\ConvertsLexicalToHtml;
+
+class ConvertsLexicalToHtmlTestHarness
+{
+    use ConvertsLexicalToHtml;
+
+    public function convert(?string $lexicalJson): string
+    {
+        return $this->convertLexicalToHtml($lexicalJson);
+    }
+}
+
+class ConvertsLexicalToHtmlTest extends TestCase
+{
+    private ConvertsLexicalToHtmlTestHarness $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new ConvertsLexicalToHtmlTestHarness();
+    }
+
+    public function testLinkNodeWithNewTabOpensInNewWindow(): void
+    {
+        $lexicalJson = json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'link',
+                                'fields' => [
+                                    'url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+                                    'newTab' => true,
+                                ],
+                                'children' => [
+                                    [
+                                        'type' => 'text',
+                                        'text' => 'Watch video',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = $this->converter->convert($lexicalJson);
+
+        $this->assertStringContainsString('target="_blank"', $html);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $html);
+        $this->assertStringContainsString('https://www.youtube.com/watch?v=dQw4w9WgXcQ', $html);
+    }
+}


### PR DESCRIPTION
## Changes
- Preserve newTab on Lexical links when rendering OnDemand notes
- Add a PHPUnit regression test for external video links

## Verification
- cd src && ./vendor/bin/phpunit --filter ConvertsLexicalToHtmlTest
- php -l src/models/Concerns/ConvertsLexicalToHtml.php
