### PR TITLE
fix: declare voterKey field so Payload recognizes its generated DB column

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -6,7 +6,8 @@ const filterLintIgnored = (files) =>
     (f) =>
       !f.includes('/.storybook/') &&
       !f.endsWith('next-env.d.ts') &&
-      !f.includes('/bin/migrations/'),
+      !f.includes('/bin/migrations/') &&
+      !f.includes('/payload/migrations/'),
   );
 
 export default {

--- a/payload/migrations/20260704_000000_add_top11_votes_voterkey_field.ts
+++ b/payload/migrations/20260704_000000_add_top11_votes_voterkey_field.ts
@@ -1,0 +1,11 @@
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
+
+// No-op: the top11_votes.voter_key column and its unique index already exist,
+// created by migration 20260701_170648_add_top11_vote_dedup_and_lookback via
+// raw SQL (GENERATED ALWAYS AS ... STORED). This migration exists only to mark
+// the point where the Top11Votes collection config started declaring a
+// matching `voterKey` field, so Payload's schema introspection stops treating
+// that column as unmanaged.
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {}

--- a/payload/migrations/index.ts
+++ b/payload/migrations/index.ts
@@ -13,6 +13,7 @@ import * as migration_20260701_170648_add_top11_vote_dedup_and_lookback from './
 import * as migration_20260701_172922_add_top11_contestant_dedup from './20260701_172922_add_top11_contestant_dedup';
 import * as migration_20260701_203840_add_top11_recording_fields_and_drop_title from './20260701_203840_add_top11_recording_fields_and_drop_title';
 import * as migration_20260701_221242_add_top11_display_title from './20260701_221242_add_top11_display_title';
+import * as migration_20260704_000000_add_top11_votes_voterkey_field from './20260704_000000_add_top11_votes_voterkey_field';
 
 export const migrations = [
   {
@@ -89,5 +90,10 @@ export const migrations = [
     up: migration_20260701_221242_add_top11_display_title.up,
     down: migration_20260701_221242_add_top11_display_title.down,
     name: '20260701_221242_add_top11_display_title',
+  },
+  {
+    up: migration_20260704_000000_add_top11_votes_voterkey_field.up,
+    down: migration_20260704_000000_add_top11_votes_voterkey_field.down,
+    name: '20260704_000000_add_top11_votes_voterkey_field',
   },
 ];

--- a/payload/src/collections/Top11Votes.ts
+++ b/payload/src/collections/Top11Votes.ts
@@ -30,7 +30,15 @@ export const Top11Votes: CollectionConfig = {
   },
   hooks: {
     beforeChange: [
-      async ({ operation, data, req }) => {
+      async ({ operation, data: incomingData, req }) => {
+        // voterKey is a Postgres GENERATED ALWAYS column (see migration
+        // 20260701_170648_add_top11_vote_dedup_and_lookback) — Postgres computes
+        // and writes it, so Payload must never attempt to set it itself.
+        const data = incomingData;
+        if (data) {
+          delete (data as Record<string, unknown>).voterKey;
+        }
+
         if (operation !== 'create' || !data) {
           return data;
         }
@@ -148,6 +156,15 @@ export const Top11Votes: CollectionConfig = {
           },
         },
       ],
+    },
+    {
+      name: 'voterKey',
+      type: 'text',
+      admin: {
+        readOnly: true,
+        description:
+          'Auto-generated dedup key (voterAuth0Id || voterUserId || voterEmail). Computed by Postgres, not editable.',
+      },
     },
     {
       name: 'voteSource',


### PR DESCRIPTION
## Summary
- `top11_votes.voter_key` is a Postgres `GENERATED ALWAYS` column added via raw SQL in migration `20260701_170648_add_top11_vote_dedup_and_lookback`, backing a unique index that enforces one vote per contest per voter at the DB level.
- It was never declared as a field in the `Top11Votes` collection config, so Payload's dev-mode schema push (which diffs the live DB against fields declared in config) treats it as unmanaged and prompts to drop it — with 120 rows of real vote data, that's a destructive prompt someone will eventually accept by mistake, prod included (Top 11 has already merged to production).
- Declares `voterKey` as a read-only field so the config matches the DB, and strips it from `beforeChange` payloads so Payload never attempts to write to a column only Postgres is allowed to set.
- Includes a no-op migration marker (the column/index already exist; there's no SQL to run) purely to keep migration history consistent.
- Also fixes `lint-staged.config.mjs` to exclude `payload/migrations/` from linting, matching the existing `bin/migrations/` exclusion — without it, any commit touching only migration files fails on eslint's `--ignore-pattern` warning tripping `--max-warnings=0`.

## Test plan
- [x] `yarn lint` — clean
- [x] `yarn tsc --noEmit` — no new errors introduced (pre-existing baseline errors in this file unchanged)
- [x] Manual: booted Payload against both local Postgres and Neon dev (with `voter_key` present on both) — no schema-push prompt on either
- [x] Manual: confirmed prompt reproduces without this fix (reverting locally re-triggers "You're about to delete voter_key column... with 120 items")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rMyo1v4dsZJoWZQFUj5Vk