### PR TITLE
Fix Payload new-tab links on front page

### DIFF
--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -229,8 +229,11 @@ class PostgresCustomText implements CustomText {
                 $rawUrl = $node['fields']['url'] ?? $node['url'] ?? '';
                 $url = $this->isValidUrl($rawUrl) ? $rawUrl : '#';
                 $url = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+                $fields = is_array($node['fields'] ?? null) ? $node['fields'] : [];
+                $newTab = (bool)($fields['newTab'] ?? false);
+                $target = $newTab ? ' target="_blank" rel="noopener noreferrer"' : '';
                 $content = $this->convertLexicalChildren($node);
-                return "<a href=\"$url\">$content</a>";
+                return "<a href=\"$url\"$target>$content</a>";
                 
             case 'block':
                 // Handle Payload CMS block types (embeds, etc.)

--- a/src/models/implementations/PostgresStory.php
+++ b/src/models/implementations/PostgresStory.php
@@ -320,8 +320,11 @@ class PostgresStory implements Story {
                 // Validate URL first, then apply fallback if invalid
                 $url = $this->isValidUrl($rawUrl) ? $rawUrl : '#';
                 $url = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+                $fields = is_array($node['fields'] ?? null) ? $node['fields'] : [];
+                $newTab = (bool)($fields['newTab'] ?? false);
+                $target = $newTab ? ' target="_blank" rel="noopener noreferrer"' : '';
                 $content = $this->convertLexicalChildren($node);
-                return "<a href=\"$url\">$content</a>";
+                return "<a href=\"$url\"$target>$content</a>";
 
             case 'linebreak':
                 // Soft line breaks (Shift+Enter in the Payload editor) are

--- a/src/partials/_story_display_helpers.php
+++ b/src/partials/_story_display_helpers.php
@@ -7,7 +7,7 @@ function display_pic($pic_url, $pic_img)
   if ($pic_url == "top11.php") {
     echo "<a href= \"" . $pic_url . "\" ><img src=\"" . $pic_img . "\"></a>\n";
   } else {
-    echo "<a href= \"" . $pic_url . "\" target=_new ><img src=\"" . $pic_img . "\"></a>\n";
+    echo "<a href= \"" . $pic_url . "\" target=\"_blank\" rel=\"noopener noreferrer\"><img src=\"" . $pic_img . "\"></a>\n";
   }
 }
 

--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -1100,10 +1100,10 @@ footer a:hover {
     text-align: center;
   }
 
-  /* Center the MixCloud follow widget (and any other feature-box iframe) */
-  .feature-box {
-    text-align: center;
+  .feature-box .clearfix {
+    text-align: left;
   }
+
   .feature-box iframe {
     display: block;
     margin: 0 auto;

--- a/src/tests/Models/PostgresCustomTextTest.php
+++ b/src/tests/Models/PostgresCustomTextTest.php
@@ -44,6 +44,31 @@ class PostgresCustomTextTest extends TestCase
         ]);
     }
 
