### PR TITLE
fix: Story Order tool shows every published story ever, not just active ones

### DIFF
--- a/payload/src/features/story-order/StoryOrderClient.test.tsx
+++ b/payload/src/features/story-order/StoryOrderClient.test.tsx
@@ -113,10 +113,18 @@ describe('StoryOrderClient', () => {
       render(<StoryOrderClient />);
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(
-          '/api/posts?limit=100&sort=priority&where[showOnFrontPage][equals]=true&where[_status][equals]=published',
-        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
       });
+      const [calledUrl] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const params = new URL(calledUrl, 'http://localhost').searchParams;
+      expect(params.get('limit')).toBe('100');
+      expect(params.get('sort')).toBe('priority');
+      expect(params.get('where[showOnFrontPage][equals]')).toBe('true');
+      expect(params.get('where[_status][equals]')).toBe('published');
+      // Only currently-active stories should be fetched — without this, every
+      // story ever published (hundreds of expired/future ones) piles up here.
+      expect(params.get('where[endDate][greater_than_equal]')).toBeTruthy();
+      expect(params.get('where[startDate][less_than_equal]')).toBeTruthy();
     });
 
     it('should display stories after loading', async () => {

--- a/payload/src/features/story-order/StoryOrderClient.tsx
+++ b/payload/src/features/story-order/StoryOrderClient.tsx
@@ -56,9 +56,20 @@ export const StoryOrderClient: React.FC = () => {
       try {
         // _status=published excludes drafts — reordering a draft could otherwise force-publish
         // it, since PATCHing without ?draft=true always writes straight to the published doc.
-        const response = await fetch(
-          '/api/posts?limit=100&sort=priority&where[showOnFrontPage][equals]=true&where[_status][equals]=published',
-        );
+        // Only stories currently in their active date window are shown — matching the front
+        // page's own query — otherwise every story ever published piles up here indefinitely
+        // (hundreds of expired/future stories mixed in with the handful that actually matter).
+        const now = new Date();
+        now.setUTCHours(12, 0, 0, 0);
+        const params = new URLSearchParams({
+          limit: '100',
+          sort: 'priority',
+          'where[showOnFrontPage][equals]': 'true',
+          'where[_status][equals]': 'published',
+          'where[endDate][greater_than_equal]': now.toISOString(),
+          'where[startDate][less_than_equal]': now.toISOString(),
+        });
+        const response = await fetch(`/api/posts?${params.toString()}`);
         if (!response.ok) {
           throw new Error('Failed to fetch stories');
         }
@@ -154,8 +165,9 @@ export const StoryOrderClient: React.FC = () => {
         <div className="story-order-client__header">
           <h1 className="story-order-client__title">Story Order</h1>
           <p className="story-order-client__description">
-            Drag and drop stories to change their display order on the front page. Changes
-            won&apos;t be saved until you click the &quot;Save Order&quot; button.
+            Drag and drop stories to change their display order on the front page. Only stories
+            currently in their active date range are shown. Changes won&apos;t be saved until you
+            click the &quot;Save Order&quot; button.
           </p>
         </div>
 
@@ -180,7 +192,7 @@ export const StoryOrderClient: React.FC = () => {
               strategy={verticalListSortingStrategy}
             >
               {stories.length === 0 ? (
-                <EmptyState message='No front-page stories found. Enable "Show on front page" on a story first.' />
+                <EmptyState message='No stories are currently active on the front page. Check that a story has "Show on front page" enabled and its start/end dates include today.' />
               ) : (
                 stories.map((story) => (
                   <SortableItem


### PR DESCRIPTION
## Summary
- Story Order's fetch only filtered by `showOnFrontPage=true` + `_status=published`, with no date-range filter. Confirmed against dev Neon (read-only query): 663 stories match that filter, but only 8 are within their actual active `startDate`/`endDate` window — the other 655 are expired or not-yet-live, cluttering the reorder UI with stories that will never appear on the front page.
- Apply the same date-window filter the PHP front page's own query (`PostgresStory::getAll`) and the admin Stories list's default filter (`middleware.ts`) already use: `startDate <= today <= endDate`.
- Updated the header description and empty-state copy to reflect the new scope.

## Test plan
- [x] Confirmed via a read-only query against dev Neon: 663 total matches vs. 8 in the active date window
- [x] Verified locally against local Postgres: seeded an expired story and a future story alongside the 3 existing active ones, confirmed Story Order only shows the 3 active ones, then cleaned up the test rows
- [x] Updated `StoryOrderClient.test.tsx` to assert the new date-range query params are present (without pinning to an exact timestamp)
- [x] Full `yarn vitest run` suite passes (4697 tests)
- [x] `yarn lint` clean

Note: I did **not** point the local dev server directly at dev Neon for live UI verification — Payload's dev-mode schema push detected drift (unrelated `top11_*` tables) and prompted to delete data there. Verified via a read-only SQL query instead, plus local Postgres for the UI behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)