### PR TITLE
Fix legacy CP Payload admin links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Payload Core
 PAYLOAD_SECRET=replace-with-dev-secret
 PAYLOAD_PUBLIC_SERVER_URL=http://localhost:3000
+PAYLOAD_ADMIN_SERVER_URL=http://localhost:3000
 PORT=3000
 
 # Development Auto-Login (optional, for faster local development)

--- a/.env.production.example
+++ b/.env.production.example
@@ -5,6 +5,7 @@
 # Payload Core
 PAYLOAD_SECRET=replace-with-production-secret-in-netlify
 PAYLOAD_PUBLIC_SERVER_URL=https://www.ynotradio.net
+PAYLOAD_ADMIN_SERVER_URL=https://ynotradio-admin.netlify.app
 PORT=3000
 
 # Production Neon PostgreSQL

--- a/src/cp/index.php
+++ b/src/cp/index.php
@@ -4,6 +4,7 @@ $page_file = "index.php";
 $page_title = "Control Panel";
 
 require ("../functions/main_fns.php");
+require ("../functions/payload_fns.php");
 require ("../partials/_header.php");
 
 if (!$_SESSION["logged_in"]) {
@@ -19,26 +20,26 @@ if (!$_SESSION["logged_in"]) {
         <tr>
           <td width="275px">
             <dt>Ads</dt>
-              <dd>Edit in <a href="/admin/collections/ads">Payload &rarr; Ads</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('ads'); ?>">Payload &rarr; Ads</a></dd>
             <dt>CD of The Week</dt>
-              <dd>Edit in <a href="/admin/collections/cd-of-the-week">Payload &rarr; CD of The Week</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('cdoftheweek'); ?>">Payload &rarr; CD of The Week</a></dd>
             <dt>Concerts</dt>
-              <dd>Edit in <a href="/admin/collections/concerts">Payload &rarr; Concerts</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('concerts'); ?>">Payload &rarr; Concerts</a></dd>
             <dt>Custom Text Pages</dt>
-              <dd>Edit in <a href="/admin/collections/posts">Payload &rarr; Posts</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('posts'); ?>">Payload &rarr; Posts</a></dd>
             <dt>Deejays</dt>
-              <dd>Edit in <a href="/admin/collections/deejays">Payload &rarr; Deejays</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('djs'); ?>">Payload &rarr; Deejays</a></dd>
           </td>
           <td width="275px">
             <dt>New Music</dt>
-              <dd>Edit in <a href="/admin/collections/music">Payload &rarr; New Music</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('records'); ?>">Payload &rarr; Records</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('songs'); ?>">Payload &rarr; Songs</a></dd>
             <dt>On Demand</dt>
-              <dd>Edit in <a href="/admin/collections/on-demand">Payload &rarr; On Demand</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('ondemand'); ?>">Payload &rarr; On Demand</a></dd>
             <dt>Schedule</dt>
-              <dd><a href="schedule_add.php">Add to Schedule</a></dd>
-              <dd><a href="schedule_view_all.php">View Schedule</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('shows'); ?>">Payload &rarr; Schedule</a></dd>
             <dt>Stories</dt>
-              <dd>Edit in <a href="/admin/collections/posts">Payload &rarr; Stories</a></dd>
+              <dd>Edit in <a href="<?php echo get_payload_collection_url('posts'); ?>">Payload &rarr; Stories</a></dd>
           </td>
           <td width="275px">
             <dt>Top 11 @ 11</dt>

--- a/src/functions/payload_fns.php
+++ b/src/functions/payload_fns.php
@@ -14,8 +14,18 @@ require_once __DIR__ . '/../lib/Database.php';
  * Return the Payload admin base URL (no trailing slash), e.g. "http://localhost:3000/admin".
  */
 function get_payload_admin_url(): string {
-    $base = $_ENV['PAYLOAD_PUBLIC_SERVER_URL'] ?? getenv('PAYLOAD_PUBLIC_SERVER_URL') ?: 'https://ynotradio-admin.netlify.app';
-    return rtrim($base, '/') . '/admin';
+    $base = $_ENV['PAYLOAD_ADMIN_SERVER_URL'] ?? getenv('PAYLOAD_ADMIN_SERVER_URL');
+    $payload_public_url = $_ENV['PAYLOAD_PUBLIC_SERVER_URL'] ?? getenv('PAYLOAD_PUBLIC_SERVER_URL');
+
+    if (
+        !$base
+        && $payload_public_url
+        && preg_match('#^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$#', $payload_public_url)
+    ) {
+        $base = $payload_public_url;
+    }
+
+    return rtrim($base ?: 'https://ynotradio-admin.netlify.app', '/') . '/admin';
 }
 
 /**

--- a/src/tests/Functions/PayloadFnsTest.php
+++ b/src/tests/Functions/PayloadFnsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace YNotRadio\Tests\Functions;
+
+use YNotRadio\Tests\TestCase;
+
+require_once __DIR__ . '/../../functions/payload_fns.php';
+
+class PayloadFnsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->clearPayloadEnv();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearPayloadEnv();
+    }
+
+    private function clearPayloadEnv(): void
+    {
+        unset($_ENV['PAYLOAD_ADMIN_SERVER_URL'], $_ENV['PAYLOAD_PUBLIC_SERVER_URL']);
+        putenv('PAYLOAD_ADMIN_SERVER_URL');
+        putenv('PAYLOAD_PUBLIC_SERVER_URL');
+    }
+
+    public function testPayloadAdminUrlDefaultsToNetlifyAdmin(): void
+    {
+        $this->assertSame('https://ynotradio-admin.netlify.app/admin', get_payload_admin_url());
+    }
+
+    public function testPayloadAdminUrlUsesAdminOverride(): void
+    {
+        $_ENV['PAYLOAD_ADMIN_SERVER_URL'] = 'https://example-admin.netlify.app/';
+
+        $this->assertSame('https://example-admin.netlify.app/admin', get_payload_admin_url());
+    }
+
+    public function testPayloadAdminUrlAllowsLocalPayloadPublicServer(): void
+    {
+        $_ENV['PAYLOAD_PUBLIC_SERVER_URL'] = 'http://localhost:3000';
+
+        $this->assertSame('http://localhost:3000/admin', get_payload_admin_url());
+    }
+
+    public function testPayloadAdminUrlIgnoresPublicSiteUrl(): void
+    {
+        $_ENV['PAYLOAD_PUBLIC_SERVER_URL'] = 'https://www.ynotradio.net';
+
+        $this->assertSame('https://ynotradio-admin.netlify.app/admin', get_payload_admin_url());
+    }
+
+    public function testPayloadCollectionUrlUsesPayloadAdminUrl(): void
+    {
+        $_ENV['PAYLOAD_ADMIN_SERVER_URL'] = 'https://example-admin.netlify.app';
+
+        $this->assertSame(
+            'https://example-admin.netlify.app/admin/collections/shows',
+            get_payload_collection_url('shows')
+        );
+    }
+}


### PR DESCRIPTION
## Changes
- Route legacy `/cp/` Payload links through the Netlify admin app
- Add Schedule to Payload links and keep Top 11 / Year End legacy
- Fix stale collection slugs and add helper tests

## Verification
- [x] `yarn lint` exits 0
- [x] `CI=true yarn test` exits 0
- [x] `yarn build` exits 0
- [x] `vendor/bin/phpunit tests/Functions/PayloadFnsTest.php` exits 0

## Screenshot
Draft PR: screenshot pending.