### PR TITLE
feat: backfill OnDemand song relationships from legacy free-text lists

### DIFF
--- a/bin/migrations/shared/payloadClient.test.ts
+++ b/bin/migrations/shared/payloadClient.test.ts
@@ -31,6 +31,7 @@ vi.mock('dotenv', () => ({
 // Mock musicbrainz
 vi.mock('./musicbrainz', () => ({
   getArtistMbid: vi.fn(),
+  getRecordingMbid: vi.fn(),
 }));
 
 // Mock payload.config for getPayloadClient success path
@@ -41,11 +42,13 @@ vi.mock('../../../payload.config', () => ({
 describe('payloadClient', () => {
   let mockPayload: Partial<Payload>;
   let mockGetArtistMbid: Mock;
+  let mockGetRecordingMbid: Mock;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     const musicbrainz = await import('./musicbrainz');
     mockGetArtistMbid = musicbrainz.getArtistMbid as Mock;
+    mockGetRecordingMbid = musicbrainz.getRecordingMbid as Mock;
 
     mockPayload = {
       find: vi.fn(),
@@ -529,6 +532,8 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValue({ docs: [] });
+      (mockPayload.findByID as Mock).mockResolvedValue({ name: 'New Song Artist' });
+      mockGetRecordingMbid.mockResolvedValue('recording-mbid-123');
       (mockPayload.create as Mock).mockResolvedValue({ id: 'new-song-789' });
 
       const songId = await findOrCreateSong(mockPayload as Payload, 'New Song', 42);
@@ -539,6 +544,7 @@ describe('payloadClient', () => {
         data: {
           title: 'New Song',
           artist: 42,
+          musicbrainzId: 'recording-mbid-123',
         },
       });
     });
@@ -547,6 +553,7 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValue({ docs: [] });
+      mockGetRecordingMbid.mockResolvedValue(null);
       (mockPayload.create as Mock).mockResolvedValue({ id: 'new-song-999' });
 
       const songId = await findOrCreateSong(mockPayload as Payload, 'Orphan Song');
@@ -566,6 +573,31 @@ describe('payloadClient', () => {
       await expect(findOrCreateSong(mockPayload as Payload, '')).rejects.toThrow(
         'Song title is required',
       );
+    });
+
+    it('retries song creation without MBID on musicbrainzId conflict', async () => {
+      const { findOrCreateSong } = await import('./payloadClient');
+
+      (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Conflict Artist' });
+      mockGetRecordingMbid.mockResolvedValueOnce('duplicate-mbid');
+      const mbidError = {
+        status: 400,
+        data: { errors: [{ path: 'musicbrainzId', message: 'Value must be unique' }] },
+      };
+      (mockPayload.create as Mock).mockRejectedValueOnce(mbidError);
+      (mockPayload.create as Mock).mockResolvedValueOnce({ id: 'song-without-mbid' });
+
+      const songId = await findOrCreateSong(mockPayload as Payload, 'Conflict Song', 99);
+
+      expect(songId).toBe('song-without-mbid');
+      expect(mockPayload.create).toHaveBeenNthCalledWith(2, {
+        collection: 'songs',
+        data: {
+          title: 'Conflict Song',
+          artist: 99,
+        },
+      });
     });
   });
 
@@ -1021,13 +1053,14 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Song Artist' });
+      mockGetRecordingMbid.mockResolvedValueOnce(null);
       const slugError = {
         status: 400,
         data: { errors: [{ path: 'slug', message: 'Duplicate slug' }] },
         message: 'Duplicate slug',
       };
       (mockPayload.create as Mock).mockRejectedValueOnce(slugError);
-      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Song Artist' });
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [{ id: 'song-by-slug' }] });
 
       const songId = await findOrCreateSong(mockPayload as Payload, 'Duplicate Song', 10);
@@ -1040,6 +1073,7 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      mockGetRecordingMbid.mockResolvedValueOnce(null);
       const slugError = {
         status: 400,
         data: { errors: [{ path: 'slug', message: 'Duplicate slug' }] },
@@ -1058,13 +1092,14 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      (mockPayload.findByID as Mock).mockResolvedValueOnce({ id: 10 }); // no name field
+      mockGetRecordingMbid.mockResolvedValueOnce(null);
       const slugError = {
         status: 400,
         data: { errors: [{ path: 'slug', message: 'Duplicate slug' }] },
         message: 'Duplicate slug',
       };
       (mockPayload.create as Mock).mockRejectedValueOnce(slugError);
-      (mockPayload.findByID as Mock).mockResolvedValueOnce({ id: 10 }); // no name field
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [{ id: 'song-nameless-artist' }] });
 
       const songId = await findOrCreateSong(mockPayload as Payload, 'Nameless Artist Song', 10);
@@ -1076,6 +1111,8 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Some Artist' });
+      mockGetRecordingMbid.mockResolvedValueOnce(null);
       const genericError = { status: 500, message: 'Database error' };
       (mockPayload.create as Mock).mockRejectedValueOnce(genericError);
 
@@ -1088,18 +1125,41 @@ describe('payloadClient', () => {
       const { findOrCreateSong } = await import('./payloadClient');
 
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Artist Name' });
+      mockGetRecordingMbid.mockResolvedValueOnce(null);
       const slugError = {
         status: 400,
         data: { errors: [{ path: 'slug', message: 'Duplicate slug' }] },
         message: 'Duplicate slug',
       };
       (mockPayload.create as Mock).mockRejectedValueOnce(slugError);
-      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Artist Name' });
       (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
 
       await expect(
         findOrCreateSong(mockPayload as Payload, 'Ghost Song', 12),
       ).rejects.toEqual(slugError);
+    });
+
+    it('should resolve slug conflict when artist name fetch fails before create', async () => {
+      const { findOrCreateSong } = await import('./payloadClient');
+
+      (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [] });
+      // pre-create artist fetch throws — artistName stays ''
+      (mockPayload.findByID as Mock).mockRejectedValueOnce(new Error('DB timeout'));
+      mockGetRecordingMbid.mockResolvedValueOnce(null);
+      const slugError = {
+        status: 400,
+        data: { errors: [{ path: 'slug', message: 'Duplicate slug' }] },
+        message: 'Duplicate slug',
+      };
+      (mockPayload.create as Mock).mockRejectedValueOnce(slugError);
+      // retry fetch inside slug handler succeeds
+      (mockPayload.findByID as Mock).mockResolvedValueOnce({ name: 'Recovered Artist' });
+      (mockPayload.find as Mock).mockResolvedValueOnce({ docs: [{ id: 'song-recovered' }] });
+
+      const songId = await findOrCreateSong(mockPayload as Payload, 'Recovered Song', 20);
+
+      expect(songId).toBe('song-recovered');
     });
   });
 });

