### PR TITLE
docs: custom-text strategy + Phase 1 embed plan (Chapters 15 & 16)

### DIFF
--- a/docs/payload-migration/15-custom-text-strategy.md
+++ b/docs/payload-migration/15-custom-text-strategy.md
@@ -2,7 +2,8 @@
 
 [← Back to Index](./README.md)
 
-**Status:** Proposed (Plan 3 adopted) · **Last Updated:** June 2026
+**Status:** Proposed (Plan 3 adopted; custom text targets a dedicated `Pages`
+collection) · **Last Updated:** July 2026
 
 ---
 
@@ -71,7 +72,34 @@ Stabilize now, then replace the blob model one archetype at a time — highest
 pain first — keeping the feature flag as the safety net throughout. This reaches
 the correct end state without a big-bang migration.
 
-### Phase 0 — Stabilize (done, PR #786)
+### Target home: a dedicated `Pages` collection (per Josh)
+
+Custom texts get their **own `Pages` collection, separate and distinct from
+`Posts`** — they are not stories, and the two content types should not share a
+table:
+
+| | `Posts` (Stories) | `Pages` (Custom Text) |
+|---|---|---|
+| Addressing | Front-page rotation, date-windowed (`startDate`/`endDate`, `priority`, `showOnFrontPage`) | Evergreen, addressed by a stable `permalink`/slug |
+| Lifecycle | Time-bound news items that age off the front page | Long-lived reference / marketing pages |
+| Identity | A headline + dated body | A titled page at a fixed URL |
+
+`Pages` is the baseline home for the 35 custom texts and preserves the permalinks
+the front end already routes on — `pages.php?page=…`, plus `donate.php`,
+`shows.php`, `y100rocks.php`, and `rodney.php`, which all resolve custom text by
+permalink via `CustomTextFactory`. Minimum fields: `title`, `slug`/`permalink`
+(unique, matching the legacy values), `content` (richText + embed blocks),
+`status`, `legacyId`. `PostgresCustomText` — the read model the
+`use_postgres_customtext` flag toggles — repoints from `custom_texts` to the
+`pages` table once content is migrated, so no front-end call sites change.
+
+The archetype work below refines this baseline: pages that are really *structured
+data* (A/B specialty shows, C year-end lists) graduate **out of** freeform
+`Pages` into purpose-built collections; the genuine rich-text pages (D/E) stay in
+`Pages` with rich text + embed blocks. (Whether every custom text must live in
+`Pages` or the structured archetypes graduate out is tracked in Open Questions.)
+
+### Phase 0 — Stabilize (done, PR #786 — merged)
 
 - `use_postgres_customtext` flag (default MySQL) toggles the front-end read path.
 - Legacy CP add/update/delete/view screens restored; `/cp` always resolves to
@@ -82,10 +110,14 @@ the correct end state without a big-bang migration.
 
 - **Fix the charset.** Migrate custom-text content to UTF-8 on import so mojibake
   stops being introduced.
-- **Add Lexical embed blocks** to `Posts` (`payload/src/collections/Posts.ts`)
-  for Mixcloud, YouTube, and OpenDrive, so editors insert an embed by pasting a
-  URL/slug instead of raw `<iframe>` markup. This is what makes archetypes D and
-  E acceptable on Payload and removes the converter's main failure mode.
+- **Add Lexical embed blocks** for Mixcloud, YouTube, and OpenDrive, so editors
+  insert an embed by pasting a URL/slug instead of raw `<iframe>` markup. This is
+  what makes archetypes D and E acceptable on Payload and removes the converter's
+  main failure mode. The embed capability itself is in flight — the generic
+  `embed` block + shared `RendersLexicalEmbeds` rendering (TS + PHP) is **PR #800**,
+  with the plan and alternatives weighed in **Chapter 16 / PR #801**. It is
+  currently exercised through `PostgresCustomText`; it attaches to the `Pages`
+  rich-text field when that collection lands.
 - Once D/E render acceptably from Postgres, flip `use_postgres_customtext` for
   those pages (the flag is page-agnostic today; see Open Questions for
   per-page/per-archetype gating).
