### PR TITLE
Restore custom text control panel with MySQL backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ POSTGRES_USER=REPLACE_ME
 POSTGRES_PASSWORD=REPLACE_ME
 POSTGRES_SSL_MODE=disable
 USE_POSTGRES_TOP11=false
+# Serve custom text pages from Postgres (default false = MySQL) while the
+# Postgres/Payload front-end output is validated.
+USE_POSTGRES_CUSTOMTEXT=false
 
 # Security
 PAYLOAD_CORS=http://localhost:3000,http://localhost:5173

--- a/.env.php.example
+++ b/.env.php.example
@@ -24,6 +24,8 @@ POSTGRES_SSL_MODE=require
 
 # Legacy PHP feature flags (optional)
 USE_POSTGRES_TOP11=false
+# Serve custom text pages from Postgres (default false = MySQL).
+USE_POSTGRES_CUSTOMTEXT=false
 
 # Media Storage (optional)
 CLOUDINARY_CLOUD_NAME=your-cloud-name

--- a/src/config/features.php
+++ b/src/config/features.php
@@ -2,7 +2,13 @@
 
 return [
     // Top 11 @ 11 has no Postgres/Payload adapter yet, so it stays on MySQL.
-    // Stories and custom text were cut over to Postgres directly (their
-    // factories no longer consult a flag).
     'use_postgres_top11' => false,
+
+    // Custom text reads are flagged between MySQL and Postgres while the
+    // Postgres/Payload front-end output is validated. Default off (MySQL);
+    // flip to true (env var USE_POSTGRES_CUSTOMTEXT or `?ff=use_postgres_customtext`)
+    // to serve custom text pages from Postgres. CP edit screens always use
+    // MySQL regardless (use_postgres_* is suppressed on /cp routes).
+    // Stories were cut over to Postgres directly (factory does not consult a flag).
+    'use_postgres_customtext' => false,
 ];

--- a/src/cp/custom_text_add.php
+++ b/src/cp/custom_text_add.php
@@ -1,0 +1,69 @@
+<?php
+
+$page_file = "custom_text_add.php";
+$page_title = "Add a Custom Text";
+
+require ("../functions/main_fns.php");
+require_once ("../models/CustomTextFactory.php");
+require ("../partials/_header.php");
+
+$action = $_POST['action'];
+
+if (!$_SESSION["logged_in"]) {
+  login_prompt($_POST['username'],$_POST['remember_me'],$_SESSION["error"]);
+} else {
+
+/*----- CONTENT ------*/
+?>
+<div class="row">
+  <div class="tweleve columns content full-width">
+    <h1>Add a Custom Text</h1>
+      <?php if ($action != "insert") { ?>
+      <form action="custom_text_add.php" method="post" class="form-internal inline input-seperation" id="admin">
+        <?php require ("../partials/_custom_text_form.php"); ?>
+      </form>
+    <?php
+      } else {
+        $title = $_POST['title'];
+        $html = $_POST['html'];
+
+        if (!$title || !$html)
+          echo '<div class="top-spacer_20 center error">Error - missing required value(s)</div>';
+        else {
+          $db = open_db();
+          $customTextModel = \YNotRadio\Models\CustomTextFactory::create($db);
+          
+          try {
+            $data = [
+              'title' => $title,
+              'html' => $html
+            ];
+            $newId = $customTextModel->add($data);
+            
+            echo "<div class=\"center\"><h1>Success!</h1>".
+                 "<h3>New Custom Text has been saved</h3>".
+                 "<hr width=75%>";
+            
+            $customText = $customTextModel->getById($newId);
+            echo "<b>Title:</b> ". $customText['title'].
+                 "<br><b>Permalink:</b> ". $customText['permalink'].
+                 "<br><b>Url:</b> <a href=\"../pages.php?page=".$customText['permalink']."\" target=\"_new\">http://www.ynotradio.net/pages.php?page=".$customText['permalink']."</a>".
+                 "<br><b>Copy:</b><br>". $customText['html'];
+            echo "</div>";
+          } catch (\Exception $e) {
+            echo '<div class="top-spacer_20 center error">Error: ' . $e->getMessage() . '</div>';
+          }
+        }
+      }
+    ?>
+    <div class="top-spacer_20">
+      <?php if ($action == 'insert')
+        echo "<a href=\"".$page_file."\">Add another Custom Text</a>\n<p>";
+      ?>
+      <a href="index.php">Control Panel</a>
+    </div>
+  </div>
+</div> <!-- end of row div -->
+<?php }
+  require ("../partials/_footer.php");
+?>

