### PR TITLE
test: catch importMap.js import/export mismatches in CI

### DIFF
--- a/bin/check-importmap.test.ts
+++ b/bin/check-importmap.test.ts
@@ -16,6 +16,27 @@ function extractComponentPaths(src: string): string[] {
   return [...src.matchAll(/['"](\/(payload)[^'"]+)['"]/g)].map((m) => m[1]);
 }
 
+/**
+ * Extracts the local identifier bound by each top-level `import { X as Y } from '...'`
+ * or `import { X } from '...'` statement in importMap.js.
+ */
+function extractImportedIdentifiers(src: string): Set<string> {
+  const clauses = [...src.matchAll(/^import\s*\{([^}]+)\}\s*from/gm)].flatMap((match) => match[1].split(','));
+  const identifiers = clauses
+    .map((clause) => clause.match(/\bas\s+(\w+)/)?.[1] ?? clause.trim().match(/^(\w+)$/)?.[1])
+    .filter((identifier): identifier is string => Boolean(identifier));
+  return new Set(identifiers);
+}
+
+/**
+ * Extracts the identifier used as the value for each `"path#Key": Identifier,` entry
+ * in importMap.js's `export const importMap = { ... }` object.
+ */
+function extractMapValueIdentifiers(src: string): Map<string, string> {
+  const matches = [...src.matchAll(/^\s*"([^"]+)":\s*(\w+),?\s*$/gm)];
+  return new Map(matches.map((match) => [match[1], match[2]]));
+}
+
 describe('Payload importMap integrity', () => {
   it('registers every custom component path from collection configs in importMap.js', () => {
     const importMapSrc = readFileSync(resolve(root, 'app/(payload)/admin/importMap.js'), 'utf-8');
@@ -39,6 +60,29 @@ describe('Payload importMap integrity', () => {
     expect(
       missing,
       `These component paths are missing from importMap.js:\n${missing.join('\n')}`,
+    ).toHaveLength(0);
+  });
+
+  it('every identifier used in the importMap object has a matching import statement', () => {
+    // Regenerating importMap.js (via `yarn payload:generate-importmap` or the dev
+    // server's live auto-regen) can silently drop the `import` line for an entry
+    // while leaving its "path#Key": Identifier map entry in place — this compiles
+    // fine (the map object doesn't error until Next.js tries to render that
+    // specific admin view) but throws `ReferenceError: X is not defined` at
+    // runtime for anyone who visits it. This check catches that class of bug at
+    // the file level, independent of Payload's own (incomplete) static analysis.
+    const importMapSrc = readFileSync(resolve(root, 'app/(payload)/admin/importMap.js'), 'utf-8');
+
+    const importedIdentifiers = extractImportedIdentifiers(importMapSrc);
+    const mapEntries = extractMapValueIdentifiers(importMapSrc);
+
+    const orphaned = [...mapEntries.entries()]
+      .filter(([, identifier]) => !importedIdentifiers.has(identifier))
+      .map(([path, identifier]) => `"${path}": ${identifier}  (no matching import statement)`);
+
+    expect(
+      orphaned,
+      `These importMap.js entries reference an identifier with no import statement:\n${orphaned.join('\n')}`,
     ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a second assertion to `bin/check-importmap.test.ts` that parses every `import` statement and every `"path#Key": Identifier` entry in `app/(payload)/admin/importMap.js`, then verifies each entry's identifier actually has a matching import.
- This catches the exact bug that shipped in PR #806 and broke `/admin` in production: an entry's export-object line was present but its `import` statement had been silently dropped (by both Payload's dev-server auto-regen and the `yarn payload:generate-importmap` CLI, which have a shared blind spot for components referenced via a client-passed prop rather than a direct collection field).
- Verified locally by reproducing the exact broken state (stripping just the import line) and confirming the new test fails with a clear message, then restoring and confirming it passes.

## Test plan
- [x] `yarn vitest run bin/check-importmap.test.ts` passes on the current (correct) importMap.js
- [x] Confirmed the new test fails when the import line is manually stripped (reproducing the real bug)
- [x] Full `yarn vitest run` suite passes (4698 tests)
- [x] `yarn lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)