### PR TITLE
fix: unblock production deploys (migration ESM/type-import bugs)

### DIFF
--- a/payload/migrations/20260111_021023.ts
+++ b/payload/migrations/20260111_021023.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres'
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`

--- a/payload/migrations/20260303_185500_add_link_url_to_posts.ts
+++ b/payload/migrations/20260303_185500_add_link_url_to_posts.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres'
 
 export async function up({ db }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`

--- a/payload/migrations/20260308_033000_add_slug_to_cdoftheweek.ts
+++ b/payload/migrations/20260308_033000_add_slug_to_cdoftheweek.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres'
 
 export async function up({ db }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`

--- a/payload/migrations/20260313_191847_add_mrm_tables.ts
+++ b/payload/migrations/20260313_191847_add_mrm_tables.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres';
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   // Create enums

--- a/payload/migrations/20260504_020436_slug_field_consistency.ts
+++ b/payload/migrations/20260504_020436_slug_field_consistency.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+import { sql } from '@payloadcms/db-postgres'
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres'
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`

--- a/payload/migrations/20260505_140811_concert_title_richtext.ts
+++ b/payload/migrations/20260505_140811_concert_title_richtext.ts
@@ -1,6 +1,7 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres';
-import { htmlTitleToLexical } from '../../bin/migrations/shared/htmlTitleToLexical';
-import { convertConcertTitleToPlain } from '../src/utils/concertTitle';
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
+import { htmlTitleToLexical } from '../../bin/migrations/shared/htmlTitleToLexical.ts';
+import { convertConcertTitleToPlain } from '../src/utils/concertTitle.ts';
 
 /**
  * Convert concerts.title from plain varchar (which historically held raw HTML

--- a/payload/migrations/20260508_152000_concert_artists_text.ts
+++ b/payload/migrations/20260508_152000_concert_artists_text.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres';
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
 
 /**
  * Add `artists_text` column to concerts tables.

--- a/payload/migrations/20260509_172217_cdoftheweek_ondemand_search_text.ts
+++ b/payload/migrations/20260509_172217_cdoftheweek_ondemand_search_text.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres';
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
 
 /**
  * Add searchable text columns to cdoftheweek and ondemand tables.

--- a/payload/migrations/20260511_024334.ts
+++ b/payload/migrations/20260511_024334.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres';
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
 
 /**
  * Add the payload-query-presets system collection introduced in Payload 3.76.

--- a/payload/migrations/20260511_154500_add_cdotw_artist_url.ts
+++ b/payload/migrations/20260511_154500_add_cdotw_artist_url.ts
@@ -1,4 +1,5 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres';
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
 
 export async function up({ db }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`ALTER TABLE "cdoftheweek" ADD COLUMN IF NOT EXISTS "artist_url" varchar`);


### PR DESCRIPTION
## Summary
- Production deploys have been failing since ~2:00 PM today. `yarn validate:migrations` (run at the start of every Netlify build, before `payload:migrate`/`yarn build`) throws `ERR_MODULE_NOT_FOUND` and fails the build.
- Root cause: two distinct bugs in how migration files are written, both triggered when Node's native ESM loader falls back for a migration file that tsx's CJS transform can't handle cleanly:
  1. `20260505_140811_concert_title_richtext.ts` imports two local modules without file extensions. Node's ESM resolver (unlike tsx's CJS path) requires explicit extensions for relative imports.
  2. **Every** migration file does `import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'`, mixing type-only exports with a real runtime value in one import. TS/tsx's CJS transform silently erases the type names; Node's native ESM loader tries to resolve them as real bindings and throws.
- Fixed both: added the missing `.ts` extensions, and split every migration file's import into a value import (`sql`) plus a separate `import type` import (`MigrateUpArgs`, `MigrateDownArgs`).

## Why this is urgent
Confirmed via the live Netlify build log for a branch-deploy that this exact error has been failing `master` production deploys repeatedly since ~2:00 PM today — every push since then has hit the same failure. This isn't cosmetic; it currently blocks all deploys.

## Test plan
- [x] `yarn payload:migrate` runs cleanly end-to-end against a fresh local database (all 10 migrations applied successfully) — previously failed identically to the production error before this fix.
- [x] `yarn validate:migrations` (the exact script Netlify's build runs) passes clean: "✅ Migration status is clean — build can proceed".
- [x] `npx tsc --noEmit` reports zero errors in the 10 edited files.
- [x] Existing test suite (`bin/migrations/shared/htmlTitleToLexical.test.ts` and related) passes unchanged.
- [ ] Netlify CI build for this branch (will confirm once triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)