--- a/src/cp/custom_text_delete.php
+++ b/src/cp/custom_text_delete.php
@@ -1,0 +1,54 @@
+<?php
+
+$page_file = "custom_text_delete.php";
+$page_title = "Delete a Custom Text";
+
+require ("../functions/main_fns.php");
+require_once ("../models/CustomTextFactory.php");
+require ("../partials/_header.php");
+
+$id = $_GET['id'];
+
+if (!$_SESSION["logged_in"]) {
+  login_prompt($_POST['username'],$_POST['remember_me'],$_SESSION["error"]);
+} else {
+
+/*----- CONTENT ------*/
+?>
+<div class="row">
+  <div class="tweleve columns content full-width">
+    <h1>Delete a Custom Text</h1>
+    <?php
+      if (!$id) {
+        echo '<div class="top-spacer_20 center error">Error - missing ID value</div>';
+      } else {
+        $db = open_db();
+        $customTextModel = \YNotRadio\Models\CustomTextFactory::create($db);
+        
+        try {
+          // Get the custom text before deletion for the success message
+          $customText = $customTextModel->getById($id);
+          
+          $result = $customTextModel->delete($id);
+          
+          if ($result) {
+            echo "<div class=\"center\"><h1>Success!</h1>".
+                 "<h3>The custom text <span class=\"success\">". $customText['title'] ."</span> has been deleted.</h3></div>";
+          } else {
+            echo '<div class="top-spacer_20 center error">Error deleting the custom text</div>';
+          }
+        } catch (\Exception $e) {
+          echo '<div class="top-spacer_20 center error">Error: ' . $e->getMessage() . '</div>';
+        }
+      }
+    ?>
+    <div class="top-spacer_20">
+      <a href="custom_text_view_all.php">View all Custom Texts</a>
+      <p>
+      <a href="index.php">Control Panel</a>
+    </div>
+  </div>
+</div> <!-- end of row div -->
+<?php }
+  require ("../partials/_footer.php");
+?>

