### PR TITLE
Stabilize Vitest state isolation and async test cleanup

### DIFF
--- a/payload/src/features/dj-order/DJOrderClient.test.tsx
+++ b/payload/src/features/dj-order/DJOrderClient.test.tsx
@@ -38,7 +38,13 @@ vi.mock('./components/SortableItem', () => ({
 
 // Mock @dnd-kit/core
 vi.mock('@dnd-kit/core', () => ({
-  DndContext: ({ children, onDragEnd }: { children: React.ReactNode; onDragEnd?: (event: any) => void }) => {
+  DndContext: ({
+    children,
+    onDragEnd,
+  }: {
+    children: React.ReactNode;
+    onDragEnd?: (event: any) => void;
+  }) => {
     dndCallbacks.onDragEnd = onDragEnd;
     return <div data-testid="dnd-context">{children}</div>;
   },
@@ -233,6 +239,9 @@ describe('DJOrderClient', () => {
       fireEvent.click(saveButton);
 
       expect(screen.getByRole('button', { name: /Saving.../i })).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Save Order/i })).toBeInTheDocument();
+      });
     });
 
     it('should handle save error', async () => {
@@ -280,6 +289,9 @@ describe('DJOrderClient', () => {
 
       const savingButton = screen.getByRole('button', { name: /Saving.../i });
       expect(savingButton).toBeDisabled();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Save Order/i })).toBeInTheDocument();
+      });
     });
   });
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,2 +1,11 @@
-// Vitest setup file
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
     environment: 'jsdom',
     include: ['**/*.test.ts', '**/*.test.tsx'],
     setupFiles: ['./test/setup.ts'],
+    clearMocks: true,
+    restoreMocks: true,
+    unstubGlobals: true,
+    unstubEnvs: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],


### PR DESCRIPTION
## Changes

- Add shared `afterEach` cleanup in `test/setup.ts` to reset React DOM, timers, mocks, global stubs, and env stubs between tests.
- Enable Vitest isolation flags in `vitest.config.ts` (`clearMocks`, `restoreMocks`, `unstubGlobals`, `unstubEnvs`) so state cannot leak across files.
- Update `DJOrderClient` saving-state tests to await async completion, preventing the unhandled rejection seen in CI (`ReferenceError: window is not defined` from a late `setState`).

## Verification

- [x] `yarn lint` exits 0
- [x] `yarn test` exits 0
- [ ] `yarn test:e2e` exits 0 (required if e2e tests were added or modified)
- [x] Screenshot attached below

## Screenshot

![Storybook rendering for the test-hardening branch](https://github.com/user-attachments/assets/602f6bac-515d-4105-9186-e818c4cc82f0)