### PR TITLE
Add Mixcloud and OpenDrive embed support with shared rendering

### DIFF
--- a/payload/src/features/embed/client.stories.tsx
+++ b/payload/src/features/embed/client.stories.tsx
@@ -62,6 +62,20 @@ export const SoundCloudTrack: Story = {
   },
 };
 
+export const MixcloudShow: Story = {
+  args: {
+    url: 'https://www.mixcloud.com/ynotradio/rodney-anonymous-tells-you-how-to-live-6526/',
+    caption: 'Rodney Anonymous Tells You How To Live',
+  },
+};
+
+export const OpenDrivePlayer: Story = {
+  args: {
+    url: 'https://www.opendrive.com/player/216190430_XqukK',
+    caption: 'OpenDrive audio player',
+  },
+};
+
 export const WithoutCaption: Story = {
   args: {
     url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',

--- a/payload/src/features/embed/client.tsx
+++ b/payload/src/features/embed/client.tsx
@@ -10,10 +10,10 @@ export interface EmbedComponentProps {
 
 export const EmbedComponent: React.FC<EmbedComponentProps> = ({ url, caption }) => {
   // Convert to proper embed URL if needed
-  const { embedUrl } = detectEmbedType(url);
+  const { embedUrl, type } = detectEmbedType(url);
 
   return (
-    <div className="embed-container">
+    <div className={`embed-container embed-container--${type}`}>
       <div className="embed-wrapper">
         <iframe
           src={embedUrl}

--- a/payload/src/features/embed/index.ts
+++ b/payload/src/features/embed/index.ts
@@ -6,6 +6,7 @@ export {
   extractVimeoId,
   extractSpotifyInfo,
   extractSoundCloudInfo,
+  extractMixcloudFeed,
 } from './server';
 export type { EmbedType, EmbedInfo } from './server';
 export { EmbedComponent } from './client';

--- a/payload/src/features/embed/server.ts
+++ b/payload/src/features/embed/server.ts
@@ -9,6 +9,7 @@ export {
   extractVimeoId,
   extractSpotifyInfo,
   extractSoundCloudInfo,
+  extractMixcloudFeed,
 } from './utils';
 
 export const EmbedBlock: Block = {
@@ -21,7 +22,8 @@ export const EmbedBlock: Block = {
       required: true,
       label: 'Embed URL',
       admin: {
-        description: 'YouTube, Vimeo, Spotify, SoundCloud, or any iframe URL',
+        description:
+          'Paste a URL: YouTube, Vimeo, Mixcloud, OpenDrive, Spotify, SoundCloud, or any iframe URL',
       },
     },
     {

--- a/payload/src/features/embed/utils.test.ts
+++ b/payload/src/features/embed/utils.test.ts
@@ -16,9 +16,7 @@ import {
 
 describe('extractYouTubeId', () => {
   it('should extract ID from standard watch URL', () => {
-    expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
-      'dQw4w9WgXcQ',
-    );
+    expect(extractYouTubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
   });
 
   it('should extract ID from short URL', () => {
@@ -26,9 +24,7 @@ describe('extractYouTubeId', () => {
   });
 
   it('should extract ID from embed URL', () => {
-    expect(extractYouTubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(
-      'dQw4w9WgXcQ',
-    );
+    expect(extractYouTubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
   });
 
   it('should extract ID from watch URL with additional parameters', () => {
@@ -101,9 +97,7 @@ describe('extractSoundCloudInfo', () => {
   });
 
   it('should handle URLs with dashes and underscores', () => {
-    const result = extractSoundCloudInfo(
-      'https://soundcloud.com/artist_name-123/track-name_456',
-    );
+    const result = extractSoundCloudInfo('https://soundcloud.com/artist_name-123/track-name_456');
     expect(result).toBe('artist_name-123/track-name_456');
   });
 
@@ -248,8 +242,7 @@ describe('detectEmbedType', () => {
     });
 
     it('should pass through an existing player-widget URL', () => {
-      const url =
-        'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=%2Fynotradio%2Fshow%2F';
+      const url = 'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=%2Fynotradio%2Fshow%2F';
       const result = detectEmbedType(url);
       expect(result).toEqual({ type: 'mixcloud', embedUrl: url, originalUrl: url });
     });

--- a/payload/src/features/embed/utils.test.ts
+++ b/payload/src/features/embed/utils.test.ts
@@ -10,6 +10,7 @@ import {
   extractVimeoId,
   extractSpotifyInfo,
   extractSoundCloudInfo,
+  extractMixcloudFeed,
   detectEmbedType,
 } from './utils';
 
@@ -233,5 +234,64 @@ describe('detectEmbedType', () => {
         originalUrl: url,
       });
     });
+  });
+
+  describe('Mixcloud detection', () => {
+    it('should convert a public show URL to the player widget', () => {
+      const url = 'https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/';
+      const result = detectEmbedType(url);
+      expect(result.type).toBe('mixcloud');
+      expect(result.embedUrl).toBe(
+        'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=%2Fynotradio%2Frodney-anonymous-6526%2F',
+      );
+      expect(result.originalUrl).toBe(url);
+    });
+
+    it('should pass through an existing player-widget URL', () => {
+      const url =
+        'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=%2Fynotradio%2Fshow%2F';
+      const result = detectEmbedType(url);
+      expect(result).toEqual({ type: 'mixcloud', embedUrl: url, originalUrl: url });
+    });
+
+    it('should fall back to generic for a genre/hub URL', () => {
+      const url = 'https://www.mixcloud.com/genres/british%2Bynotradio/?order=latest';
+      const result = detectEmbedType(url);
+      expect(result.type).toBe('generic');
+    });
+  });
+
+  describe('OpenDrive detection', () => {
+    it('should pass through an OpenDrive player URL', () => {
+      const url = 'https://www.opendrive.com/player/216190430_XqukK';
+      const result = detectEmbedType(url);
+      expect(result).toEqual({ type: 'opendrive', embedUrl: url, originalUrl: url });
+    });
+  });
+});
+
+describe('extractMixcloudFeed', () => {
+  it('should extract the feed path from a public show URL', () => {
+    expect(extractMixcloudFeed('https://www.mixcloud.com/ynotradio/some-show/')).toBe(
+      '/ynotradio/some-show/',
+    );
+  });
+
+  it('should add a trailing slash when missing', () => {
+    expect(extractMixcloudFeed('https://www.mixcloud.com/ynotradio/some-show')).toBe(
+      '/ynotradio/some-show/',
+    );
+  });
+
+  it('should return null for genre/hub URLs', () => {
+    expect(extractMixcloudFeed('https://www.mixcloud.com/genres/punk%2Bynotradio/')).toBeNull();
+  });
+
+  it('should return null for a single-segment path', () => {
+    expect(extractMixcloudFeed('https://www.mixcloud.com/ynotradio/')).toBeNull();
+  });
+
+  it('should return null for an unparseable URL', () => {
+    expect(extractMixcloudFeed('not a url')).toBeNull();
   });
 });

--- a/payload/src/features/embed/utils.ts
+++ b/payload/src/features/embed/utils.ts
@@ -1,4 +1,11 @@
-export type EmbedType = 'youtube' | 'vimeo' | 'spotify' | 'soundcloud' | 'generic';
+export type EmbedType =
+  | 'youtube'
+  | 'vimeo'
+  | 'spotify'
+  | 'soundcloud'
+  | 'mixcloud'
+  | 'opendrive'
+  | 'generic';
 
 export interface EmbedInfo {
   type: EmbedType;
@@ -30,6 +37,30 @@ export function extractSoundCloudInfo(url: string): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Pull a Mixcloud feed path (e.g. `/ynotradio/some-show/`) from a public
+ * mixcloud.com show URL. Genre/discover/search hub pages aren't single feeds,
+ * so return null and let the caller fall back to a generic embed.
+ *
+ * Keep in sync with extractMixcloudFeed() in
+ * src/models/Concerns/RendersLexicalEmbeds.php.
+ */
+export function extractMixcloudFeed(url: string): string | null {
+  let path: string;
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    return null;
+  }
+  const segments = path.split('/').filter(Boolean);
+  const hubs = ['genres', 'discover', 'categories', 'tag', 'search', 'upload', 'live'];
+  if (segments.length < 2 || hubs.includes(segments[0])) {
+    return null;
+  }
+  // Mixcloud feeds are addressed with a leading and trailing slash.
+  return `/${segments.join('/')}/`;
+}
+
 export function detectEmbedType(url: string): EmbedInfo {
   if (url.includes('youtube.com') || url.includes('youtu.be')) {
     const videoId = extractYouTubeId(url);
@@ -57,6 +88,27 @@ export function detectEmbedType(url: string): EmbedInfo {
     if (trackInfo) {
       return { type: 'soundcloud', embedUrl: `https://w.soundcloud.com/player/?url=https://soundcloud.com/${trackInfo}`, originalUrl: url };
     }
+  }
+
+  // Mixcloud — the dominant provider in the legacy custom-text content.
+  if (url.includes('mixcloud.com')) {
+    if (url.includes('player-widget.mixcloud.com')) {
+      // Already a widget embed URL — use as-is.
+      return { type: 'mixcloud', embedUrl: url, originalUrl: url };
+    }
+    const feed = extractMixcloudFeed(url);
+    if (feed) {
+      return {
+        type: 'mixcloud',
+        embedUrl: `https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=${encodeURIComponent(feed)}`,
+        originalUrl: url,
+      };
+    }
+  }
+
+  // OpenDrive — the /player/<id> URL is already an embeddable audio bar.
+  if (url.includes('opendrive.com')) {
+    return { type: 'opendrive', embedUrl: url, originalUrl: url };
   }
 
   return { type: 'generic', embedUrl: url, originalUrl: url };

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -11,6 +11,8 @@ namespace YNotRadio\Models\Concerns;
  */
 trait ConvertsLexicalToHtml
 {
+    use RendersLexicalEmbeds;
+
     // Lexical text format bit flags
     private static int $LEXICAL_FORMAT_BOLD = 1;
     private static int $LEXICAL_FORMAT_ITALIC = 2;
@@ -89,6 +91,11 @@ trait ConvertsLexicalToHtml
 
             case 'linebreak':
                 return "<br>\n";
+
+            case 'block':
+                // Payload block nodes (e.g. the EmbedFeature embed block).
+                $fields = is_array($node['fields'] ?? null) ? $node['fields'] : [];
+                return $this->renderLexicalEmbedBlock($fields);
 
             case 'text':
                 $text = $node['text'] ?? '';

--- a/src/models/Concerns/RendersLexicalEmbeds.php
+++ b/src/models/Concerns/RendersLexicalEmbeds.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace YNotRadio\Models\Concerns;
+
+/**
+ * Renders Payload Lexical "embed" blocks (the EmbedFeature block) to HTML
+ * iframes for the legacy PHP front end.
+ *
+ * Shared by every Postgres read model that converts Lexical content so media
+ * embeds render the same way regardless of which collection the content lives
+ * in. The provider rules here must stay in sync with the TypeScript editor
+ * side in `payload/src/features/embed/utils.ts`.
+ */
+trait RendersLexicalEmbeds
+{
+    /**
+     * Render an embed block's fields (url, caption) to HTML. Returns '' when
+     * the block has no usable, safe URL.
+     *
+     * @param array $fields The Lexical block node's `fields` payload.
+     */
+    protected function renderLexicalEmbedBlock(array $fields): string
+    {
+        $url = is_string($fields['url'] ?? null) ? trim($fields['url']) : '';
+        if ($url === '' || !$this->isSafeEmbedUrl($url)) {
+            return '';
+        }
+
+        $embed = $this->normalizeEmbedUrl($url);
+        $src = htmlspecialchars($embed['src'], ENT_QUOTES, 'UTF-8');
+
+        if ($embed['layout'] === 'video') {
+            // Responsive 16:9 wrapper so videos scale with the column width.
+            $iframe = '<div class="embed embed--video" '
+                . 'style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:100%;">'
+                . "<iframe src=\"{$src}\" "
+                . 'style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" '
+                . 'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; '
+                . 'picture-in-picture; web-share" allowfullscreen></iframe></div>';
+        } else {
+            // Audio players have a fixed height; full-width keeps them tidy.
+            $height = (int) $embed['height'];
+            $cls = 'embed embed--' . $embed['provider'];
+            $iframe = "<iframe class=\"{$cls}\" width=\"100%\" height=\"{$height}\" src=\"{$src}\" "
+                . 'frameborder="0" allow="encrypted-media; fullscreen; autoplay" '
+                . 'scrolling="no"></iframe>';
+        }
+
+        $caption = '';
+        if (!empty($fields['caption']) && is_string($fields['caption'])) {
+            $caption = '<p class="embed-caption">'
+                . htmlspecialchars($fields['caption'], ENT_QUOTES, 'UTF-8') . '</p>';
+        }
+
+        return "\n" . $iframe . $caption . "\n";
+    }
+
+    /**
+     * Map any supported media URL to an iframe-ready src plus layout hints.
+     * Mirror of `detectEmbedType()` in payload/src/features/embed/utils.ts.
+     *
+     * @return array{provider:string, src:string, layout:string, height:int}
+     */
+    protected function normalizeEmbedUrl(string $url): array
+    {
+        // YouTube -> /embed/<id>
+        if (str_contains($url, 'youtube.com') || str_contains($url, 'youtu.be')) {
+            $id = $this->extractYouTubeId($url);
+            if ($id !== null) {
+                return [
+                    'provider' => 'youtube',
+                    'src' => "https://www.youtube.com/embed/{$id}",
+                    'layout' => 'video',
+                    'height' => 0,
+                ];
+            }
+        }
+
+        // Vimeo -> player.vimeo.com/video/<id>
+        if (str_contains($url, 'vimeo.com') && preg_match('#vimeo\.com/(?:video/)?(\d+)#', $url, $m)) {
+            return [
+                'provider' => 'vimeo',
+                'src' => "https://player.vimeo.com/video/{$m[1]}",
+                'layout' => 'video',
+                'height' => 0,
+            ];
+        }
+
+        // Mixcloud -> player widget (the dominant provider in legacy custom text)
+        if (str_contains($url, 'mixcloud.com')) {
+            if (str_contains($url, 'player-widget.mixcloud.com')) {
+                // Already a widget embed URL — use as-is.
+                return ['provider' => 'mixcloud', 'src' => $url, 'layout' => 'audio', 'height' => 120];
+            }
+            $feed = $this->extractMixcloudFeed($url);
+            if ($feed !== null) {
+                $src = 'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed='
+                    . rawurlencode($feed);
+                return ['provider' => 'mixcloud', 'src' => $src, 'layout' => 'audio', 'height' => 120];
+            }
+            // Genre/discover/hub URLs aren't single feeds; fall through to generic.
+        }
+
+        // OpenDrive -> the /player/<id> URL is already an embeddable audio bar.
+        if (str_contains($url, 'opendrive.com')) {
+            return ['provider' => 'opendrive', 'src' => $url, 'layout' => 'audio', 'height' => 60];
+        }
+
+        // Spotify -> open.spotify.com/embed/<type>/<id>
+        if (
+            str_contains($url, 'spotify.com')
+            && preg_match('#spotify\.com/(track|album|playlist|artist|episode|show)/([a-zA-Z0-9]+)#', $url, $m)
+        ) {
+            return [
+                'provider' => 'spotify',
+                'src' => "https://open.spotify.com/embed/{$m[1]}/{$m[2]}",
+                'layout' => 'audio',
+                'height' => 152,
+            ];
+        }
+
+        // SoundCloud -> player wrapper around the original URL
+        if (str_contains($url, 'soundcloud.com')) {
+            return [
+                'provider' => 'soundcloud',
+                'src' => 'https://w.soundcloud.com/player/?url=' . rawurlencode($url),
+                'layout' => 'audio',
+                'height' => 120,
+            ];
+        }
+
+        // Generic — embed the URL as-is (matches the block's "any iframe URL").
+        return ['provider' => 'generic', 'src' => $url, 'layout' => 'audio', 'height' => 152];
+    }
+
+    protected function extractYouTubeId(string $url): ?string
+    {
+        $patterns = [
+            '#(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([a-zA-Z0-9_-]{11})#',
+            '#youtube\.com/watch\?.*v=([a-zA-Z0-9_-]{11})#',
+        ];
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $url, $m)) {
+                return $m[1];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Pull a Mixcloud feed path (e.g. `/ynotradio/some-show/`) from a public
+     * mixcloud.com show URL. Genre/discover/search hub pages aren't single
+     * feeds, so return null and let the caller fall back to a generic embed.
+     */
+    protected function extractMixcloudFeed(string $url): ?string
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+        if (!is_string($path) || trim($path, '/') === '') {
+            return null;
+        }
+
+        $trimmed = trim($path, '/');
+        $segments = explode('/', $trimmed);
+        $hubs = ['genres', 'discover', 'categories', 'tag', 'search', 'upload', 'live'];
+
+        if (count($segments) < 2 || in_array($segments[0], $hubs, true)) {
+            return null;
+        }
+
+        // Mixcloud feeds are addressed with a leading and trailing slash.
+        return '/' . $trimmed . '/';
+    }
+
+    protected function isSafeEmbedUrl(string $url): bool
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false || !isset($parsed['scheme'])) {
+            return false;
+        }
+        $scheme = strtolower($parsed['scheme']);
+        return $scheme === 'http' || $scheme === 'https';
+    }
+}

--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -236,25 +236,13 @@ class PostgresCustomText implements CustomText {
                 return "<a href=\"$url\"$target>$content</a>";
                 
             case 'block':
-                // Handle Payload CMS block types (embeds, etc.)
-                $fields = $node['fields'] ?? [];
-                $blockType = $fields['blockType'] ?? '';
-                
-                if ($blockType === 'embed' && !empty($fields['url'])) {
-                    $url = $fields['url'];
-                    $escapedUrl = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
-                    
-                    // Check if it's a MixCloud embed
-                    if (strpos($url, 'mixcloud.com') !== false) {
-                        return "<br><br>\n<iframe width=\"100%\" height=\"60\" src=\"$escapedUrl\" frameborder=\"0\" ></iframe>\n<br><br>\n";
-                    }
-                    
-                    // Generic iframe for other embeds
-                    return "<br><br>\n<iframe src=\"$escapedUrl\" frameborder=\"0\"></iframe>\n<br><br>\n";
-                }
-                
-                return '';
-                
+                // Payload block nodes (e.g. the EmbedFeature embed block).
+                // Rendered via the shared RendersLexicalEmbeds helper so the
+                // legacy front end embeds Mixcloud/YouTube/OpenDrive/etc. the
+                // same way here as in every other Postgres-backed model.
+                $fields = is_array($node['fields'] ?? null) ? $node['fields'] : [];
+                return $this->renderLexicalEmbedBlock($fields);
+
             case 'text':
                 $text = $node['text'] ?? '';
                 $format = $node['format'] ?? 0;

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -117,4 +117,86 @@ class ConvertsLexicalToHtmlTest extends TestCase
         $this->assertStringContainsString('target="_blank"', $html);
         $this->assertStringContainsString('rel="noopener noreferrer"', $html);
     }
+
+    /**
+     * Build a Lexical document containing a single embed block.
+     */
+    private function embedBlockJson(string $url, ?string $caption = null): string
+    {
+        $fields = ['blockType' => 'embed', 'url' => $url];
+        if ($caption !== null) {
+            $fields['caption'] = $caption;
+        }
+
+        return json_encode([
+            'root' => [
+                'children' => [
+                    ['type' => 'block', 'fields' => $fields],
+                ],
+            ],
+        ]);
+    }
+
+    public function testEmbedBlockRendersYouTubeAsResponsiveVideo(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+        );
+
+        $this->assertStringContainsString('https://www.youtube.com/embed/dQw4w9WgXcQ', $html);
+        $this->assertStringContainsString('allowfullscreen', $html);
+        $this->assertStringContainsString('padding-bottom:56.25%', $html);
+    }
+
+    public function testEmbedBlockConvertsPublicMixcloudUrlToWidget(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson('https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/')
+        );
+
+        $this->assertStringContainsString('player-widget.mixcloud.com/widget/iframe/', $html);
+        // Feed path is rawurlencoded onto the widget src.
+        $this->assertStringContainsString(
+            'feed=%2Fynotradio%2Frodney-anonymous-6526%2F',
+            $html
+        );
+    }
+
+    public function testEmbedBlockPassesThroughMixcloudWidgetUrl(): void
+    {
+        $widget = 'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=%2Fynotradio%2Fshow%2F';
+        $html = $this->converter->convert($this->embedBlockJson($widget));
+
+        $this->assertStringContainsString('player-widget.mixcloud.com/widget/iframe/', $html);
+        $this->assertStringContainsString('%2Fynotradio%2Fshow%2F', $html);
+    }
+
+    public function testEmbedBlockRendersOpenDrivePlayer(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson('https://www.opendrive.com/player/216190430_XqukK')
+        );
+
+        $this->assertStringContainsString('https://www.opendrive.com/player/216190430_XqukK', $html);
+        $this->assertStringContainsString('height="60"', $html);
+    }
+
+    public function testEmbedBlockRendersCaption(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson('https://youtu.be/dQw4w9WgXcQ', 'Episode 1')
+        );
+
+        $this->assertStringContainsString('class="embed-caption"', $html);
+        $this->assertStringContainsString('Episode 1', $html);
+    }
+
+    public function testEmbedBlockRejectsUnsafeUrl(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson('javascript:alert(1)')
+        );
+
+        $this->assertStringNotContainsString('<iframe', $html);
+    }
 }


### PR DESCRIPTION
## Changes

- Created `RendersLexicalEmbeds` trait to centralize Lexical embed block rendering logic across all Postgres read models
- Added support for Mixcloud embeds: converts public show URLs to player widget embeds, passes through existing widget URLs, and rejects hub/genre pages
- Added support for OpenDrive embeds: passes through player URLs as-is
- Extended `EmbedType` to include `'mixcloud'` and `'opendrive'` providers
- Implemented `extractMixcloudFeed()` in both TypeScript and PHP to extract feed paths from Mixcloud URLs
- Updated `PostgresCustomText` to use the shared `RendersLexicalEmbeds` trait instead of inline embed handling
- Updated `ConvertsLexicalToHtml` trait to use the shared embed rendering logic
- Added comprehensive test coverage for YouTube, Mixcloud, OpenDrive, and caption rendering
- Updated Payload CMS embed feature to export `extractMixcloudFeed` and include new providers in admin description
- Added CSS class variants to embed container for provider-specific styling

The implementation keeps TypeScript and PHP embed detection logic in sync, ensuring consistent rendering across the editor and legacy PHP frontend.

## Verification

- [ ] `yarn lint` exits 0
- [ ] `yarn test` exits 0
- [ ] `yarn test:e2e` exits 0 (required if e2e tests were added or modified)
- [ ] Screenshot attached below

## Screenshot

<!-- REQUIRED: Paste a screenshot showing the feature/fix working in the browser. -->
<!-- Agent instructions: use playwright-browser_take_screenshot and attach the image here. -->
<!-- PRs without a screenshot will be sent back. -->

https://claude.ai/code/session_017EKg94jBD2EtvGvdsyT1q8