--- a/src/cp/custom_text_update.php
+++ b/src/cp/custom_text_update.php
@@ -1,0 +1,82 @@
+<?php
+
+$page_file = "custom_text_update.php";
+$page_title = "Update Custom Text";
+
+require ("../functions/main_fns.php");
+require ("../functions/payload_fns.php");
+require_once ("../models/CustomTextFactory.php");
+require ("../partials/_header.php");
+
+$id = $_GET['id'];
+
+if ($_POST['action'] != "update")
+	$action = "update";
+
+if (!$_SESSION["logged_in"]) {
+  login_prompt($_POST['username'],$_POST['remember_me'],$_SESSION["error"]);
+} else {
+
+/*----- CONTENT ------*/
+?>
+<div class="row">
+  <div class="tweleve columns content full-width">
+    <h1>Update a Custom Text</h1>
+    <?php
+      if (!$id) {
+        echo '<div class="top-spacer_20 center error">Error - missing ID value</div>';
+      } elseif ($action == "update"){
+        $db = open_db();
+        $customTextModel = \YNotRadio\Models\CustomTextFactory::create($db);
+        $custom_text = $customTextModel->getById($id);
+        
+        echo "<form action=\"custom_text_update.php?id=".$id."\" method=\"post\" class=\"form-internal inline input-seperation\" id=\"admin\">";
+        require ("../partials/_custom_text_form.php");
+        echo "</form>";
+      } else {
+        $title = $_POST['title'];
+        $html = $_POST['html'];
+
+        if (!$title || !$html) {
+          echo '<div class="top-spacer_20 center error">Error - missing required value(s)</div>';
+        } else {
+          $db = open_db();
+          $customTextModel = \YNotRadio\Models\CustomTextFactory::create($db);
+          
+          try {
+            $data = [
+              'title' => $title,
+              'html' => $html
+            ];
+            $result = $customTextModel->update($id, $data);
+            
+            if ($result) {
+              echo '<div class="top-spacer_20"><h1 class="center">Update was successful!</h1>';
+              $customText = $customTextModel->getById($id);
+              echo "<b>Title:</b> ". $customText['title'].
+                   "<br><b>Permalink:</b> ". $customText['permalink'].
+                   "<br><b>Url:</b> <a href=\"../pages.php?page=".$customText['permalink']."\" target=\"_new\">http://www.ynotradio.net/pages.php?page=".$customText['permalink']."</a>".
+                   "<br><b>Copy:</b><br>". $customText['html'];
+              echo "</div>";
+            }
+          } catch (\Exception $e) {
+            echo '<div class="top-spacer_20 center error">Error: ' . $e->getMessage() . '</div>';
+          }
+        }
+      }
+    ?>
+    <div class="top-spacer_20">
+      <a href="custom_text_view_all.php">View all Custom Texts</a>
+      <p>
+      <?php $payload_edit_url = $id ? get_payload_edit_url('posts', 'posts', (int) $id + 10000) : null; ?>
+      <?php if ($payload_edit_url): ?>
+        <a href="<?php echo htmlspecialchars($payload_edit_url); ?>" target="_blank">Edit in Payload ↗</a>
+        <p>
+      <?php endif; ?>
+      <a href="index.php">Control Panel</a>
+    </div>
+  </div>
+</div> <!-- end of row div -->
+<?php }
+  require ("../partials/_footer.php");
+?>

--- a/src/cp/custom_text_view_all.php
+++ b/src/cp/custom_text_view_all.php
@@ -1,0 +1,42 @@
+<?php
+
+$page_file = "custom_text_view_all.php";
+$page_title = "View All Custom Texts";
+
+require ("../functions/main_fns.php");
+require ("../functions/payload_fns.php");
+require_once ("../models/CustomTextFactory.php");
+require ("../partials/_header.php");
+
+if (!$_SESSION["logged_in"]) {
+  login_prompt($_POST['username'],$_POST['remember_me'],$_SESSION["error"]);
+} else {
+
+/*----- CONTENT ------*/
+?>
+<div class="row">
+  <div class="tweleve columns content full-width">
+    <h1>View all Custom Texts</h1>
+      <?php 
+        $db = open_db();
+        $customTextModel = \YNotRadio\Models\CustomTextFactory::create($db);
+        $customTexts = $customTextModel->getAll();
+        
+        echo '<ol>';
+        foreach ($customTexts as $customText) {
+          echo "<b>Title:</b> ". $customText['title'] .
+               "<br><b>Permalink:</b> " . $customText['permalink'] .
+               '<br>[ <a href="custom_text_update.php?id=' .$customText['id']. '">Edit</a> | <a href="custom_text_delete.php?id=' .$customText['id']. '">Delete</a> ] <p>';
+        }
+        echo '</ol>';
+      ?>
+    <div class="top-spacer_20">
+      <a href="<?php echo htmlspecialchars(get_payload_collection_url('posts')); ?>" target="_blank">View in Payload ↗</a>
+      <p>
+      <a href="index.php">Control Panel</a>
+    </div>
+  </div>
+</div> <!-- end of row div -->
+<?php }
+  require ("../partials/_footer.php");
+?>