@@ -121,11 +153,11 @@ Sequenced by pain:
      `pages.php?page=top22X…` / `yearendpoll…` URLs at the Payload-rendered
      output. No new modelling in this chapter.
 
-3. **D — Multimedia retrospectives.** Migrate to `Posts` rich text using the
+3. **D — Multimedia retrospectives.** Migrate to `Pages` rich text using the
    Phase 1 embed blocks. These are true articles; the only requirement is clean
    embeds.
 
-4. **E — Landing pages.** Migrate to `Posts` rich text. Handle the few
+4. **E — Landing pages.** Migrate to `Pages` rich text. Handle the few
    form/script pages (`donate`, raffle, MRM bracket) as a small set of reusable
    front-end components rather than pasted HTML/JS.
 
@@ -141,27 +173,38 @@ Sequenced by pain:
 
 ## Archetype → target model summary
 
+Baseline home for all custom text is the new **`Pages`** collection; the
+structured archetypes graduate out of it into purpose-built collections.
+
 | Archetype | Target | Status |
 |-----------|--------|--------|
 | A — episode archives | `SpecialtyShow` (+ episodes) | **New work** (biggest gap) |
 | B — show hub | `SpecialtyShow` directory view | **New work** (with A) |
 | C — year-end lists | `YearEndPollResults` (Ch. 13 / #154) | **Exists** — reuse |
 | C — voting | `YearEndPolls*` (PR #518) | **Open PR** — land |
-| D — retrospectives | `Posts` + embed blocks | Needs Phase 1 blocks |
-| E — landing/forms | `Posts` + form components | Needs Phase 1 blocks |
+| D — retrospectives | `Pages` + embed blocks | Needs `Pages` + Phase 1 blocks |
+| E — landing/forms | `Pages` + form components | Needs `Pages` + Phase 1 blocks |
 
 ---
 
 ## Open questions
 
-1. **Flag granularity.** `use_postgres_customtext` is currently all-or-nothing
+1. **Scope of `Pages`.** Does every custom text live in `Pages` (simplest, one
+   model), or do the structured archetypes graduate to purpose-built collections
+   (A/B → `SpecialtyShow`, C → `YearEndPollResults`) with `Pages` holding only
+   the D/E rich-text pages? This doc assumes the latter; Josh to confirm.
+2. **`Pages` vs `Posts` field overlap.** `Pages` needs `title` + `slug` +
+   `content`; it deliberately omits the date-window/front-page fields that define
+   `Posts`. Confirm no shared base is wanted (keeping them fully separate is the
+   point of the split).
+3. **Flag granularity.** `use_postgres_customtext` is currently all-or-nothing
    across every custom-text page. Phasing by archetype likely wants either
    per-permalink routing (serve some permalinks from Postgres, others from MySQL)
    or retiring the flag per archetype as each is cut over. Decide before Phase 2.
-2. **Episode source of truth.** Should specialty-show episodes be entered in
+4. **Episode source of truth.** Should specialty-show episodes be entered in
    Payload, or pulled from the Mixcloud API by playlist/genre? An API pull would
    make `rodney-anonymous`-style archives self-maintaining.
-3. **Asset hosting.** Whether to backfill imgur/Mixcloud-thumbnail images into
+5. **Asset hosting.** Whether to backfill imgur/Mixcloud-thumbnail images into
    Cloudinary/Media as part of each archetype migration.
 
 ---
@@ -169,7 +212,9 @@ Sequenced by pain:
 ## Related Documentation
 
 - [Chapter 13: Year End Poll Results](./13-year-end-poll-results.md) — archetype C
+- Chapter 16 / PR #801 — Rich-Text Embeds (Custom Text — Phase 1) plan
 - [Core Data Models](./03-core-data-models.md)
 - [Frontend Cutover](./06-frontend-cutover.md)
-- PR #786 — feature flag + restored CP screens (Phase 0)
+- PR #786 — feature flag + restored CP screens (Phase 0, merged)
+- PR #800 — embed block + shared `RendersLexicalEmbeds` rendering (Phase 1 code)
 - PR #518 — Year End Poll voting collections (archetype C, voting)

--- a/docs/payload-migration/15-custom-text-strategy.md
+++ b/docs/payload-migration/15-custom-text-strategy.md
@@ -115,9 +115,9 @@ data* (A/B specialty shows, C year-end lists) graduate **out of** freeform
   what makes archetypes D and E acceptable on Payload and removes the converter's
   main failure mode. The embed capability itself is in flight — the generic
   `embed` block + shared `RendersLexicalEmbeds` rendering (TS + PHP) is **PR #800**,
-  with the plan and alternatives weighed in **Chapter 16 / PR #801**. It is
-  currently exercised through `PostgresCustomText`; it attaches to the `Pages`
-  rich-text field when that collection lands.
+  with the plan and alternatives weighed in [Chapter 16](./16-rich-text-embeds.md).
+  It is currently exercised through `PostgresCustomText`; it attaches to the
+  `Pages` rich-text field when that collection lands.
 - Once D/E render acceptably from Postgres, flip `use_postgres_customtext` for
   those pages (the flag is page-agnostic today; see Open Questions for
   per-page/per-archetype gating).
@@ -211,8 +211,8 @@ structured archetypes graduate out of it into purpose-built collections.
 
 ## Related Documentation
 
+- [Chapter 16: Rich-Text Embeds](./16-rich-text-embeds.md) — Phase 1 embed detail
 - [Chapter 13: Year End Poll Results](./13-year-end-poll-results.md) — archetype C
-- Chapter 16 / PR #801 — Rich-Text Embeds (Custom Text — Phase 1) plan
 - [Core Data Models](./03-core-data-models.md)
 - [Frontend Cutover](./06-frontend-cutover.md)
 - PR #786 — feature flag + restored CP screens (Phase 0, merged)

--- a/docs/payload-migration/15-custom-text-strategy.md
+++ b/docs/payload-migration/15-custom-text-strategy.md
@@ -1,0 +1,175 @@
+# Chapter 15: Custom Text Strategy
+
+[← Back to Index](./README.md)
+
+**Status:** Proposed (Plan 3 adopted) · **Last Updated:** June 2026
+
+---
+
+## Context
+
+PR #780 cut stories and custom text over to Postgres/Payload unconditionally and
+deleted the legacy CP edit screens. The Postgres/Payload front-end output for
+**custom text** is not yet acceptable, so PR #786 reintroduced a
+`use_postgres_customtext` feature flag (default MySQL) and restored the legacy CP
+edit screens as a safety net. See `src/models/CustomTextFactory.php` and
+`src/config/features.php`.
+
+This chapter records the assessment of what the ~35 active custom-text pages
+actually contain and the strategy for giving editors a content-management
+experience that fits — rather than re-hosting the same opaque HTML blob in a new
+database.
+
+> This is **not** a MySQL-vs-Postgres question. Both backends store the same
+> single `longtext` HTML blob. Porting that blob to a Lexical rich-text field
+> preserves the bad model and is the direct source of the HTML→Lexical
+> embed-dropping and whitespace bugs fixed in #780. The real question is how the
+> content should be *modelled*.
+
+---
+
+## Findings
+
+There are **35 active rows** in `custom_texts`. Every one is a single freeform
+HTML blob in one `longtext` column, authored as raw HTML in a `<textarea>`. They
+fall into five archetypes — only one of which is genuinely "a rich-text article."
+
+| # | Archetype | Count | Representative pages | What it really is |
+|---|-----------|-------|----------------------|-------------------|
+| **A** | Specialty-show episode archive | 2 | `rodney-anonymous` (143 embeds), `quarantine-takeovers` (35) | A flat list of hand-pasted Mixcloud `<iframe>`s separated by `<br><br>` |
+| **B** | Show directory / hub | 1 | `shows` | A 4-column HTML `<table>` of program tiles (thumbnail + link) → Mixcloud or sibling pages |
+| **C** | Year-end ranked lists & poll results | 12 | `top220of2020`…`top225of2025`, `yearendpoll2020`…`2025` | Ranked **data** (rank / artist / title; album lists) hand-typed as 220–230-row `<table>`s |
+| **D** | Multimedia retrospective | 4 | `y100:-20-years-gone`, `future-friday`, `words-with-nerds`, `y100-rocks` | Genuine rich articles: prose + dozens of mixed embeds (Mixcloud / YouTube / OpenDrive) |
+| **E** | Landing / marketing / stub | 16 | `donate`, `t-shirts`, `contests`, `ynotsessions20XX`×6, `remembering-starla`, `player-test` | Simple pages; a few carry PayPal **forms** / **scripts** |
+
+### Concrete problems observed in the stored content
+
+- **Repetitive manual embed-pasting.** `rodney-anonymous` is 143 copies of the
+  same `<iframe>` with only the feed slug changed, ordered by hand with
+  `<br><br>`. Adding or reordering an episode means editing raw iframe markup.
+- **Hand-built layout tables for what is really structured data.** The Top-225
+  lists are 230-row tables with **manual alternating-row `bgcolor` striping** and
+  fixed pixel widths (`width="685"`). The data can't be sorted, reused, or
+  queried, and is brittle to edit.
+- **Encoding corruption is baked in.** `custom_texts` is `DEFAULT CHARSET=latin1`,
+  producing mojibake (`Â `, smart-quote garble) visible in 10 of 12 year-end
+  pages. This is a storage-layer defect, not a rendering one.
+- **Presentation welded to content.** 17 pages still use `<font>`; many embed
+  `<style>` blocks and fixed widths — not responsive, not themeable.
+- **External hosting dependencies.** Images on imgur, audio on Mixcloud /
+  OpenDrive; nothing is in the asset pipeline → link-rot risk.
+- **Editors fight the schema.** Several `title` values are literally `<img …>` or
+  `<center>…` because the 64-char `title` column can't do what's needed.
+- **Duplicated hand-maintained navigation.** Each year's trio re-types the same
+  sibling-nav table.
+
+---
+
+## Decision: Plan 3 (phased, archetype-driven)
+
+Stabilize now, then replace the blob model one archetype at a time — highest
+pain first — keeping the feature flag as the safety net throughout. This reaches
+the correct end state without a big-bang migration.
+
+### Phase 0 — Stabilize (done, PR #786)
+
+- `use_postgres_customtext` flag (default MySQL) toggles the front-end read path.
+- Legacy CP add/update/delete/view screens restored; `/cp` always resolves to
+  MySQL (FeatureManager suppresses `use_postgres_*` there), so editors keep a
+  working editor while the model is rebuilt.
+
+### Phase 1 — Stop the bleeding for rich-text pages (archetypes D, E)
+
+- **Fix the charset.** Migrate custom-text content to UTF-8 on import so mojibake
+  stops being introduced.
+- **Add Lexical embed blocks** to `Posts` (`payload/src/collections/Posts.ts`)
+  for Mixcloud, YouTube, and OpenDrive, so editors insert an embed by pasting a
+  URL/slug instead of raw `<iframe>` markup. This is what makes archetypes D and
+  E acceptable on Payload and removes the converter's main failure mode.
+- Once D/E render acceptably from Postgres, flip `use_postgres_customtext` for
+  those pages (the flag is page-agnostic today; see Open Questions for
+  per-page/per-archetype gating).
+
+### Phase 2 — Model the repeatable shapes (archetypes A, B, C)
+
+Sequenced by pain:
+
+1. **A + B — Specialty Shows (highest pain, genuinely unbuilt).**
+   The existing `Shows` collection is the *airing schedule* (date / host /
+   start–end time), **not** a directory of programs — so neither A nor B is
+   served today. Introduce a program/episode model that powers both:
+   - `SpecialtyShow` (program): `name`, `slug`, `thumbnail` (Media),
+     `externalUrl` (Mixcloud genre/playlist), `description` (richText),
+     `featured`/`order`.
+   - Episodes: either an `episodes` array on the program or a separate
+     `Episodes` collection related to it — each episode is just a Mixcloud
+     (or other) embed reference + title/date.
+   - The hub page (B) renders all programs as tiles; each program page (A)
+     renders its episode list. This replaces the 143-iframe `rodney-anonymous`
+     blob and the hand-built `shows` table in one model.
+
+2. **C — Year-end lists & polls (already planned — reuse, do not re-plan).**
+   - Recap/display pages (`top22Xof20XX`, `yearendpoll20XX`) are covered by the
+     existing **`YearEndPollResults`** collection — see
+     [Chapter 13](./13-year-end-poll-results.md) and merged PR #154. It already
+     models ranked songs/records/staff-picks blocks with relationships to
+     `Songs`/`Records`/`DJs`, eliminating the hand-typed tables and mojibake.
+   - The interactive **voting** side is **open PR #518**
+     (`YearEndPolls` / `YearEndPollCategories` / `YearEndPollVotes`, modelled on
+     the shipped Modern Rock Madness collections).
+   - Action here is limited to: land/finish those efforts and point the legacy
+     `pages.php?page=top22X…` / `yearendpoll…` URLs at the Payload-rendered
+     output. No new modelling in this chapter.
+
+3. **D — Multimedia retrospectives.** Migrate to `Posts` rich text using the
+   Phase 1 embed blocks. These are true articles; the only requirement is clean
+   embeds.
+
+4. **E — Landing pages.** Migrate to `Posts` rich text. Handle the few
+   form/script pages (`donate`, raffle, MRM bracket) as a small set of reusable
+   front-end components rather than pasted HTML/JS.
+
+### Rollout & rollback
+
+- Each archetype migrates behind `use_postgres_customtext` (today) and is only
+  cut over once it renders acceptably; the legacy MySQL blob + CP screens remain
+  the instant rollback for the duration.
+- The flag is removed per archetype once its replacement is the sole source of
+  truth, mirroring the per-collection cutover pattern used elsewhere.
+
+---
+
+## Archetype → target model summary
+
+| Archetype | Target | Status |
+|-----------|--------|--------|
+| A — episode archives | `SpecialtyShow` (+ episodes) | **New work** (biggest gap) |
+| B — show hub | `SpecialtyShow` directory view | **New work** (with A) |
+| C — year-end lists | `YearEndPollResults` (Ch. 13 / #154) | **Exists** — reuse |
+| C — voting | `YearEndPolls*` (PR #518) | **Open PR** — land |
+| D — retrospectives | `Posts` + embed blocks | Needs Phase 1 blocks |
+| E — landing/forms | `Posts` + form components | Needs Phase 1 blocks |
+
+---
+
+## Open questions
+
+1. **Flag granularity.** `use_postgres_customtext` is currently all-or-nothing
+   across every custom-text page. Phasing by archetype likely wants either
+   per-permalink routing (serve some permalinks from Postgres, others from MySQL)
+   or retiring the flag per archetype as each is cut over. Decide before Phase 2.
+2. **Episode source of truth.** Should specialty-show episodes be entered in
+   Payload, or pulled from the Mixcloud API by playlist/genre? An API pull would
+   make `rodney-anonymous`-style archives self-maintaining.
+3. **Asset hosting.** Whether to backfill imgur/Mixcloud-thumbnail images into
+   Cloudinary/Media as part of each archetype migration.
+
+---
+
+## Related Documentation
+
+- [Chapter 13: Year End Poll Results](./13-year-end-poll-results.md) — archetype C
+- [Core Data Models](./03-core-data-models.md)
+- [Frontend Cutover](./06-frontend-cutover.md)
+- PR #786 — feature flag + restored CP screens (Phase 0)
+- PR #518 — Year End Poll voting collections (archetype C, voting)

--- a/docs/payload-migration/16-rich-text-embeds.md
+++ b/docs/payload-migration/16-rich-text-embeds.md
@@ -1,0 +1,165 @@
+# Chapter 16: Rich-Text Embeds (Custom Text — Phase 1)
+
+[← Back to Index](./README.md)
+
+**Status:** In progress · **Last Updated:** July 2026
+
+This chapter details **Phase 1** of the custom-text strategy in
+[Chapter 15](./15-custom-text-strategy.md): giving editors a real embed
+experience for rich-text pages (archetypes **D** — multimedia retrospectives —
+and **E** — landing pages) so they paste a URL instead of hand-pasting raw
+`<iframe>` markup. These pages are the ones that stay as freeform rich text in
+the dedicated **`Pages`** collection (Chapter 15), so the embed block attaches to
+the `Pages` rich-text field. This is the prerequisite for flipping
+`use_postgres_customtext` for those pages.
+
+---
+
+## Why this is the first thing to fix
+
+The legacy custom-text content is dominated by media embeds. Across the 35 active
+pages there are **314 Mixcloud** player iframes, plus **YouTube** and
+**OpenDrive** players in the retrospectives — all currently pasted as raw
+`<iframe>` blocks into a `longtext` HTML field. When that HTML is imported to
+Payload's Lexical rich text, the embeds are the exact thing that breaks (the
+HTML→Lexical converter dropped embeds nested in tables/paragraphs — see the
+fixes in PR #780). Until embeds are a first-class, provider-aware block, moving
+these pages to Payload trades a working page for a broken one.
+
+## Requirements
+
+1. Editors add an embed by pasting a URL (YouTube, Vimeo, **Mixcloud**,
+   **OpenDrive**, Spotify, SoundCloud, or any iframe URL) plus an optional
+   caption.
+2. The embed renders correctly in **both** render paths:
+   - Payload admin preview + any Next.js/React frontend.
+   - The **legacy PHP frontend** (`pages.php`), which converts Payload Lexical
+     JSON to HTML on read.
+3. Video embeds are responsive (16:9); audio players use a fixed height.
+4. Only `http(s)` URLs are embedded (no `javascript:`/`data:`).
+
+---
+
+## Chosen approach (implemented in PR #800)
+
+**A single generic `embed` block + runtime URL normalization, mirrored in both
+stacks.**
+
+- One Lexical block (`EmbedFeature`) with `url` + `caption` fields. It attaches
+  to the `Pages` rich-text field (Chapter 15); today it is exercised through
+  `PostgresCustomText`, the read model the `use_postgres_customtext` flag toggles.
+- **URL → embed** normalization lives in two mirrored places:
+  - TS: `payload/src/features/embed/utils.ts` (`detectEmbedType`).
+  - PHP: `src/models/Concerns/RendersLexicalEmbeds.php` (`normalizeEmbedUrl`).
+- The PHP helper is a trait shared by **both** PHP converters — the
+  `ConvertsLexicalToHtml` trait (stories, DJs, on-demand, …) and
+  `PostgresCustomText`'s own converter — so a `block` node renders the same
+  everywhere. Previously the shared trait dropped block nodes entirely and
+  `PostgresCustomText` handled Mixcloud-or-broken-generic only.
+- Provider rules: YouTube `watch`/`youtu.be` → `/embed/<id>`; Mixcloud public
+  show URL → `player-widget…?feed=<encoded path>` (widget URLs pass through);
+  OpenDrive `/player/<id>` as-is; Vimeo/Spotify/SoundCloud → their embed URLs;
+  everything else → generic iframe.
+
+**Trade-off:** the provider logic is duplicated across TypeScript and PHP. Kept
+honest by mirrored unit tests and "keep in sync" comments, but it is genuine
+drift risk (see Option C).
+
+---
+
+## Remaining Phase 1 work (after PR #800)
+
+1. **The `Pages` collection.** These D/E pages need their home — the dedicated
+   `Pages` collection (Chapter 15) with the embed-enabled rich-text field — to
+   exist before content can be migrated off `custom_texts`.
+2. **Legacy embed CSS.** The PHP helper emits `embed`, `embed--video`,
+   `embed--<provider>` classes and a 16:9 wrapper; the legacy theme needs
+   matching CSS so audio vs video sizing is correct on `pages.php`.
+3. **Content migration for archetypes D & E (~20 pages).** Convert existing raw
+   `<iframe>`/media HTML into embed blocks. Either:
+   - extend the importer's HTML→Lexical pass to emit embed blocks from legacy
+     iframes, or
+   - re-author the handful of D/E pages by hand.
+4. **UTF-8 / mojibake cleanup.** Separate, data-side concern (the legacy
+   `custom_texts` table is `latin1`; 10 of 12 year-end pages show mojibake).
+   Options: re-import reading MySQL as latin1 → UTF-8, or an in-place fix of the
+   migrated Postgres text. Needs a decision; tracked here so it isn't lost.
+5. **Flag granularity.** `use_postgres_customtext` is currently all-or-nothing
+   across every custom-text page. Flipping D/E first wants either per-permalink
+   routing or retiring the flag per archetype (see Chapter 15 open questions).
+6. **Verification.** Render D/E pages from Postgres and compare against the
+   MySQL originals before flipping the flag.
+
+---
+
+## Alternatives considered
+
+### Option A — Generic embed block + runtime detection *(chosen, shipped)*
+
+One block, paste any URL, detect provider at render time.
+
+- **Pros:** one block to learn; handles arbitrary iframe URLs; matches the
+  existing `EmbedFeature`; smallest change to ship Phase 1.
+- **Cons:** provider logic duplicated in TS + PHP; no author-time validation
+  (a bad URL only shows as a broken embed at render).
+
+### Option B — Provider-specific typed blocks
+
+Separate `MixcloudBlock`, `YouTubeBlock`, `OpenDriveBlock`, … each storing just
+the ID/slug (not a full URL).
+
+- **Pros:** clean, validated data; no URL parsing at render; the editor picks a
+  provider and gets provider-specific fields (e.g. Mixcloud "mini" toggle);
+  aligns with the **SpecialtyShow/episode** model in Chapter 15 Phase 2, where a
+  Mixcloud episode is already a stored reference.
+- **Cons:** more blocks to maintain; awkward for one-off/unknown iframe sources;
+  still needs per-provider render code in both stacks.
+- **When it wins:** once the SpecialtyShow model lands, a first-class
+  `MixcloudBlock` is a natural fit and could replace generic Mixcloud embeds.
+
+### Option C — Single source of truth for provider rules
+
+Define the provider rules once (a small declarative table: match pattern →
+embed-URL template → layout) and consume from both TS and PHP (shared JSON +
+thin adapters, or codegen).
+
+- **Pros:** eliminates the TS/PHP drift that Option A accepts; new providers are
+  a one-line data change.
+- **Cons:** build/tooling complexity for a rules set that changes rarely; a
+  JSON-driven regex table is less expressive than code for edge cases (e.g.
+  Mixcloud hub-vs-feed detection).
+- **Recommendation:** worth adopting as a fast-follow once a third or fourth
+  provider forces the issue; not blocking for Phase 1.
+
+### Option D — Single render path (retire PHP Lexical→HTML for these pages)
+
+Render embeds (and eventually all rich text) only via a Next/React frontend, or
+server-render Lexical→HTML in Node and have PHP consume that, instead of
+maintaining a PHP converter.
+
+- **Pros:** kills the dual-stack duplication at the root; uses Payload's own
+  Lexical renderer; aligns with the framework migration in
+  [Chapter 14](./14-frontend-framework-evaluation.md).
+- **Cons:** a much larger architectural move than Phase 1; premature while the
+  front end is still PHP.
+- **Recommendation:** fold into the Chapter 14 framework decision, not Phase 1.
+
+---
+
+## Recommendation
+
+Ship **Option A** now (done, PR #800) to unblock D/E, then:
+
+- adopt **Option C** as a fast-follow if/when provider drift bites, and
+- reach for **Option B** for Mixcloud specifically when the Chapter 15 Phase 2
+  **SpecialtyShow** model lands, and
+- treat **Option D** as part of the Chapter 14 framework migration.
+
+---
+
+## Related Documentation
+
+- [Chapter 15: Custom Text Strategy](./15-custom-text-strategy.md) — the phased plan this detail sits under
+- [Chapter 14: Frontend Framework Evaluation](./14-frontend-framework-evaluation.md) — context for Option D
+- PR #800 — embed block implementation (Option A)
+- PR #786 — feature flag + restored CP screens (Phase 0, merged)

--- a/docs/payload-migration/README.md
+++ b/docs/payload-migration/README.md
@@ -29,8 +29,8 @@ Legacy MySQL/admin still owns:
 - Top 11
 - Year End Poll voting/admin
 - Staff Picks
-- Custom text (served from MySQL behind `use_postgres_customtext`; storage
-  strategy under review — see Chapter 15)
+- Custom text (served from MySQL behind `use_postgres_customtext`; targeting a
+  dedicated `Pages` collection, distinct from Posts — see Chapter 15)
 
 ## Active References
 

--- a/docs/payload-migration/README.md
+++ b/docs/payload-migration/README.md
@@ -45,6 +45,7 @@ Legacy MySQL/admin still owns:
 9. [Cloudinary Integration](12-cloudinary-integration.md)
 10. [Year End Poll Results](13-year-end-poll-results.md)
 11. [Custom Text Strategy](15-custom-text-strategy.md)
+12. [Rich-Text Embeds (Custom Text Phase 1)](16-rich-text-embeds.md)
 
 ## Historical / Planning References
 

--- a/docs/payload-migration/README.md
+++ b/docs/payload-migration/README.md
@@ -20,7 +20,7 @@ Payload manages:
 - Music records and songs
 - On Demand
 - Schedule
-- Stories and custom text as Posts
+- Stories as Posts
 - Modern Rock Madness
 - Year End Poll Results display data
 
@@ -29,6 +29,8 @@ Legacy MySQL/admin still owns:
 - Top 11
 - Year End Poll voting/admin
 - Staff Picks
+- Custom text (served from MySQL behind `use_postgres_customtext`; storage
+  strategy under review — see Chapter 15)
 
 ## Active References
 
@@ -42,6 +44,7 @@ Legacy MySQL/admin still owns:
 8. [Quick Reference](08-quick-reference.md)
 9. [Cloudinary Integration](12-cloudinary-integration.md)
 10. [Year End Poll Results](13-year-end-poll-results.md)
+11. [Custom Text Strategy](15-custom-text-strategy.md)
 
 ## Historical / Planning References
 


### PR DESCRIPTION
Consolidated planning PR for the custom-text migration. Combines the two overlapping docs PRs (**supersedes #801**) into one, and applies Josh's decision that custom text lives in a dedicated **`Pages`** collection, distinct from `Posts`.

## Changes

**Chapter 15 — Custom Text Strategy** (`15-custom-text-strategy.md`)
- Assessment of the ~35 active `custom_texts` pages: the problem is the storage model (one freeform HTML blob), not MySQL-vs-Postgres. Splits into five archetypes (Mixcloud episode archives, show-directory hub, year-end ranked lists, multimedia retrospectives, simple landing pages).
- **Target home: a dedicated `Pages` collection**, separate and distinct from `Posts` — custom texts are evergreen, permalink-addressed pages, not date-windowed front-page Stories. Rich-text archetypes (D/E) live in `Pages`; structured archetypes graduate out (A/B → `SpecialtyShow`, C → `YearEndPollResults`).
- Phased plan (Plan 3): stabilize behind `use_postgres_customtext` (#786, merged), add embed blocks + UTF-8 (Phase 1), then model the repeatable shapes.

**Chapter 16 — Rich-Text Embeds / Phase 1** (`16-rich-text-embeds.md`)
- Detailed embed plan: why embeds are the first fix (314 Mixcloud + YouTube/OpenDrive across the pages; embeds are what breaks on the HTML→Lexical path), the chosen generic `embed` block + shared `RendersLexicalEmbeds` rendering (shipped in **PR #800**), remaining Phase 1 work, and alternatives A–D weighed.
- Aligned to the `Pages` decision (the embed block attaches to the `Pages` rich-text field; "create the `Pages` collection" is listed as remaining Phase 1 work).

**README** — index lists both chapters; custom text marked as targeting the `Pages` collection.

## Relationship to other PRs

- **Supersedes #801** (which added a now-stale, Posts-based copy of Chapter 15). Closing #801 in favor of this.
- **#800** — the embed-block code (Option A). This PR is the plan; #800 is the implementation.
- **#786** (merged) — Phase 0 feature flag + restored CP screens.

## Verification

Documentation-only change — no code affected.

- [ ] `yarn lint` — N/A (docs only)
- [ ] `yarn test` — N/A (docs only)
- [ ] `yarn test:e2e` — N/A (docs only)
- [ ] Screenshot — N/A (docs only)

## Screenshot

N/A — documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)