### PR TITLE
Make ondemand links default to opening in new tabs

### DIFF
--- a/src/ondemand.php
+++ b/src/ondemand.php
@@ -78,4 +78,19 @@ $id = "";
   </div>
   <div class="three columns"><?php require ("partials/_featured_concerts_and_ads.php") ?></div>
 </div> <!-- end of row div -->
+<script>
+  document.querySelectorAll('a').forEach(function(link) {
+    link.setAttribute('target', '_blank');
+    var rel = (link.getAttribute('rel') || '').split(/\s+/).filter(Boolean);
+
+    if (!rel.includes('noopener')) {
+      rel.push('noopener');
+    }
+    if (!rel.includes('noreferrer')) {
+      rel.push('noreferrer');
+    }
+
+    link.setAttribute('rel', rel.join(' '));
+  });
+</script>
 <?php require ("partials/_footer.php"); ?>

--- a/src/ondemand.php
+++ b/src/ondemand.php
@@ -2,6 +2,7 @@
 
 $page_file = "ondemand.php";
 $page_title = "On Demand";
+$page_default_link_target = "_blank";
 
 require ("functions/main_fns.php");
 require ("models/OnDemandFactory.php");
@@ -78,19 +79,4 @@ $id = "";
   </div>
   <div class="three columns"><?php require ("partials/_featured_concerts_and_ads.php") ?></div>
 </div> <!-- end of row div -->
-<script>
-  document.querySelectorAll('a').forEach(function(link) {
-    link.setAttribute('target', '_blank');
-    var rel = (link.getAttribute('rel') || '').split(/\s+/).filter(Boolean);
-
-    if (!rel.includes('noopener')) {
-      rel.push('noopener');
-    }
-    if (!rel.includes('noreferrer')) {
-      rel.push('noreferrer');
-    }
-
-    link.setAttribute('rel', rel.join(' '));
-  });
-</script>
 <?php require ("partials/_footer.php"); ?>

--- a/src/partials/_header.php
+++ b/src/partials/_header.php
@@ -34,6 +34,9 @@ if ($page_file != "logout.php") {
       <meta property="og:type" content="article">
       <meta property="og:url" content="https://www.ynotradio.net">
       <!-- social meta end -->
+      <?php if (isset($page_default_link_target) && $page_default_link_target !== ''): ?>
+      <base target="<?php echo htmlspecialchars($page_default_link_target, ENT_QUOTES, 'UTF-8'); ?>">
+      <?php endif; ?>
     <!--[if lte IE 8]>
     <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
## Changes

- Set a page-scoped server-side default link target for `ondemand.php` by defining `$page_default_link_target = "_blank"`.
- Updated the shared header partial to emit `<base target="...">` when that page variable is provided.
- Removed the client-side JavaScript that was previously forcing link targets.

## Verification

- [x] `yarn lint` exits 0
- [x] `yarn test` exits 0
- [ ] `yarn test:e2e` exits 0 (required if e2e tests were added or modified) - blocked: Docker daemon unavailable in this environment
- [ ] Screenshot attached below

## Screenshot

N/A

## Blocker

@owner - Could not capture a valid app-functionality screenshot for this change. Payload admin returned `Error: cannot connect to Postgres`, and `yarn test:e2e` could not start containers because Docker daemon access is unavailable in this environment.