--- a/src/cp/index.php
+++ b/src/cp/index.php
@@ -26,6 +26,8 @@ if (!$_SESSION["logged_in"]) {
             <dt>Concerts</dt>
               <dd>Edit in <a href="<?php echo get_payload_collection_url('concerts'); ?>">Payload &rarr; Concerts</a></dd>
             <dt>Custom Text Pages</dt>
+              <dd><a href="custom_text_add.php">Add Custom Text</a></dd>
+              <dd><a href="custom_text_view_all.php">View all Custom Text</a></dd>
               <dd>Edit in <a href="<?php echo get_payload_collection_url('posts'); ?>">Payload &rarr; Posts</a></dd>
             <dt>Deejays</dt>
               <dd>Edit in <a href="<?php echo get_payload_collection_url('djs'); ?>">Payload &rarr; Deejays</a></dd>

--- a/src/models/CustomTextFactory.php
+++ b/src/models/CustomTextFactory.php
@@ -4,15 +4,33 @@ namespace YNotRadio\Models;
 
 require_once(__DIR__ . "/CustomText.php");
 require_once(__DIR__ . "/implementations/PostgresCustomText.php");
+require_once(__DIR__ . "/implementations/SqlCustomText.php");
+require_once(__DIR__ . "/FeatureManager.php");
 require_once(__DIR__ . "/../lib/Database.php");
 
 use YNotRadio\Models\Implementations\PostgresCustomText;
+use YNotRadio\Models\Implementations\SqlCustomText;
 use YNotRadio\Lib\Database;
 
 class CustomTextFactory
 {
+    /**
+     * Create a CustomText implementation.
+     *
+     * Custom text reads are flagged between MySQL and Postgres while we
+     * validate the Postgres/Payload front-end output. When
+     * `use_postgres_customtext` is enabled the read path is served from
+     * Postgres; otherwise (the default) it falls back to MySQL. Control
+     * Panel requests always resolve to MySQL because FeatureManager
+     * suppresses `use_postgres_*` flags there, so the restored CP edit
+     * screens continue to read and write the legacy `custom_texts` table.
+     */
     public static function create($db): CustomText
     {
-        return new PostgresCustomText(Database::getPostgres());
+        if (FeatureManager::isEnabled('use_postgres_customtext')) {
+            return new PostgresCustomText(Database::getPostgres());
+        }
+
+        return new SqlCustomText($db);
     }
 }

--- a/src/models/implementations/SqlCustomText.php
+++ b/src/models/implementations/SqlCustomText.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace YNotRadio\Models\Implementations;
+
+use YNotRadio\Models\CustomText;
+
+/**
+ * SQL implementation of the CustomText interface
+ */
+class SqlCustomText implements CustomText
+{
+    /**
+     * @var mixed Database connection
+     */
+    private $db;
+
+    /**
+     * Constructor
+     *
+     * @param mixed $db Database connection
+     */
+    public function __construct($db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAll(): array
+    {
+        $query = "SELECT * FROM custom_texts WHERE status = 'active'";
+        $result = mysqli_query($this->db, $query);
+
+        if (!$result) {
+            return [];
+        }
+
+        $customTexts = [];
+        while ($row = mysqli_fetch_assoc($result)) {
+            $customTexts[] = $row;
+        }
+
+        return $customTexts;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getById(int $id): ?array
+    {
+        $query = "SELECT * FROM custom_texts WHERE status = 'active' AND id = " . $id;
+        $result = mysqli_query($this->db, $query);
+
+        if (!$result || mysqli_num_rows($result) === 0) {
+            return null;
+        }
+
+        return mysqli_fetch_assoc($result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findByPermalink(string $permalink): ?array
+    {
+        $safePermalink = mysqli_real_escape_string($this->db, $permalink);
+        $query = "SELECT * FROM custom_texts WHERE status = 'active' AND permalink = '" . $safePermalink . "'";
+        $result = mysqli_query($this->db, $query);
+
+        if (!$result || mysqli_num_rows($result) === 0) {
+            return null;
+        }
+
+        return mysqli_fetch_assoc($result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(array $data): int
+    {
+        if (!isset($data['title']) || !isset($data['html'])) {
+            throw new \InvalidArgumentException("Title and HTML content are required");
+        }
+
+        $title = mysqli_real_escape_string($this->db, $data['title']);
+        $html = mysqli_real_escape_string($this->db, $data['html']);
+        $permalink = $this->createPermalink($title);
+
+        $insert = "INSERT INTO custom_texts VALUES (id, '{$title}', '{$permalink}', '{$html}', 'active')";
+        $result = mysqli_query($this->db, $insert);
+
+        if (!$result) {
+            throw new \RuntimeException("Error inserting custom text: " . mysqli_error($this->db));
+        }
+
+        return mysqli_insert_id($this->db);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update(int $id, array $data): bool
+    {
+        if (!isset($data['title']) || !isset($data['html'])) {
+            throw new \InvalidArgumentException("Title and HTML content are required");
+        }
+
+        $title = mysqli_real_escape_string($this->db, $data['title']);
+        $html = mysqli_real_escape_string($this->db, $data['html']);
+
+        $update = "UPDATE custom_texts SET title='{$title}', html='{$html}' WHERE id={$id}";
+        $result = mysqli_query($this->db, $update);
+
+        return $result !== false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(int $id): bool
+    {
+        $update = "UPDATE custom_texts SET status ='deleted' WHERE id=" . $id;
+        $result = mysqli_query($this->db, $update);
+
+        return $result !== false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isValidPermalink(string $permalink): bool
+    {
+        $safePermalink = mysqli_real_escape_string($this->db, $permalink);
+        $count = "SELECT count('permalink') AS 'permalink' FROM custom_texts WHERE permalink ='{$safePermalink}'";
+        $result = mysqli_query($this->db, $count);
+
+        if (!$result) {
+            return false;
+        }
+
+        $info = mysqli_fetch_assoc($result);
+        return $info['permalink'] == '0';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createPermalink(string $title): string
+    {
+        $permalink = strtolower($title);
+        $permalink = str_replace(' ', '-', $permalink);
+
+        if (!$this->isValidPermalink($permalink)) {
+            $count = 0;
+            do {
+                $count = $count + 1;
+                $temp_permalink = $permalink . '-' . $count;
+            } while (!$this->isValidPermalink($temp_permalink));
+
+            $permalink = $temp_permalink;
+        }
+        
+        return $permalink;
+    }
+}

--- a/src/tests/Models/CustomTextFactoryTest.php
+++ b/src/tests/Models/CustomTextFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace YNotRadio\Tests\Models;
+
+use YNotRadio\Tests\TestCase;
+use YNotRadio\Models\CustomTextFactory;
+use YNotRadio\Models\Implementations\SqlCustomText;
+
+/**
+ * Tests for CustomTextFactory backend selection.
+ *
+ * Custom text reads are toggled between MySQL and Postgres via the
+ * `use_postgres_customtext` feature flag while the Postgres/Payload
+ * front-end output is validated. The factory must default to MySQL
+ * (SqlCustomText) and only return the Postgres implementation when the
+ * flag is explicitly enabled. The Postgres branch is not exercised here
+ * because it requires a live Postgres connection (Database::getPostgres()).
+ */
+class CustomTextFactoryTest extends TestCase
+{
+    public function testDefaultsToSqlCustomText(): void
+    {
+        $db = $this->createMock(\mysqli::class);
+
+        $model = CustomTextFactory::create($db);
+
+        $this->assertInstanceOf(SqlCustomText::class, $model);
+    }
+
+    public function testEnvFlagFalseKeepsSqlCustomText(): void
+    {
+        putenv('USE_POSTGRES_CUSTOMTEXT=false');
+
+        $db = $this->createMock(\mysqli::class);
+        $model = CustomTextFactory::create($db);
+
+        $this->assertInstanceOf(SqlCustomText::class, $model);
+
+        putenv('USE_POSTGRES_CUSTOMTEXT');
+    }
+
+    public function testControlPanelRequestForcesSqlCustomText(): void
+    {
+        // Even with the flag enabled, /cp routes must resolve to MySQL so the
+        // restored CP edit screens read and write the legacy custom_texts table.
+        $originalScriptName = $_SERVER['SCRIPT_NAME'] ?? null;
+        $_SERVER['SCRIPT_NAME'] = '/cp/custom_text_view_all.php';
+        putenv('USE_POSTGRES_CUSTOMTEXT=true');
+
+        $db = $this->createMock(\mysqli::class);
+        $model = CustomTextFactory::create($db);
+
+        $this->assertInstanceOf(SqlCustomText::class, $model);
+
+        putenv('USE_POSTGRES_CUSTOMTEXT');
+        if ($originalScriptName === null) {
+            unset($_SERVER['SCRIPT_NAME']);
+        } else {
+            $_SERVER['SCRIPT_NAME'] = $originalScriptName;
+        }
+    }
+}

--- a/src/tests/Models/SqlCustomTextTest.php
+++ b/src/tests/Models/SqlCustomTextTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace YNotRadio\Tests\Models;
+
+use YNotRadio\Tests\TestCase;
+use YNotRadio\Models\Implementations\SqlCustomText;
+
+/**
+ * Tests for SqlCustomText validation logic
+ * 
+ * Tests pure validation methods that don't require database access:
+ * - add: Required field validation
+ * - update: Required field validation
+ * - createPermalink: Pure string transformation logic
+ */
+class SqlCustomTextTest extends TestCase
+{
+    private SqlCustomText $customText;
+    private $mockDb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->mockDb = $this->createMock(\mysqli::class);
+        $this->customText = new SqlCustomText($this->mockDb);
+    }
+
+    /**
+     * Test add throws exception when required field 'title' is missing
+     */
+    public function testAddThrowsExceptionWhenTitleMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Title and HTML content are required");
+        
+        $data = [
+            'html' => '<p>Test content</p>'
+        ];
+        
+        $this->customText->add($data);
+    }
+
+    /**
+     * Test add throws exception when required field 'html' is missing
+     */
+    public function testAddThrowsExceptionWhenHtmlMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Title and HTML content are required");
+        
+        $data = [
+            'title' => 'Test Title'
+        ];
+        
+        $this->customText->add($data);
+    }
+
+    /**
+     * Test add throws exception when both required fields are missing
+     */
+    public function testAddThrowsExceptionWhenBothFieldsMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Title and HTML content are required");
+        
+        $data = [];
+        
+        $this->customText->add($data);
+    }
+
+    /**
+     * Test update throws exception when required field 'title' is missing
+     */
+    public function testUpdateThrowsExceptionWhenTitleMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Title and HTML content are required");
+        
+        $data = [
+            'html' => '<p>Test content</p>'
+        ];
+        
+        $this->customText->update(1, $data);
+    }
+
+    /**
+     * Test update throws exception when required field 'html' is missing
+     */
+    public function testUpdateThrowsExceptionWhenHtmlMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Title and HTML content are required");
+        
+        $data = [
+            'title' => 'Test Title'
+        ];
+        
+        $this->customText->update(1, $data);
+    }
+
+    /**
+     * Test update throws exception when both required fields are missing
+     */
+    public function testUpdateThrowsExceptionWhenBothFieldsMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Title and HTML content are required");
+        
+        $data = [];
+        
+        $this->customText->update(1, $data);
+    }
+}


### PR DESCRIPTION
## Changes

- Add `SqlCustomText` implementation to support MySQL-backed custom text operations (CRUD)
- Restore control panel pages for custom text management:
  - `custom_text_add.php` - Create new custom text entries
  - `custom_text_update.php` - Edit existing custom text entries
  - `custom_text_delete.php` - Soft-delete custom text entries
  - `custom_text_view_all.php` - List all active custom text entries
- Update `CustomTextFactory` to support feature-flagged backend selection:
  - Default to `SqlCustomText` (MySQL) for backward compatibility
  - Switch to `PostgresCustomText` when `use_postgres_customtext` flag is enabled
  - Control panel routes always use MySQL regardless of flag state
- Add `CustomTextFactory` unit tests to verify backend selection logic
- Add `SqlCustomText` unit tests for validation logic (required field checks)
- Update feature flag configuration and environment examples to document the new `use_postgres_customtext` flag
- Update control panel index to link to custom text management pages

## Verification

- [x] Unit tests added for `SqlCustomText` validation and `CustomTextFactory` backend selection
- [x] Control panel pages follow existing patterns and use factory for backend abstraction
- [x] Feature flag properly gates Postgres backend while preserving MySQL for CP operations
- [x] SQL implementation includes proper escaping for user input

https://claude.ai/code/session_017EKg94jBD2EtvGvdsyT1q8