### PR TITLE
fix: require explicit confirmation before scripts write to production Neon

### DIFF
--- a/bin/migrations/shared/payloadClient.test.ts
+++ b/bin/migrations/shared/payloadClient.test.ts
@@ -77,10 +77,12 @@ describe('payloadClient', () => {
     });
 
     it('should throw when NEON_PROD_DATABASE_URL is not set for prod-neon target', async () => {
+      process.env.YES_I_MEAN_PROD = 'true';
       const { getPayloadClient } = await import('./payloadClient');
       await expect(getPayloadClient('prod-neon')).rejects.toThrow(
         'Database URI not found for target "prod-neon"',
       );
+      delete process.env.YES_I_MEAN_PROD;
     });
 
     it('should throw when neither NEON_DEV_DATABASE_URL nor DATABASE_URI is set for local-postgres', async () => {
@@ -110,8 +112,44 @@ describe('payloadClient', () => {
       expect(process.env.DATABASE_URI).toBe('postgresql://local/fallback');
     });
 
-    it('should return uri for prod-neon when NEON_PROD_DATABASE_URL is set', async () => {
+    it('should prefer DATABASE_URI over NEON_DEV_DATABASE_URL for local-postgres target', async () => {
+      process.env.DATABASE_URI = 'postgresql://local/actual';
+      process.env.NEON_DEV_DATABASE_URL = 'postgresql://dev/should-not-be-used';
+      const { getPayload } = await import('payload');
+      const mockLocal = { find: vi.fn() };
+      (getPayload as Mock).mockResolvedValueOnce(mockLocal);
+
+      const { getPayloadClient } = await import('./payloadClient');
+      await getPayloadClient('local-postgres');
+
+      expect(process.env.DATABASE_URI).toBe('postgresql://local/actual');
+    });
+
+    it('should default to local-postgres when no target is given', async () => {
+      process.env.DATABASE_URI = 'postgresql://local/default';
+      const { getPayload } = await import('payload');
+      const mockDefault = { find: vi.fn() };
+      (getPayload as Mock).mockResolvedValueOnce(mockDefault);
+
+      const { getPayloadClient } = await import('./payloadClient');
+      const result = await getPayloadClient();
+
+      expect(result).toBe(mockDefault);
+    });
+
+    it('should refuse prod-neon target without YES_I_MEAN_PROD=true', async () => {
       process.env.NEON_PROD_DATABASE_URL = 'postgresql://prod/db';
+      delete process.env.YES_I_MEAN_PROD;
+
+      const { getPayloadClient } = await import('./payloadClient');
+      await expect(getPayloadClient('prod-neon')).rejects.toThrow(
+        'Refusing to connect to production database',
+      );
+    });
+
+    it('should return uri for prod-neon when NEON_PROD_DATABASE_URL is set and YES_I_MEAN_PROD=true', async () => {
+      process.env.NEON_PROD_DATABASE_URL = 'postgresql://prod/db';
+      process.env.YES_I_MEAN_PROD = 'true';
       const { getPayload } = await import('payload');
       const mockProd = { find: vi.fn(), create: vi.fn() };
       (getPayload as Mock).mockResolvedValueOnce(mockProd);
@@ -121,6 +159,8 @@ describe('payloadClient', () => {
 
       expect(result).toBe(mockProd);
       expect(process.env.DATABASE_URI).toBe('postgresql://prod/db');
+
+      delete process.env.YES_I_MEAN_PROD;
     });
 
     it('should return uri for dev-neon when NEON_DEV_DATABASE_URL is set', async () => {
@@ -146,6 +186,93 @@ describe('payloadClient', () => {
       const result = await getPayloadClient('local-postgres');
 
       expect(result).toBe(mockLocal);
+    });
+  });
+
+  describe('prod-write guard', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      savedEnv.NEON_PROD_DATABASE_URL = process.env.NEON_PROD_DATABASE_URL;
+      savedEnv.DATABASE_URI = process.env.DATABASE_URI;
+      savedEnv.YES_I_MEAN_PROD = process.env.YES_I_MEAN_PROD;
+      delete process.env.NEON_PROD_DATABASE_URL;
+      delete process.env.DATABASE_URI;
+      delete process.env.YES_I_MEAN_PROD;
+    });
+
+    afterEach(() => {
+      process.env.NEON_PROD_DATABASE_URL = savedEnv.NEON_PROD_DATABASE_URL;
+      process.env.DATABASE_URI = savedEnv.DATABASE_URI;
+      process.env.YES_I_MEAN_PROD = savedEnv.YES_I_MEAN_PROD;
+    });
+
+    describe('isProdTarget', () => {
+      it('is true for prod and prod-neon', async () => {
+        const { isProdTarget } = await import('./payloadClient');
+        expect(isProdTarget('prod')).toBe(true);
+        expect(isProdTarget('prod-neon')).toBe(true);
+      });
+
+      it('is false for non-prod targets', async () => {
+        const { isProdTarget } = await import('./payloadClient');
+        expect(isProdTarget('dev')).toBe(false);
+        expect(isProdTarget('dev-neon')).toBe(false);
+        expect(isProdTarget('local-postgres')).toBe(false);
+      });
+    });
+
+    describe('assertProdWriteAllowed', () => {
+      it('does not throw for non-prod targets', async () => {
+        const { assertProdWriteAllowed } = await import('./payloadClient');
+        expect(() => assertProdWriteAllowed('local-postgres')).not.toThrow();
+        expect(() => assertProdWriteAllowed('dev-neon')).not.toThrow();
+      });
+
+      it('throws for prod targets without YES_I_MEAN_PROD=true', async () => {
+        const { assertProdWriteAllowed } = await import('./payloadClient');
+        expect(() => assertProdWriteAllowed('prod-neon')).toThrow(
+          'Refusing to connect to production database',
+        );
+      });
+
+      it('does not throw for prod targets when YES_I_MEAN_PROD=true', async () => {
+        process.env.YES_I_MEAN_PROD = 'true';
+        const { assertProdWriteAllowed } = await import('./payloadClient');
+        expect(() => assertProdWriteAllowed('prod-neon')).not.toThrow();
+      });
+    });
+
+    describe('assertNotConnectedToProd', () => {
+      it('does not throw when DATABASE_URI is unset', async () => {
+        process.env.NEON_PROD_DATABASE_URL = 'postgresql://prod/db';
+        const { assertNotConnectedToProd } = await import('./payloadClient');
+        expect(() => assertNotConnectedToProd()).not.toThrow();
+      });
+
+      it('does not throw when DATABASE_URI differs from prod', async () => {
+        process.env.NEON_PROD_DATABASE_URL = 'postgresql://prod/db';
+        process.env.DATABASE_URI = 'postgresql://dev/db';
+        const { assertNotConnectedToProd } = await import('./payloadClient');
+        expect(() => assertNotConnectedToProd()).not.toThrow();
+      });
+
+      it('throws when DATABASE_URI matches prod without YES_I_MEAN_PROD=true', async () => {
+        process.env.NEON_PROD_DATABASE_URL = 'postgresql://prod/db';
+        process.env.DATABASE_URI = 'postgresql://prod/db';
+        const { assertNotConnectedToProd } = await import('./payloadClient');
+        expect(() => assertNotConnectedToProd()).toThrow(
+          'DATABASE_URI is currently set to the production database',
+        );
+      });
+
+      it('does not throw when DATABASE_URI matches prod and YES_I_MEAN_PROD=true', async () => {
+        process.env.NEON_PROD_DATABASE_URL = 'postgresql://prod/db';
+        process.env.DATABASE_URI = 'postgresql://prod/db';
+        process.env.YES_I_MEAN_PROD = 'true';
+        const { assertNotConnectedToProd } = await import('./payloadClient');
+        expect(() => assertNotConnectedToProd()).not.toThrow();
+      });
     });
   });
 

--- a/bin/migrations/shared/payloadClient.ts
+++ b/bin/migrations/shared/payloadClient.ts
@@ -38,6 +38,32 @@ async function findDocBySlug(
   return result.docs.length > 0 ? (result.docs[0].id as number) : null;
 }
 
+function isProdTarget(target: PostgresTarget): boolean {
+  return target === 'prod-neon' || target === 'prod';
+}
+
+/**
+ * Prod writes must be explicit. Any script connecting to prod-neon/prod has to be
+ * invoked with YES_I_MEAN_PROD=true, otherwise we throw before a connection is made.
+ *
+ * Why: a prior agent session ran bin/seed-top11.ts against production Neon by accident
+ * (DATABASE_URI happened to resolve to prod), seeding demo data hours before the
+ * feature was meant to go live. This guard makes that class of mistake impossible
+ * without a deliberate, named opt-in.
+ */
+function assertProdWriteAllowed(target: PostgresTarget): void {
+  if (!isProdTarget(target)) {
+    return;
+  }
+  if (process.env.YES_I_MEAN_PROD === 'true') {
+    return;
+  }
+  throw new Error(
+    `Refusing to connect to production database (target "${target}") without explicit confirmation.\n`
+      + 'If you really mean to write to production, re-run with YES_I_MEAN_PROD=true.',
+  );
+}
+
 function getDatabaseUri(target: PostgresTarget): string {
   if (target === 'prod-neon' || target === 'prod') {
     const uri = process.env.NEON_PROD_DATABASE_URL;
@@ -57,30 +83,59 @@ function getDatabaseUri(target: PostgresTarget): string {
     }
     return uri;
   }
-  const uri = process.env.NEON_DEV_DATABASE_URL || process.env.DATABASE_URI;
+  const uri = process.env.DATABASE_URI || process.env.NEON_DEV_DATABASE_URL;
   if (!uri) {
     throw new Error(
-      `Database URI not found for target "${target}". Please set NEON_DEV_DATABASE_URL or DATABASE_URI in .env.local`,
+      `Database URI not found for target "${target}". Please set DATABASE_URI or NEON_DEV_DATABASE_URL in .env.local`,
     );
   }
   return uri;
 }
 
-export { getDatabaseUri };
+/**
+ * Guard for scripts (e.g. seed-top11.ts) that connect via getPayloadHMR/getPayload
+ * directly instead of going through getPayloadClient, and so have no target param
+ * to check. These scripts pick up whatever DATABASE_URI is already in the process
+ * environment — this compares that value against the known prod URI and refuses
+ * to proceed unless YES_I_MEAN_PROD=true.
+ */
+function assertNotConnectedToProd(): void {
+  const prodUri = process.env.NEON_PROD_DATABASE_URL;
+  const activeUri = process.env.DATABASE_URI;
+  if (!prodUri || !activeUri || activeUri !== prodUri) {
+    return;
+  }
+  if (process.env.YES_I_MEAN_PROD === 'true') {
+    return;
+  }
+  throw new Error(
+    'Refusing to run: DATABASE_URI is currently set to the production database.\n'
+      + 'If you really mean to write to production, re-run with YES_I_MEAN_PROD=true.',
+  );
+}
+
+export {
+  getDatabaseUri, isProdTarget, assertProdWriteAllowed, assertNotConnectedToProd,
+};
 
 export type PostgresTarget = 'local-postgres' | 'prod-neon' | 'dev-neon' | 'dev' | 'prod';
 
 /**
  * Get the Payload instance configured for the specified target database
  *
- * @param target - 'prod-neon' for production Neon, 'local-postgres' for local/dev
+ * @param target - 'local-postgres' for local/dev (default), 'prod-neon'/'prod' for production
+ *   (requires YES_I_MEAN_PROD=true)
  */
-export async function getPayloadClient(target: PostgresTarget = 'prod-neon'): Promise<Payload> {
+export async function getPayloadClient(
+  target: PostgresTarget = 'local-postgres',
+): Promise<Payload> {
   // NOTE: Scripts that call this must run with
   //   `yarn tsx --import ./bin/preload-nextenv-fix.mjs <script>.ts`
   // Otherwise payload's collection imports transitively load `bin/loadEnv.js`,
   // which crashes under tsx because of an @next/env default-export interop bug.
   // See bin/preload-nextenv-fix.mjs for the full explanation.
+
+  assertProdWriteAllowed(target);
 
   // Load environment variables from .env.local with override
   dotenv.config({

--- a/bin/musicbrainz-bulk-match.ts
+++ b/bin/musicbrainz-bulk-match.ts
@@ -17,6 +17,7 @@
 import { getPayload, type Payload } from 'payload';
 import config from '@payload-config';
 import { getArtistMbid, getReleaseMbid, getRecordingMbid } from './migrations/shared/musicbrainz';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
 import {
   parseArgs,
   getArtistName,
@@ -273,6 +274,10 @@ async function processSongs(payload: Payload, options: CliOptions): Promise<Coll
 
 async function main() {
   const options = parseArgs(process.argv);
+
+  if (options.fix) {
+    assertNotConnectedToProd();
+  }
 
   const mode = options.fix ? '🔧 FIX MODE' : '👀 DRY RUN';
   console.log(`\n🎵 MusicBrainz Bulk Match — ${mode}`);

--- a/bin/repair-dj-issues.ts
+++ b/bin/repair-dj-issues.ts
@@ -19,6 +19,7 @@
 
 import { getPayload } from 'payload';
 import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
 
 process.env.PAYLOAD_MIGRATING = 'true';
 
@@ -43,6 +44,7 @@ async function main() {
     console.log('    Run with --confirm to actually delete records.\n');
   } else {
     console.log('🔥 CONFIRM MODE: Records will be DELETED!\n');
+    assertNotConnectedToProd();
   }
 
   const payload = await getPayload({ config });

--- a/bin/seed-mrm-fresh.ts
+++ b/bin/seed-mrm-fresh.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
 
 /**
  * Seed a fresh Modern Rock Madness tournament into Payload database.
@@ -41,6 +42,8 @@ function r1BandPair(matchNumber: number): [number, number] {
 }
 
 async function seedMrmFresh() {
+  assertNotConnectedToProd();
+
   console.log('🏆 Seeding fresh Modern Rock Madness tournament...\n');
 
   const payload = await getPayloadHMR({ config });

--- a/bin/seed-mrm.ts
+++ b/bin/seed-mrm.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
 
 /**
  * Seed Modern Rock Madness data into Payload database
@@ -18,6 +19,8 @@ import config from '@payload-config';
  */
 
 async function seedMrm() {
+  assertNotConnectedToProd();
+
   console.log('🏆 Seeding Modern Rock Madness data...\n');
 
   const payload = await getPayloadHMR({ config });

--- a/bin/seed-payload.ts
+++ b/bin/seed-payload.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
 
 /**
  * Seed Payload database with sample data for testing
@@ -17,6 +18,8 @@ import config from '@payload-config';
  */
 
 async function seed() {
+  assertNotConnectedToProd();
+
   console.log('🌱 Seeding Payload database with sample data...\n');
 
   const payload = await getPayloadHMR({ config });
@@ -414,7 +417,9 @@ async function seed() {
       },
     });
 
-    console.log(`   ✅ Created "${post1.headline}", "${post2.headline}", "${post3.headline}", "${donatePost.headline}" (donate page)`);
+    console.log(
+      `   ✅ Created "${post1.headline}", "${post2.headline}", "${post3.headline}", "${donatePost.headline}" (donate page)`,
+    );
 
     // Create sample DJs first (for Shows)
     console.log('🎧 Creating sample DJs...');

--- a/bin/seed-top11.ts
+++ b/bin/seed-top11.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
 
 /**
  * Seed a realistic Top 11 contest into the Payload database for demos/dev.
@@ -191,6 +192,8 @@ async function findOrCreateSong(
 }
 
 async function seedTop11() {
+  assertNotConnectedToProd();
+
   console.log('🎵 Seeding Top 11 demo contest (week of 2026-06-25)...\n');
 
   const payload = await getPayloadHMR({ config });


### PR DESCRIPTION
## Summary
- A prior agent session accidentally ran `bin/seed-top11.ts` against production Neon (`DATABASE_URI` happened to resolve to prod), seeding demo data live hours before the feature merged.
- `getPayloadClient`'s default target was `'prod-neon'`, and its `local-postgres` fallback preferred `NEON_DEV_DATABASE_URL` over `DATABASE_URI` — both footguns that make an accidental prod connection easy to trigger silently.
- Adds an explicit `YES_I_MEAN_PROD=true` requirement before any write-capable script connects to production. Wired into `getPayloadClient` (`assertProdWriteAllowed`) and every script that seeds/mutates data directly via `getPayloadHMR`/`getPayload` (`assertNotConnectedToProd`): `seed-top11.ts`, `seed-mrm.ts`, `seed-mrm-fresh.ts`, `seed-payload.ts`, `repair-dj-issues.ts` (guarded only in `--confirm` mode), `musicbrainz-bulk-match.ts` (guarded only in `--fix` mode).
- Fixes `getPayloadClient`'s default target to `'local-postgres'` instead of `'prod-neon'`, and fixes the `local-postgres` fallback to prefer `DATABASE_URI` over `NEON_DEV_DATABASE_URL`.

## Test plan
- [x] `yarn vitest run bin/migrations/shared/payloadClient.test.ts` — 77/77 passing, including new coverage for `isProdTarget`, `assertProdWriteAllowed`, `assertNotConnectedToProd`, and the corrected default/fallback behavior
- [x] `yarn lint` — clean
- [x] Manual: without `YES_I_MEAN_PROD`, `getPayloadClient('prod-neon')` throws before any connection is attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rMyo1v4dsZJoWZQFUj5Vk