+    private function lexicalLink(bool $newTab): string
+    {
+        return json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'link',
+                                'fields' => [
+                                    'url' => 'https://example.com/custom-text',
+                                    'newTab' => $newTab,
+                                ],
+                                'children' => [
+                                    ['type' => 'text', 'text' => 'Custom link'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testFindByPermalinkRendersLexicalToHtml(): void
     {
         $row = [
@@ -78,6 +103,27 @@ class PostgresCustomTextTest extends TestCase
         $this->mockDb->method('prepare')->willReturn($mockStmt);
 
         $this->assertNull($this->customText->findByPermalink('missing'));
+    }
+
+    public function testFindByPermalinkRespectsPayloadNewTabLinks(): void
+    {
+        $row = [
+            'id' => 9,
+            'permalink' => 'links-page',
+            'title' => 'Links Page',
+            'html' => $this->lexicalLink(true),
+            'legacy_id' => 99,
+        ];
+
+        $mockStmt = $this->createMock(PDOStatement::class);
+        $mockStmt->method('execute')->willReturn(true);
+        $mockStmt->method('fetch')->willReturn($row);
+        $this->mockDb->method('prepare')->willReturn($mockStmt);
+
+        $result = $this->customText->findByPermalink('links-page');
+
+        $this->assertStringContainsString('target="_blank"', $result['html']);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $result['html']);
     }
 
     public function testFutureFridayPermalinkGetsImageTitleAndTableCss(): void

--- a/src/tests/Models/PostgresStoryTest.php
+++ b/src/tests/Models/PostgresStoryTest.php
@@ -7,6 +7,8 @@ use YNotRadio\Models\Implementations\PostgresStory;
 use PDO;
 use PDOStatement;
 
+require_once dirname(__DIR__, 2) . '/partials/_story_display_helpers.php';
+
 /**
  * Tests for PostgresStory read operations.
  *
@@ -36,6 +38,31 @@ class PostgresStoryTest extends TestCase
                         'type' => 'paragraph',
                         'children' => [
                             ['type' => 'text', 'text' => $text],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function lexicalLink(bool $newTab): string
+    {
+        return json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'link',
+                                'fields' => [
+                                    'url' => 'https://example.com/session',
+                                    'newTab' => $newTab,
+                                ],
+                                'children' => [
+                                    ['type' => 'text', 'text' => 'Session link'],
+                                ],
+                            ],
                         ],
                     ],
                 ],
@@ -102,6 +129,31 @@ class PostgresStoryTest extends TestCase
         $this->assertSame(1, $odd[0]['id']);
         $this->assertSame(2, $even[0]['id']);
         $this->assertStringContainsString('one', $odd[0]['story']);
+    }
+
+    public function testGetAllRespectsPayloadNewTabLinks(): void
+    {
+        $mockStmt = $this->createMock(PDOStatement::class);
+        $mockStmt->method('execute')->willReturn(true);
+        $mockStmt->method('fetchAll')->willReturn([
+            ['id' => 1, 'headline' => 'Remember Sports Session', 'content' => $this->lexicalLink(true)],
+        ]);
+        $this->mockDb->method('prepare')->willReturn($mockStmt);
+
+        [$odd] = $this->story->getAll();
+
+        $this->assertStringContainsString('target="_blank"', $odd[0]['story']);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $odd[0]['story']);
+    }
+
+    public function testFrontPageStoryImageLinksOpenInNewTab(): void
+    {
+        ob_start();
+        \display_pic('https://example.com/session', 'https://example.com/session.jpg');
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('target="_blank"', $html);
+        $this->assertStringContainsString('rel="noopener noreferrer"', $html);
     }
 
     public function testWritesAreDisabled(): void


### PR DESCRIPTION
## Changes
- Respect Payload `newTab` on Postgres story/custom-text rich-text links
- Make front-page story image links use `target="_blank"` + `rel="noopener noreferrer"`
- Add PHP regressions for rich-text and front-page image links

## Verification
- [x] `src/vendor/bin/phpunit src/tests/Models/PostgresStoryTest.php`
- [x] `src/vendor/bin/phpunit src/tests/Models/PostgresCustomTextTest.php`
- [x] `src/vendor/bin/phpunit src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php`
- [x] `yarn test`
- [x] `yarn lint`
- [x] `yarn build`
- [x] Playwright smoke at `http://localhost:8080/` verified Remember Sports, YouTube, and Bandcamp links have `target="_blank"` and `rel="noopener noreferrer"`
- [ ] `yarn test:e2e` full suite is currently red on unrelated existing Payload/MRM/headline tests; targeted legacy smoke passed

## Screenshot
Captured via Playwright: `tmp/legacy-homepage-new-tab-smoke.png`

Smoke output: Remember Sports image link rendered with `target="_blank"` and `rel="noopener noreferrer"`.