--- a/bin/migrations/shared/payloadClient.ts
+++ b/bin/migrations/shared/payloadClient.ts
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import type { Payload } from 'payload';
 import { getPayload } from 'payload';
 import { createLogger } from './logger';
-import { getArtistMbid } from './musicbrainz';
+import { getArtistMbid, getRecordingMbid } from './musicbrainz';
 import { generateSlug, generateMusicSlug, stripHtmlTags } from './importUtils';
 
 const logger = createLogger('PayloadClient');
@@ -502,39 +502,77 @@ export async function findOrCreateSong(
     return existing.docs[0].id;
   }
 
+  let recordingMbid: string | null = null;
+  let artistName = '';
+  if (artistId) {
+    try {
+      const artist = await payload.findByID({ collection: 'artists', id: artistId });
+      artistName = artist?.name || '';
+    } catch {
+      /* ignore */
+    }
+  }
   try {
-    const songData = {
-      title: cleanTitle,
-      ...(artistId && { artist: artistId }),
-    };
+    recordingMbid = await getRecordingMbid(cleanTitle, artistName || undefined);
+  } catch {
+    logger.debug(`MusicBrainz recording lookup failed for "${cleanTitle}"`);
+  }
 
+  const baseSongData = {
+    title: cleanTitle,
+    ...(artistId && { artist: artistId }),
+  };
+
+  const resolveBySlug = async (resolvedArtistName: string) => {
+    const slug = generateMusicSlug(resolvedArtistName, cleanTitle);
+    return findDocBySlug(payload, 'songs', slug);
+  };
+
+  const fetchArtistName = async (): Promise<string> => {
+    if (!artistId) return '';
+    try {
+      const artist = await payload.findByID({ collection: 'artists', id: artistId });
+      return artist?.name || '';
+    } catch {
+      return '';
+    }
+  };
+
+  try {
     const newSong = await payload.create({
       collection: 'songs',
-      data: songData,
+      data: { ...baseSongData, musicbrainzId: recordingMbid || undefined },
     });
-
     logger.debug(`Created song: ${cleanTitle}`);
     return newSong.id;
   } catch (error: any) {
-    const isSlugError = isFieldError(error, 'slug');
+    const isMbidError = isFieldError(error, 'musicbrainzId');
 
-    if (isSlugError) {
-      logger.debug(`Slug validation failed for song: ${cleanTitle}, searching by slug...`);
-
-      let artistName = '';
-      if (artistId) {
-        try {
-          const artist = await payload.findByID({ collection: 'artists', id: artistId });
-          artistName = artist?.name || '';
-        } catch {
-          /* ignore */
+    if (isMbidError) {
+      logger.debug(`MusicBrainz ID conflict for song "${cleanTitle}", retrying without MBID`);
+      try {
+        const newSong = await payload.create({ collection: 'songs', data: baseSongData });
+        logger.debug(`Created song without MBID: ${cleanTitle}`);
+        return newSong.id;
+      } catch (retryError) {
+        if (isFieldError(retryError, 'slug')) {
+          const name = artistName || (await fetchArtistName());
+          const id = await resolveBySlug(name);
+          if (id !== null) {
+            logger.debug(`Found existing song by slug after MBID retry: "${cleanTitle}" (id: ${id})`);
+            return id;
+          }
         }
+        throw retryError;
       }
+    }
 
-      const slug = generateMusicSlug(artistName, cleanTitle);
-      const id = await findDocBySlug(payload, 'songs', slug);
+    if (isFieldError(error, 'slug')) {
+      logger.debug(`Slug validation failed for song: ${cleanTitle}, searching by slug...`);
+      const name = artistName || (await fetchArtistName());
+      const id = await resolveBySlug(name);
       if (id !== null) {
-        logger.debug(`Found existing song by slug: "${cleanTitle}" -> "${slug}" (id: ${id})`);
+        logger.debug(`Found existing song by slug: "${cleanTitle}" (id: ${id})`);
         return id;
       }
     }

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -2,7 +2,12 @@ const eslintCmd = (files) =>
   `eslint --fix --max-warnings=0 --ignore-pattern 'bin/check-test-story-files.ts' --ignore-pattern '.storybook/*' --ignore-pattern 'payload/migrations/*' ${files.join(' ')}`;
 
 const filterLintIgnored = (files) =>
-  files.filter((f) => !f.includes('/.storybook/') && !f.endsWith('next-env.d.ts'));
+  files.filter(
+    (f) =>
+      !f.includes('/.storybook/') &&
+      !f.endsWith('next-env.d.ts') &&
+      !f.includes('/bin/migrations/'),
+  );
 
 export default {
   '!(*.test).{ts,tsx}': (files) => {


### PR DESCRIPTION
## Summary

- **OnDemand links:** Render `target="_blank" rel="noopener noreferrer"` on Lexical link nodes that have `fields.newTab = true` (PHP trait change)
- **Song migration — stale artistName bug:** The `findOrCreateSong` refactor moved the artist-name fetch before `payload.create`, but swallowed errors silently. If that fetch threw, `artistName` stayed `''` and slug recovery in both the `isSlugError` and `isMbidError → slug retry` paths generated the wrong slug, causing the migration to abort instead of recovering. Fixed by fetching artist name lazily on-demand inside conflict handlers via a shared `fetchArtistName` helper.
- **Duplicated create payload:** Extracted `baseSongData` to remove the duplicate `{ title, artist }` shape in the MBID retry block — new fields added to song creation will no longer silently be omitted from retries.
- **Test coverage:** Added test for the previously undetected regression path (pre-create `findByID` throws + slug conflict). Updated existing slug-conflict tests to match the new mock ordering.
- **lint-staged fix:** Excluded `bin/migrations/` from the lint-staged ESLint run (those files are already excluded in ESLint config, causing a spurious warning that failed `--max-warnings=0`).

## Test plan

- [ ] `yarn vitest run bin/migrations/shared/payloadClient.test.ts` — 128 tests pass
- [ ] Manual: create an OnDemand show with a YouTube link set to "Open in new tab" — verify `target="_blank"` appears in rendered HTML
- [ ] Manual: run `yarn import:ondemand-songs` against a staging DB with a known MBID conflict — verify the song is created without MBID rather than aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)