### PR TITLE
feat: preserve banner images on custom-text pages via headerImage field

### DIFF
--- a/bin/migrations/importCustomTexts.test.ts
+++ b/bin/migrations/importCustomTexts.test.ts
@@ -18,18 +18,20 @@ vi.mock('./shared/payloadClient', () => ({
   getPayloadClient: vi.fn(),
 }));
 
+const mockConvertHtmlToLexicalEnhanced = vi.fn((html: string) => ({
+  root: {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: html, format: 0 }],
+      },
+    ],
+  },
+}));
+
 vi.mock('./shared/enhancedHtmlToLexical', () => ({
-  convertHtmlToLexicalEnhanced: vi.fn((html: string) => ({
-    root: {
-      type: 'root',
-      children: [
-        {
-          type: 'paragraph',
-          children: [{ type: 'text', text: html, format: 0 }],
-        },
-      ],
-    },
-  })),
+  convertHtmlToLexicalEnhanced: (html: string) => mockConvertHtmlToLexicalEnhanced(html),
 }));
 
 vi.mock('./shared/logger', () => ({
@@ -48,6 +50,17 @@ describe('importCustomTexts', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConvertHtmlToLexicalEnhanced.mockImplementation((html: string) => ({
+      root: {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [{ type: 'text', text: html, format: 0 }],
+          },
+        ],
+      },
+    }));
 
     mockPayload = {
       find: vi.fn(),
@@ -201,6 +214,78 @@ describe('importCustomTexts', () => {
       const result = await importCustomText(mockPayload as Payload, customText);
 
       expect(result).toBe('error');
+    });
+
+    it('should not use the generic empty-content fallback for an image-only body', async () => {
+      // Regression test: a body that converts to a single `upload` node has
+      // real content, but previously got nulled to "(No content available)"
+      // because the emptiness check ran after upload nodes were stripped.
+      mockConvertHtmlToLexicalEnhanced.mockReturnValueOnce({
+        root: {
+          type: 'root',
+          children: [
+            {
+              type: 'upload',
+              value: { id: 'https://i.imgur.com/banner.png' },
+              children: [],
+            },
+          ],
+        },
+      });
+
+      const { importCustomText } = await import('./importCustomTexts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-banner' });
+
+      const customText: CustomText = {
+        id: 47,
+        title: '<img src="https://i.imgur.com/banner.png" width="685">',
+        html: '<img src="https://i.imgur.com/banner.png" width="685">',
+        permalink: 'top220of2020',
+        status: 'active',
+      };
+
+      await importCustomText(mockPayload as Payload, customText);
+
+      const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
+      const [firstChild] = callData.content.root.children;
+      const text = firstChild.children[0].text;
+      expect(text).not.toBe('(No content available)');
+      expect(text).toBe('(Image content not yet migrated)');
+    });
+
+    it('should still use the generic empty-content fallback when there is truly no content', async () => {
+      mockConvertHtmlToLexicalEnhanced.mockReturnValueOnce({
+        root: {
+          type: 'root',
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: '   ', format: 0 }],
+            },
+          ],
+        },
+      });
+
+      const { importCustomText } = await import('./importCustomTexts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-empty' });
+
+      const customText: CustomText = {
+        id: 52,
+        title: 'Y-Not Sessions 2021',
+        html: '<p>   </p>',
+        permalink: 'ynotsessions2021',
+        status: 'active',
+      };
+
+      await importCustomText(mockPayload as Payload, customText);
+
+      const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
+      const text = callData.content.root.children[0].children[0].text;
+      expect(text).toBe('(No content available)');
     });
   });
 });

--- a/bin/migrations/importCustomTexts.test.ts
+++ b/bin/migrations/importCustomTexts.test.ts
@@ -1,9 +1,8 @@
 /**
  * Unit tests for importCustomTexts migration script
  *
- * Focuses on the donate page scenario described in GitHub issue:
- * "Donate page is blank in Postgres version" — the root cause was that
- * the 'donate' custom_text was not present in the Postgres posts table.
+ * Covers the import of custom_texts from MySQL into the dedicated `pages`
+ * Payload collection (distinct from `posts` / stories).
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
@@ -58,11 +57,11 @@ describe('importCustomTexts', () => {
   });
 
   describe('importCustomText', () => {
-    it('should import donate custom_text with slug "donate"', async () => {
+    it('should import donate custom_text into the pages collection with slug "donate"', async () => {
       const { importCustomText } = await import('./importCustomTexts');
 
       (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
-      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-donate' });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-donate' });
 
       const donateCustomText: CustomText = {
         id: 5,
@@ -77,13 +76,11 @@ describe('importCustomTexts', () => {
       expect(result).toBe('success');
       expect(mockPayload.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          collection: 'posts',
+          collection: 'pages',
           data: expect.objectContaining({
             slug: 'donate',
-            headline: 'Support Y-Not Radio',
-            showOnFrontPage: false,
-            startDate: '2000-01-01T00:00:00.000Z',
-            endDate: '2099-12-31T23:59:59.999Z',
+            title: 'Support Y-Not Radio',
+            _status: 'published',
           }),
         }),
       );
@@ -93,7 +90,7 @@ describe('importCustomTexts', () => {
       const { importCustomText } = await import('./importCustomTexts');
 
       (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
-      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-about' });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-about' });
 
       const aboutCustomText: CustomText = {
         id: 10,
@@ -134,16 +131,16 @@ describe('importCustomTexts', () => {
       // Upsert: existing docs are refreshed in place, not skipped or duplicated.
       expect(result).toBe('success');
       expect(mockPayload.update).toHaveBeenCalledWith(
-        expect.objectContaining({ collection: 'posts', id: 'existing' }),
+        expect.objectContaining({ collection: 'pages', id: 'existing' }),
       );
       expect(mockPayload.create).not.toHaveBeenCalled();
     });
 
-    it('should set showOnFrontPage to false for custom text pages', async () => {
+    it('should not include Posts-specific fields (startDate, endDate, showOnFrontPage)', async () => {
       const { importCustomText } = await import('./importCustomTexts');
 
       (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
-      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-id' });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-id' });
 
       const customText: CustomText = {
         id: 7,
@@ -155,18 +152,18 @@ describe('importCustomTexts', () => {
 
       await importCustomText(mockPayload as Payload, customText);
 
-      expect(mockPayload.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ showOnFrontPage: false }),
-        }),
-      );
+      const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
+      expect(callData).not.toHaveProperty('showOnFrontPage');
+      expect(callData).not.toHaveProperty('startDate');
+      expect(callData).not.toHaveProperty('endDate');
+      expect(callData).not.toHaveProperty('priority');
     });
 
-    it('should apply legacyId offset of 10000 to avoid collision with story IDs', async () => {
+    it('should use the raw MySQL id as legacyId (no offset needed in pages collection)', async () => {
       const { importCustomText } = await import('./importCustomTexts');
 
       (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
-      (mockPayload.create as Mock).mockResolvedValue({ id: 'post-id' });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-id' });
 
       const customText: CustomText = {
         id: 5,
@@ -178,10 +175,11 @@ describe('importCustomTexts', () => {
 
       await importCustomText(mockPayload as Payload, customText);
 
-      // Verify the find call used legacyId = 5 + 10000 = 10005
+      // Find uses the raw MySQL id (no +10000 offset; pages has no story ID collisions)
       expect(mockPayload.find).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { legacyId: { equals: 10005 } },
+          collection: 'pages',
+          where: { legacyId: { equals: 5 } },
         }),
       );
     });
@@ -206,3 +204,4 @@ describe('importCustomTexts', () => {
     });
   });
 });
+

--- a/bin/migrations/importCustomTexts.test.ts
+++ b/bin/migrations/importCustomTexts.test.ts
@@ -34,6 +34,11 @@ vi.mock('./shared/enhancedHtmlToLexical', () => ({
   convertHtmlToLexicalEnhanced: (html: string) => mockConvertHtmlToLexicalEnhanced(html),
 }));
 
+const mockImportImageFromUrl = vi.fn();
+vi.mock('./shared/mediaImporter', () => ({
+  importImageFromUrl: (...args: unknown[]) => mockImportImageFromUrl(...args),
+}));
+
 vi.mock('./shared/logger', () => ({
   createLogger: () => ({
     info: vi.fn(),
@@ -61,6 +66,7 @@ describe('importCustomTexts', () => {
         ],
       },
     }));
+    mockImportImageFromUrl.mockResolvedValue({ success: false, error: 'not mocked' });
 
     mockPayload = {
       find: vi.fn(),
@@ -286,6 +292,86 @@ describe('importCustomTexts', () => {
       const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
       const text = callData.content.root.children[0].children[0].text;
       expect(text).toBe('(No content available)');
+    });
+
+    it('should extract and import a stylized <img> title as headerImage', async () => {
+      mockImportImageFromUrl.mockResolvedValue({
+        success: true,
+        mediaId: 'media-banner-123',
+        cloudinaryUrl: 'https://cloudinary.example/banner.png',
+      });
+
+      const { importCustomText } = await import('./importCustomTexts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-top220' });
+
+      const customText: CustomText = {
+        id: 47,
+        title: '<img src="https://i.imgur.com/QRvzAZV.png" width="685">',
+        html: '<table><tr><td>Song</td></tr></table>',
+        permalink: 'top220of2020',
+        status: 'active',
+      };
+
+      await importCustomText(mockPayload as Payload, customText);
+
+      expect(mockImportImageFromUrl).toHaveBeenCalledWith(
+        mockPayload,
+        'https://i.imgur.com/QRvzAZV.png',
+        expect.objectContaining({ legacyUrl: 'https://i.imgur.com/QRvzAZV.png' }),
+      );
+
+      const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
+      expect(callData.headerImage).toBe('media-banner-123');
+      expect(callData.title).toBe('Top220of2020');
+    });
+
+    it('should omit headerImage when the banner image import fails', async () => {
+      mockImportImageFromUrl.mockResolvedValue({
+        success: false,
+        error: 'Failed to download image',
+      });
+
+      const { importCustomText } = await import('./importCustomTexts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-top221' });
+
+      const customText: CustomText = {
+        id: 50,
+        title: '<img src="https://i.imgur.com/p7LzXZv.gif" width="685">',
+        html: '<table><tr><td>Song</td></tr></table>',
+        permalink: 'top221of2021',
+        status: 'active',
+      };
+
+      await importCustomText(mockPayload as Payload, customText);
+
+      const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
+      expect(callData).not.toHaveProperty('headerImage');
+      expect(callData.title).toBe('Top221of2021');
+    });
+
+    it('should not attempt an image import when title HTML has no <img>', async () => {
+      const { importCustomText } = await import('./importCustomTexts');
+
+      (mockPayload.find as Mock).mockResolvedValue({ totalDocs: 0, docs: [] });
+      (mockPayload.create as Mock).mockResolvedValue({ id: 'page-centered' });
+
+      const customText: CustomText = {
+        id: 73,
+        title: '<center>Y-Not Sessions 2025</center>',
+        html: '<p>Sessions info</p>',
+        permalink: 'ynotsessions2025',
+        status: 'active',
+      };
+
+      await importCustomText(mockPayload as Payload, customText);
+
+      expect(mockImportImageFromUrl).not.toHaveBeenCalled();
+      const callData = (mockPayload.create as Mock).mock.calls[0][0].data;
+      expect(callData).not.toHaveProperty('headerImage');
     });
   });
 });

--- a/bin/migrations/importCustomTexts.ts
+++ b/bin/migrations/importCustomTexts.ts
@@ -37,13 +37,13 @@ async function importCustomText(
   payload: any,
   customText: CustomText,
 ): Promise<'success' | 'skipped' | 'error'> {
-  const legacyId = customText.id + 10000; // Offset to avoid collisions with story IDs
+  const legacyId = customText.id;
 
   try {
     // Check if already imported — if so we update in place so re-running the
     // script refreshes stale custom-text content (e.g. new Mixcloud embeds).
     const existing = await payload.find({
-      collection: 'posts',
+      collection: 'pages',
       where: { legacyId: { equals: legacyId } },
       limit: 1,
     });
@@ -51,20 +51,20 @@ async function importCustomText(
 
     logger.info(`Importing custom_text ${customText.id}: ${customText.title}`);
 
-    // Generate proper headline from permalink if title is HTML
-    let headline = customText.title;
-    if (headline.trim().startsWith('<')) {
+    // Generate proper title from permalink if title is HTML
+    let { title } = customText;
+    if (title.trim().startsWith('<')) {
       // Title is HTML (likely an image tag), use permalink instead
       if (customText.permalink) {
         // Convert permalink to title case: "top220of2020" -> "Top 220 Of 2020"
-        headline = customText.permalink
+        title = customText.permalink
           .split('-')
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
           .join(' ');
       } else {
-        headline = `Custom Text ${customText.id}`;
+        title = `Custom Text ${customText.id}`;
       }
-      logger.info(`  Converted HTML title to: "${headline}"`);
+      logger.info(`  Converted HTML title to: "${title}"`);
     }
 
     // Convert HTML content to Lexical format using enhanced converter
@@ -163,25 +163,22 @@ async function importCustomText(
     const slug = customText.permalink || `custom-text-${customText.id}`;
 
     const data = {
-      headline,
+      title,
       content,
       slug,
-      // generateSlug: false ensures the postSlugify hook doesn't overwrite
-      // our permalink-derived slug with a date-prefixed value.
+      // generateSlug: false ensures the pageSlugify hook doesn't overwrite
+      // our permalink-derived slug.
       generateSlug: false,
-      startDate: '2000-01-01T00:00:00.000Z', // Always visible content
-      endDate: '2099-12-31T23:59:59.999Z', // Far future date
-      showOnFrontPage: false, // Custom texts are standalone pages, not front page stories
-      status: 'published',
+      _status: 'published' as const,
       legacyId,
     };
 
     if (existingId !== undefined) {
-      await payload.update({ collection: 'posts', id: existingId, data });
-      logger.info(`  ✓ Updated custom_text ${customText.id} (post ${existingId})`);
+      await payload.update({ collection: 'pages', id: existingId, data });
+      logger.info(`  ✓ Updated custom_text ${customText.id} (page ${existingId})`);
     } else {
-      const newPost = await payload.create({ collection: 'posts', data });
-      logger.info(`  ✓ Imported custom_text ${customText.id} as post ${newPost.id}`);
+      const newPage = await payload.create({ collection: 'pages', data });
+      logger.info(`  ✓ Imported custom_text ${customText.id} as page ${newPage.id}`);
     }
     return 'success';
   } catch (error: any) {

--- a/bin/migrations/importCustomTexts.ts
+++ b/bin/migrations/importCustomTexts.ts
@@ -16,6 +16,7 @@ import { connectToDatabase, type CustomText } from './database';
 import { getPayloadClient } from './shared/payloadClient';
 import { createLogger } from './shared/logger';
 import { convertHtmlToLexicalEnhanced } from './shared/enhancedHtmlToLexical';
+import { importImageFromUrl } from './shared/mediaImporter';
 
 const logger = createLogger('CustomTextsImport');
 
@@ -53,8 +54,26 @@ async function importCustomText(
 
     // Generate proper title from permalink if title is HTML
     let { title } = customText;
+    let headerImage: string | undefined;
     if (title && title.trim().startsWith('<')) {
-      // Title is HTML (likely an image tag), use permalink instead
+      // Title is HTML — usually a stylized banner <img> used in place of a
+      // real heading. Extract and import that image as the page's headerImage
+      // so the banner isn't lost, then fall back to a readable text title.
+      const imgMatch = title.match(/<img[^>]+src=["']([^"']+)["']/i);
+      if (imgMatch) {
+        const [, imageUrl] = imgMatch;
+        const result = await importImageFromUrl(payload, imageUrl, {
+          alt: `Banner image for ${customText.permalink || `custom text ${customText.id}`}`,
+          legacyUrl: imageUrl,
+        });
+        if (result.success && result.mediaId) {
+          headerImage = result.mediaId;
+          logger.info(`  Imported header image: ${imageUrl} -> media ${result.mediaId}`);
+        } else {
+          logger.warn(`  Failed to import header image ${imageUrl}: ${result.error}`);
+        }
+      }
+
       if (customText.permalink) {
         // Convert permalink to title case: "top220of2020" -> "Top 220 Of 2020"
         title = customText.permalink
@@ -195,7 +214,7 @@ async function importCustomText(
     // Generate slug from permalink
     const slug = customText.permalink || `custom-text-${customText.id}`;
 
-    const data = {
+    const data: Record<string, unknown> = {
       title,
       content,
       slug,
@@ -205,6 +224,9 @@ async function importCustomText(
       _status: 'published' as const,
       legacyId,
     };
+    if (headerImage) {
+      data.headerImage = headerImage;
+    }
 
     if (existingId !== undefined) {
       await payload.update({ collection: 'pages', id: existingId, data });

--- a/bin/migrations/importCustomTexts.ts
+++ b/bin/migrations/importCustomTexts.ts
@@ -72,6 +72,18 @@ async function importCustomText(
     try {
       content = convertHtmlToLexicalEnhanced(customText.html || '');
 
+      // Check if content is empty or just has empty paragraph. This must run
+      // BEFORE stripping upload nodes below — otherwise a body that's entirely
+      // an image (a banner <img>, a show-directory grid, etc.) looks empty
+      // after stripping and gets replaced with the "(No content available)"
+      // fallback, silently discarding pages that had real (if unhandled) content.
+      const hasContent = content.root.children.some((child: any) => {
+        if (child.type === 'paragraph') {
+          return child.children.some((textNode: any) => textNode.text && textNode.text.trim());
+        }
+        return true;
+      });
+
       // Strip out upload nodes (images) since they have placeholder IDs that fail validation
       // Images will need to be re-added manually or via a separate import process
       const stripUploadNodes = (nodes: any[]): any[] => nodes
@@ -85,13 +97,34 @@ async function importCustomText(
 
       content.root.children = stripUploadNodes(content.root.children);
 
-      // Check if content is empty or just has empty paragraph
-      const hasContent = content.root.children.some((child: any) => {
-        if (child.type === 'paragraph') {
-          return child.children.some((textNode: any) => textNode.text && textNode.text.trim());
-        }
-        return true;
-      });
+      // An image-only body has real content (hasContent === true) but strips
+      // down to zero children — Payload's rich-text field needs at least one
+      // block, so leave a note rather than an empty root.
+      if (hasContent && content.root.children.length === 0) {
+        logger.warn(
+          `  Custom text ${customText.id} had only image content, which was stripped`,
+        );
+        content.root.children = [
+          {
+            type: 'paragraph',
+            format: '',
+            indent: 0,
+            version: 1,
+            children: [
+              {
+                type: 'text',
+                text: '(Image content not yet migrated)',
+                format: 0,
+                mode: 'normal',
+                style: '',
+                detail: 0,
+                version: 1,
+              },
+            ],
+            direction: 'ltr',
+          },
+        ];
+      }
 
       if (!hasContent) {
         logger.warn(`  Custom text ${customText.id} has empty content, using fallback`);

--- a/bin/migrations/importCustomTexts.ts
+++ b/bin/migrations/importCustomTexts.ts
@@ -1,7 +1,7 @@
 /**
  * Import only custom_texts from MySQL to Payload
  *
- * This script imports custom_texts as Posts with special handling:
+ * This script imports custom_texts as Pages with special handling:
  * - Uses enhanced HTML-to-Lexical converter for complex content
  * - Generates slugs from permalinks
  * - Sets appropriate dates for always-visible content
@@ -53,7 +53,7 @@ async function importCustomText(
 
     // Generate proper title from permalink if title is HTML
     let { title } = customText;
-    if (title.trim().startsWith('<')) {
+    if (title && title.trim().startsWith('<')) {
       // Title is HTML (likely an image tag), use permalink instead
       if (customText.permalink) {
         // Convert permalink to title case: "top220of2020" -> "Top 220 Of 2020"

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -185,6 +185,34 @@ describe('enhancedHtmlToLexical', () => {
       expect(listItem.type).toBe('listitem');
       expect(listItem.children.some((n: any) => n.format === 1)).toBe(true);
     });
+
+    it('should set a numeric indent on every list item (Lexical rejects null/undefined)', () => {
+      // Regression test: listitem nodes without `indent` crashed the Payload
+      // admin editor with "Invalid indent value" on real imported pages that
+      // used <li value="N"> for tied countdown rankings.
+      const html = '<ol><li>First</li><li>Second</li></ol>';
+      const result = convertHtmlToLexicalEnhanced(html);
+      const listItems = result.root.children[0].children;
+      listItems.forEach((item: any) => {
+        expect(typeof item.indent).toBe('number');
+      });
+    });
+
+    it('should use an explicit li value attribute as the listitem value', () => {
+      const html = '<ol><li value="7">Tied for 7th</li><li value="7">Also tied for 7th</li></ol>';
+      const result = convertHtmlToLexicalEnhanced(html);
+      const [first, second] = result.root.children[0].children;
+      expect(first.value).toBe(7);
+      expect(second.value).toBe(7);
+    });
+
+    it('should fall back to positional numbering when li has no value attribute', () => {
+      const html = '<ol><li>First</li><li>Second</li></ol>';
+      const result = convertHtmlToLexicalEnhanced(html);
+      const [first, second] = result.root.children[0].children;
+      expect(first.value).toBe(1);
+      expect(second.value).toBe(2);
+    });
   });
 
   describe('Block Quotes', () => {

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -56,6 +56,7 @@ function sanitizeHtml(html: string): string {
       'href', 'title', 'target', 'rel',
       'src', 'alt', 'width', 'height',
       'class', 'id',
+      'value',
       'data-*',
     ],
     ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i,
@@ -300,12 +301,16 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
   // Lists
   else if (tagName === 'ul' || tagName === 'ol') {
     const listItems = Array.from(element.querySelectorAll(':scope > li'));
-    const children = listItems.map((li) => {
+    const children = listItems.map((li, index) => {
       const itemChildren = parseInlineHTML(li.innerHTML);
+      const liValue = li.getAttribute('value');
+      const parsedValue = liValue ? parseInt(liValue, 10) : NaN;
       return {
         type: 'listitem',
-        value: 1,
+        value: Number.isNaN(parsedValue) ? index + 1 : parsedValue,
         checked: undefined,
+        format: '',
+        indent: 0,
         version: 1,
         children: itemChildren.length > 0 ? itemChildren : [{
           type: 'text',

--- a/docs/payload-migration/15-custom-text-strategy.md
+++ b/docs/payload-migration/15-custom-text-strategy.md
@@ -25,7 +25,7 @@ database.
 > single `longtext` HTML blob. Porting that blob to a Lexical rich-text field
 > preserves the bad model and is the direct source of the HTML→Lexical
 > embed-dropping and whitespace bugs fixed in #780. The real question is how the
-> content should be *modelled*.
+> content should be _modelled_.
 
 ---
 
@@ -35,13 +35,13 @@ There are **35 active rows** in `custom_texts`. Every one is a single freeform
 HTML blob in one `longtext` column, authored as raw HTML in a `<textarea>`. They
 fall into five archetypes — only one of which is genuinely "a rich-text article."
 
-| # | Archetype | Count | Representative pages | What it really is |
-|---|-----------|-------|----------------------|-------------------|
-| **A** | Specialty-show episode archive | 2 | `rodney-anonymous` (143 embeds), `quarantine-takeovers` (35) | A flat list of hand-pasted Mixcloud `<iframe>`s separated by `<br><br>` |
-| **B** | Show directory / hub | 1 | `shows` | A 4-column HTML `<table>` of program tiles (thumbnail + link) → Mixcloud or sibling pages |
-| **C** | Year-end ranked lists & poll results | 12 | `top220of2020`…`top225of2025`, `yearendpoll2020`…`2025` | Ranked **data** (rank / artist / title; album lists) hand-typed as 220–230-row `<table>`s |
-| **D** | Multimedia retrospective | 4 | `y100:-20-years-gone`, `future-friday`, `words-with-nerds`, `y100-rocks` | Genuine rich articles: prose + dozens of mixed embeds (Mixcloud / YouTube / OpenDrive) |
-| **E** | Landing / marketing / stub | 16 | `donate`, `t-shirts`, `contests`, `ynotsessions20XX`×6, `remembering-starla`, `player-test` | Simple pages; a few carry PayPal **forms** / **scripts** |
+| #     | Archetype                            | Count | Representative pages                                                                        | What it really is                                                                         |
+| ----- | ------------------------------------ | ----- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **A** | Specialty-show episode archive       | 2     | `rodney-anonymous` (143 embeds), `quarantine-takeovers` (35)                                | A flat list of hand-pasted Mixcloud `<iframe>`s separated by `<br><br>`                   |
+| **B** | Show directory / hub                 | 1     | `shows`                                                                                     | A 4-column HTML `<table>` of program tiles (thumbnail + link) → Mixcloud or sibling pages |
+| **C** | Year-end ranked lists & poll results | 12    | `top220of2020`…`top225of2025`, `yearendpoll2020`…`2025`                                     | Ranked **data** (rank / artist / title; album lists) hand-typed as 220–230-row `<table>`s |
+| **D** | Multimedia retrospective             | 4     | `y100:-20-years-gone`, `future-friday`, `words-with-nerds`, `y100-rocks`                    | Genuine rich articles: prose + dozens of mixed embeds (Mixcloud / YouTube / OpenDrive)    |
+| **E** | Landing / marketing / stub           | 16    | `donate`, `t-shirts`, `contests`, `ynotsessions20XX`×6, `remembering-starla`, `player-test` | Simple pages; a few carry PayPal **forms** / **scripts**                                  |
 
 ### Concrete problems observed in the stored content
 
@@ -78,11 +78,11 @@ Custom texts get their **own `Pages` collection, separate and distinct from
 `Posts`** — they are not stories, and the two content types should not share a
 table:
 
-| | `Posts` (Stories) | `Pages` (Custom Text) |
-|---|---|---|
+|            | `Posts` (Stories)                                                                         | `Pages` (Custom Text)                             |
+| ---------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | Addressing | Front-page rotation, date-windowed (`startDate`/`endDate`, `priority`, `showOnFrontPage`) | Evergreen, addressed by a stable `permalink`/slug |
-| Lifecycle | Time-bound news items that age off the front page | Long-lived reference / marketing pages |
-| Identity | A headline + dated body | A titled page at a fixed URL |
+| Lifecycle  | Time-bound news items that age off the front page                                         | Long-lived reference / marketing pages            |
+| Identity   | A headline + dated body                                                                   | A titled page at a fixed URL                      |
 
 `Pages` is the baseline home for the 35 custom texts and preserves the permalinks
 the front end already routes on — `pages.php?page=…`, plus `donate.php`,
@@ -93,8 +93,8 @@ permalink via `CustomTextFactory`. Minimum fields: `title`, `slug`/`permalink`
 `use_postgres_customtext` flag toggles — repoints from `custom_texts` to the
 `pages` table once content is migrated, so no front-end call sites change.
 
-The archetype work below refines this baseline: pages that are really *structured
-data* (A/B specialty shows, C year-end lists) graduate **out of** freeform
+The archetype work below refines this baseline: pages that are really _structured
+data_ (A/B specialty shows, C year-end lists) graduate **out of** freeform
 `Pages` into purpose-built collections; the genuine rich-text pages (D/E) stay in
 `Pages` with rich text + embed blocks. (Whether every custom text must live in
 `Pages` or the structured archetypes graduate out is tracked in Open Questions.)
@@ -127,7 +127,7 @@ data* (A/B specialty shows, C year-end lists) graduate **out of** freeform
 Sequenced by pain:
 
 1. **A + B — Specialty Shows (highest pain, genuinely unbuilt).**
-   The existing `Shows` collection is the *airing schedule* (date / host /
+   The existing `Shows` collection is the _airing schedule_ (date / host /
    start–end time), **not** a directory of programs — so neither A nor B is
    served today. Introduce a program/episode model that powers both:
    - `SpecialtyShow` (program): `name`, `slug`, `thumbnail` (Media),
@@ -176,14 +176,100 @@ Sequenced by pain:
 Baseline home for all custom text is the new **`Pages`** collection; the
 structured archetypes graduate out of it into purpose-built collections.
 
-| Archetype | Target | Status |
-|-----------|--------|--------|
-| A — episode archives | `SpecialtyShow` (+ episodes) | **New work** (biggest gap) |
-| B — show hub | `SpecialtyShow` directory view | **New work** (with A) |
-| C — year-end lists | `YearEndPollResults` (Ch. 13 / #154) | **Exists** — reuse |
-| C — voting | `YearEndPolls*` (PR #518) | **Open PR** — land |
-| D — retrospectives | `Pages` + embed blocks | Needs `Pages` + Phase 1 blocks |
-| E — landing/forms | `Pages` + form components | Needs `Pages` + Phase 1 blocks |
+| Archetype            | Target                               | Status                         |
+| -------------------- | ------------------------------------ | ------------------------------ |
+| A — episode archives | `SpecialtyShow` (+ episodes)         | **New work** (biggest gap)     |
+| B — show hub         | `SpecialtyShow` directory view       | **New work** (with A)          |
+| C — year-end lists   | `YearEndPollResults` (Ch. 13 / #154) | **Exists** — reuse             |
+| C — voting           | `YearEndPolls*` (PR #518)            | **Open PR** — land             |
+| D — retrospectives   | `Pages` + embed blocks               | Needs `Pages` + Phase 1 blocks |
+| E — landing/forms    | `Pages` + form components            | Needs `Pages` + Phase 1 blocks |
+
+---
+
+## Import audit (all 35 pages vs. live site)
+
+Ran on 2026-07-04 against a local Payload instance pointed at the Neon `dev`
+branch, comparing each imported `pages` row to its live `ynotradio.net`
+counterpart (legacy URL pattern is `pages.php?page=<slug>`, not `/<slug>`
+directly).
+
+| id  | title                        | live URL found?                 | gap summary                                                                                                                         | severity              |
+| --- | ---------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| 1   | Support Y-Not Radio          | Yes                             | Text/links/tables preserved; tables collapsed to `[Table]` text placeholders (loses column structure)                               | minor                 |
+| 2   | Y-Not Radio Contests         | Yes                             | Local empty, but live page itself is pure JS/AJAX widget — nothing to import                                                        | none                  |
+| 3   | Modern Rock Madness          | Yes                             | Local content empty; live has tournament description, sponsorship pricing, bracket link, banner image, Mixcloud embed — all missing | major                 |
+| 4   | Y-Not Radio Contests (v2)    | Yes                             | Local empty; live also just a dynamic widget — not a bug                                                                            | none                  |
+| 5   | Future Friday                | Yes                             | Local empty; live has large weekly playlist tables spanning many weeks — all missing                                                | major                 |
+| 6   | Y100Rocks → Y-Not            | Yes                             | Local empty; live has narrative text + ~23 Mixcloud embeds + banner image — all missing                                             | major                 |
+| 7   | Specialty Shows On Demand    | Yes                             | Confirmed fallback bug; live is a grid of ~20 show-logo images (visual show directory) — all missing                                | major                 |
+| 8   | Rodney Anonymous             | Yes                             | Local empty; live has ~90 Mixcloud episode embeds — all missing                                                                     | major                 |
+| 9   | Words With Nerds             | Yes                             | Local empty; live has ~44 Mixcloud embeds + 2 "Full Interview" entries — all missing                                                | major                 |
+| 10  | Modern Rock Madness Draft    | Yes                             | Banner `<img>` title lost; embedded Google Forms voting iframe dropped (stray "Loading…" text remains)                              | major                 |
+| 11  | Top1000                      | Yes                             | Banner image lost; Google Sheets embed preserved correctly                                                                          | minor                 |
+| 12  | Quarantine Takeovers         | Yes                             | Intro text + ~35 Mixcloud embeds preserved well; inline banner image possibly dropped                                               | minor                 |
+| 13  | Top220of2020                 | Yes                             | Banner image lost; nav table flattened (acceptable); sponsor link lost as hyperlink; song tables/embeds preserved                   | minor                 |
+| 14  | Yearendpoll2020              | Yes                             | Same banner-loss/nav-flatten pattern; top lists preserved well otherwise                                                            | minor                 |
+| 15  | Y-Not Sessions 2020          | Yes                             | Confirmed fallback bug — shows literal "(No content available)"; live has download link + banner image                              | major                 |
+| 16  | Top221of2021                 | Yes                             | Banner image lost; embeds/tables preserved                                                                                          | minor                 |
+| 17  | Yearendpoll2021              | Yes                             | Same banner-loss pattern; lists preserved                                                                                           | minor                 |
+| 18  | Y-Not Sessions 2021          | No (404, retired from live nav) | Fallback "(No content available)" — root-caused to import script bug                                                                | major                 |
+| 19  | Dollar Stroll Raffle Contest | No (404)                        | Text preserved; live had interactive entry-purchase widget — not portable to static page                                            | minor (structural)    |
+| 20  | Player Test                  | No (404)                        | 4 Live365 embeds preserved correctly (dev/test page)                                                                                | none                  |
+| 21  | Top222of2022                 | No (404)                        | Countdown table + 5 Mixcloud embeds preserved; original had dynamic countdown UI (not portable)                                     | minor                 |
+| 22  | Yearendpoll2022              | No (404)                        | Text/tables preserved; original had voting UI (not portable)                                                                        | minor                 |
+| 23  | Y-Not Sessions 2022          | No (404)                        | Same fallback bug as 18                                                                                                             | major                 |
+| 24  | Top223of2023                 | No (404)                        | Countdown table + 6 Mixcloud embeds preserved; voting UI not portable                                                               | minor                 |
+| 25  | Yearendpoll2023              | No (404)                        | Text/tables preserved; voting UI not portable                                                                                       | minor                 |
+| 26  | Y-Not Sessions 2023          | No (404)                        | Same fallback bug as 18/23                                                                                                          | major                 |
+| 27  | T-Shirts                     | Yes                             | All 15 shirt-color swatch images stripped; only color names survive as plain list, no table layout                                  | major                 |
+| 28  | Top224of2024                 | Yes                             | Banner image, embeds, song tables all preserved                                                                                     | none (OK)             |
+| 29  | Yearendpoll2024              | Yes                             | Admin editor crash: "Invalid indent value" — numbered list conversion bug makes page unviewable/uneditable                          | major                 |
+| 30  | Y-Not Sessions 2024          | Yes                             | Fallback "(No content available)"; live has download link + banner image + Mixcloud follow-widget                                   | major                 |
+| 31  | Y100: 20 Years Gone          | No — live page itself now 404s  | Migration preserved real content (embeds, interviews) that live site has since lost; no baseline to compare                         | minor (informational) |
+| 32  | Remembering Starla           | Yes                             | Severe content loss: full memorial prose + 3 photos stripped; only 8 bare bolded names survive as isolated lines                    | major                 |
+| 33  | Top225of2025                 | Yes                             | Banner image, embeds, tables all preserved                                                                                          | none (OK)             |
+| 34  | Yearendpoll2025              | Yes                             | Same "Invalid indent value" crash as page 29                                                                                        | major                 |
+| 35  | Ynotsessions2025             | Yes                             | Fallback "(No content available)"; live has download link + banner image                                                            | major                 |
+
+### Priority gaps found
+
+1. **Systemic empty-content bug (≥11 of 35 pages: 3, 5, 6, 7, 8, 9, 15, 18, 23,
+   26, 30, 35).** `bin/migrations/importCustomTexts.ts` strips `upload` nodes
+   _before_ checking whether content is empty (see `importCustomText`), so any
+   body dominated by an image/embed gets nulled and hits the
+   "(No content available)" fallback. Highest-value fix — affects the most
+   pages by far. **Status: fixed** (see below).
+2. **Admin-breaking crash on numbered lists (pages 29, 34).** The HTML→Lexical
+   converter (`bin/migrations/shared/enhancedHtmlToLexical.ts`) emitted
+   `listitem` nodes without an `indent` field for `<ol><li value="N">` markup
+   (used for tied rankings in year-end countdown lists), which crashes
+   Payload's Lexical editor with "Invalid indent value" — these pages were
+   unviewable/uneditable in admin. **Status: fixed** (see below).
+3. **Banner/inline image loss (10, 11, 13, 14, 16, 17, 27, 32).** `<img>`-as-
+   banner graphics are dropped everywhere they occur; inline images mixed with
+   prose (T-Shirts color swatches, Starla memorial photos) are stripped too.
+   Page 32 is the worst case — full memorial tribute reduced to 8 disconnected
+   bolded names. Root cause: images convert to `upload` Lexical nodes with
+   placeholder IDs that fail Payload validation, so the importer strips them
+   rather than fixing the ID. **Status: open** — needs a real asset-import step
+   (upload images to Media/Cloudinary, then reference the real ID) rather than
+   stripping.
+4. **Real informational loss on pages 3 and 10** (Modern Rock Madness pages) —
+   not just images, actual tournament rules/pricing text and a Google Forms
+   voting iframe were dropped. Same root cause as #1.
+5. **Structural/non-portable items (19, 21, 22, 24, 25).** Raffle
+   entry-purchase widgets, poll voting UIs, and countdown widgets are
+   inherently dynamic — the static-page model can't capture them. Not
+   importer bugs; flag as expected limitations to design around (per the
+   archetype plan above — these are graduating out of `Pages` anyway).
+6. **Legacy URL pattern**: live custom pages resolve via
+   `ynotradio.net/pages.php?page=<slug>`, not `ynotradio.net/<slug>` directly.
+7. **Pages 18–26 range (legacy IDs 52–64) have no live counterpart** —
+   production nav no longer links to these; comparison for those relied on
+   code inspection rather than a live baseline.
+8. **Page 31 is the inverse case** — live site 404s, but the imported page
+   retains real content. Worth confirming this is intentional retention.
 
 ---
 

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -21,6 +21,7 @@ import { Concerts } from './payload/src/collections/Concerts';
 import { OnDemand } from './payload/src/collections/OnDemand';
 import { Shows } from './payload/src/collections/Shows';
 import { Posts } from './payload/src/collections/Posts';
+import { Pages } from './payload/src/collections/Pages';
 import { CdOfTheWeek } from './payload/src/collections/CdOfTheWeek';
 import { YearEndPollResults } from './payload/src/collections/YearEndPollResults';
 import { Top11Contests } from './payload/src/collections/Top11Contests';
@@ -193,6 +194,7 @@ export default buildConfig({
     OnDemand,
     Shows,
     Posts,
+    Pages,
     CdOfTheWeek,
     YearEndPollResults,
     Top11Contests,

--- a/payload/migrations/20260703_000000_add_pages_collection.ts
+++ b/payload/migrations/20260703_000000_add_pages_collection.ts
@@ -1,0 +1,139 @@
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
+
+/**
+ * Create the `pages` collection tables.
+ *
+ * `pages` is a dedicated home for the ~35 legacy `custom_texts` records
+ * (donate, contests, rodney, etc.) — separate from `posts` (front-page
+ * stories). See docs/payload-migration/15-custom-text-strategy.md.
+ *
+ * Tables created:
+ *   pages         — published / draft pages
+ *   _pages_v      — version history (drafts support)
+ *
+ * `payload_locked_documents_rels` gains a `pages_id` column so Payload can
+ * track which editor has a page locked for editing.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  // Status enums
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum_pages_status" AS ENUM('draft', 'published');
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
+  await db.execute(sql`
+    DO $$ BEGIN
+      CREATE TYPE "public"."enum__pages_v_version_status" AS ENUM('draft', 'published');
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
+
+  // pages table
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "pages" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "title" varchar,
+      "generate_slug" boolean DEFAULT true,
+      "slug" varchar,
+      "content" jsonb,
+      "legacy_id" numeric,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "_status" "enum_pages_status" DEFAULT 'draft'
+    );
+  `);
+
+  // _pages_v versions table
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "_pages_v" (
+      "id" serial PRIMARY KEY NOT NULL,
+      "parent_id" integer,
+      "version_title" varchar,
+      "version_generate_slug" boolean DEFAULT true,
+      "version_slug" varchar,
+      "version_content" jsonb,
+      "version_legacy_id" numeric,
+      "version_updated_at" timestamp(3) with time zone,
+      "version_created_at" timestamp(3) with time zone,
+      "version__status" "enum__pages_v_version_status" DEFAULT 'draft',
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "latest" boolean
+    );
+  `);
+
+  // FK constraints
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "_pages_v"
+        ADD CONSTRAINT "_pages_v_parent_id_pages_id_fk"
+        FOREIGN KEY ("parent_id") REFERENCES "public"."pages"("id")
+        ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
+
+  // Indexes on pages
+  await db.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "pages_slug_idx"      ON "pages" USING btree ("slug");
+    CREATE UNIQUE INDEX IF NOT EXISTS "pages_legacy_id_idx" ON "pages" USING btree ("legacy_id");
+    CREATE INDEX        IF NOT EXISTS "pages_updated_at_idx" ON "pages" USING btree ("updated_at");
+    CREATE INDEX        IF NOT EXISTS "pages_created_at_idx" ON "pages" USING btree ("created_at");
+    CREATE INDEX        IF NOT EXISTS "pages__status_idx"    ON "pages" USING btree ("_status");
+  `);
+
+  // Indexes on _pages_v
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "_pages_v_parent_idx"
+      ON "_pages_v" USING btree ("parent_id");
+    CREATE INDEX IF NOT EXISTS "_pages_v_version_version_slug_idx"
+      ON "_pages_v" USING btree ("version_slug");
+    CREATE INDEX IF NOT EXISTS "_pages_v_version_version_legacy_id_idx"
+      ON "_pages_v" USING btree ("version_legacy_id");
+    CREATE INDEX IF NOT EXISTS "_pages_v_version_version__status_idx"
+      ON "_pages_v" USING btree ("version__status");
+    CREATE INDEX IF NOT EXISTS "_pages_v_created_at_idx"
+      ON "_pages_v" USING btree ("created_at");
+    CREATE INDEX IF NOT EXISTS "_pages_v_updated_at_idx"
+      ON "_pages_v" USING btree ("updated_at");
+    CREATE INDEX IF NOT EXISTS "_pages_v_latest_idx"
+      ON "_pages_v" USING btree ("latest");
+  `);
+
+  // Document-locking support: add pages_id column to the existing
+  // payload_locked_documents_rels table
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels"
+      ADD COLUMN IF NOT EXISTS "pages_id" integer;
+  `);
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "payload_locked_documents_rels"
+        ADD CONSTRAINT "payload_locked_documents_rels_pages_fk"
+        FOREIGN KEY ("pages_id") REFERENCES "public"."pages"("id")
+        ON DELETE cascade ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_pages_id_idx"
+      ON "payload_locked_documents_rels" USING btree ("pages_id");
+  `);
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "payload_locked_documents_rels"
+      DROP COLUMN IF EXISTS "pages_id";
+  `);
+  await db.execute(sql`
+    DROP TABLE IF EXISTS "_pages_v";
+  `);
+  await db.execute(sql`
+    DROP TABLE IF EXISTS "pages";
+  `);
+  await db.execute(sql`
+    DROP TYPE IF EXISTS "public"."enum__pages_v_version_status";
+  `);
+  await db.execute(sql`
+    DROP TYPE IF EXISTS "public"."enum_pages_status";
+  `);
+}

--- a/payload/migrations/20260705_000000_add_pages_header_image.ts
+++ b/payload/migrations/20260705_000000_add_pages_header_image.ts
@@ -1,0 +1,57 @@
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
+
+/**
+ * Add `headerImage` to the `pages` collection.
+ *
+ * Some legacy custom-text pages used a stylized `<img>` in place of a real
+ * text title (e.g. year-end countdown banners). headerImage preserves that
+ * banner graphic as a Media reference without repurposing the plain-text
+ * `title` field. See docs/payload-migration/15-custom-text-strategy.md.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "pages"
+      ADD COLUMN IF NOT EXISTS "header_image_id" integer;
+  `);
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "pages"
+        ADD CONSTRAINT "pages_header_image_id_media_id_fk"
+        FOREIGN KEY ("header_image_id") REFERENCES "public"."media"("id")
+        ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "pages_header_image_idx"
+      ON "pages" USING btree ("header_image_id");
+  `);
+
+  await db.execute(sql`
+    ALTER TABLE "_pages_v"
+      ADD COLUMN IF NOT EXISTS "version_header_image_id" integer;
+  `);
+  await db.execute(sql`
+    DO $$ BEGIN
+      ALTER TABLE "_pages_v"
+        ADD CONSTRAINT "_pages_v_version_header_image_id_media_id_fk"
+        FOREIGN KEY ("version_header_image_id") REFERENCES "public"."media"("id")
+        ON DELETE set null ON UPDATE no action;
+    EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS "_pages_v_version_version_header_image_idx"
+      ON "_pages_v" USING btree ("version_header_image_id");
+  `);
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TABLE "_pages_v"
+      DROP COLUMN IF EXISTS "version_header_image_id";
+  `);
+  await db.execute(sql`
+    ALTER TABLE "pages"
+      DROP COLUMN IF EXISTS "header_image_id";
+  `);
+}

--- a/payload/migrations/index.ts
+++ b/payload/migrations/index.ts
@@ -13,6 +13,7 @@ import * as migration_20260701_170648_add_top11_vote_dedup_and_lookback from './
 import * as migration_20260701_172922_add_top11_contestant_dedup from './20260701_172922_add_top11_contestant_dedup';
 import * as migration_20260701_203840_add_top11_recording_fields_and_drop_title from './20260701_203840_add_top11_recording_fields_and_drop_title';
 import * as migration_20260701_221242_add_top11_display_title from './20260701_221242_add_top11_display_title';
+import * as migration_20260703_000000_add_pages_collection from './20260703_000000_add_pages_collection';
 import * as migration_20260704_000000_add_top11_votes_voterkey_field from './20260704_000000_add_top11_votes_voterkey_field';
 
 export const migrations = [
@@ -90,6 +91,11 @@ export const migrations = [
     up: migration_20260701_221242_add_top11_display_title.up,
     down: migration_20260701_221242_add_top11_display_title.down,
     name: '20260701_221242_add_top11_display_title',
+  },
+  {
+    up: migration_20260703_000000_add_pages_collection.up,
+    down: migration_20260703_000000_add_pages_collection.down,
+    name: '20260703_000000_add_pages_collection',
   },
   {
     up: migration_20260704_000000_add_top11_votes_voterkey_field.up,

--- a/payload/migrations/index.ts
+++ b/payload/migrations/index.ts
@@ -15,6 +15,7 @@ import * as migration_20260701_203840_add_top11_recording_fields_and_drop_title 
 import * as migration_20260701_221242_add_top11_display_title from './20260701_221242_add_top11_display_title';
 import * as migration_20260703_000000_add_pages_collection from './20260703_000000_add_pages_collection';
 import * as migration_20260704_000000_add_top11_votes_voterkey_field from './20260704_000000_add_top11_votes_voterkey_field';
+import * as migration_20260705_000000_add_pages_header_image from './20260705_000000_add_pages_header_image';
 
 export const migrations = [
   {
@@ -101,5 +102,10 @@ export const migrations = [
     up: migration_20260704_000000_add_top11_votes_voterkey_field.up,
     down: migration_20260704_000000_add_top11_votes_voterkey_field.down,
     name: '20260704_000000_add_top11_votes_voterkey_field',
+  },
+  {
+    up: migration_20260705_000000_add_pages_header_image.up,
+    down: migration_20260705_000000_add_pages_header_image.down,
+    name: '20260705_000000_add_pages_header_image',
   },
 ];

--- a/payload/src/collections/Pages.test.ts
+++ b/payload/src/collections/Pages.test.ts
@@ -91,6 +91,18 @@ describe('Pages', () => {
     expect(checkbox?.type).toBe('checkbox');
   });
 
+  it('has headerImage as an optional upload field relating to media', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const headerImageField = fields.find((f) => f.name === 'headerImage') as {
+      type?: string;
+      relationTo?: string;
+      required?: boolean;
+    };
+    expect(headerImageField?.type).toBe('upload');
+    expect(headerImageField?.relationTo).toBe('media');
+    expect(headerImageField?.required).toBeFalsy();
+  });
+
   it('has content as a richText field', () => {
     const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
     const contentField = fields.find((f) => f.name === 'content');

--- a/payload/src/collections/Pages.test.ts
+++ b/payload/src/collections/Pages.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Pages } from './Pages';
+import { flattenRowFields } from './testUtils';
+
+vi.mock('@payloadcms/richtext-lexical', () => ({
+  lexicalEditor: vi.fn((config) => ({ _type: 'lexical', _config: config })),
+  BlocksFeature: vi.fn((config) => ({ _type: 'blocks', ...config })),
+}));
+
+describe('Pages', () => {
+  it('has the correct slug', () => {
+    expect(Pages.slug).toBe('pages');
+  });
+
+  it('has correct labels', () => {
+    expect(Pages.labels?.singular).toBe('Page');
+    expect(Pages.labels?.plural).toBe('Pages');
+  });
+
+  it('uses title as admin title', () => {
+    expect(Pages.admin?.useAsTitle).toBe('title');
+  });
+
+  it('is grouped under Content', () => {
+    expect(Pages.admin?.group).toBe('Content');
+  });
+
+  it('has drafts enabled', () => {
+    expect((Pages.versions as { drafts?: boolean })?.drafts).toBe(true);
+  });
+
+  it('has timestamps enabled', () => {
+    expect(Pages.timestamps).toBe(true);
+  });
+
+  it('has public read access', () => {
+    const readFn = Pages.access?.read as () => boolean;
+    expect(readFn()).toBe(true);
+  });
+
+  it('requires authentication to create', () => {
+    const createFn = Pages.access?.create as (args: { req: { user: unknown } }) => boolean;
+    expect(createFn({ req: { user: null } })).toBe(false);
+    expect(createFn({ req: { user: { id: '1' } } })).toBe(true);
+  });
+
+  it('allows admin and editor to update', () => {
+    const updateFn = Pages.access?.update as (args: { req: { user: unknown } }) => boolean;
+    expect(updateFn({ req: { user: { role: 'admin' } } })).toBe(true);
+    expect(updateFn({ req: { user: { role: 'editor' } } })).toBe(true);
+    expect(updateFn({ req: { user: { role: 'dj' } } })).toBe(false);
+    expect(updateFn({ req: { user: null } })).toBe(false);
+  });
+
+  it('allows admin and editor to delete', () => {
+    const deleteFn = Pages.access?.delete as (args: { req: { user: unknown } }) => boolean;
+    expect(deleteFn({ req: { user: { role: 'admin' } } })).toBe(true);
+    expect(deleteFn({ req: { user: { role: 'editor' } } })).toBe(true);
+  });
+
+  it('has title as a required text field', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const titleField = fields.find((f) => f.name === 'title') as {
+      type?: string;
+      required?: boolean;
+    };
+    expect(titleField?.type).toBe('text');
+    expect(titleField?.required).toBe(true);
+  });
+
+  it('has slug as a required unique text field', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const slugFieldEntry = fields.find((f) => f.name === 'slug');
+    expect(slugFieldEntry?.type).toBe('text');
+    expect(slugFieldEntry?.required).toBe(true);
+    expect(slugFieldEntry?.unique).toBe(true);
+    expect(slugFieldEntry?.index).toBe(true);
+  });
+
+  it('uses pageSlugify for slug generation', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const slugFieldEntry = fields.find((f) => f.name === 'slug') as {
+      custom?: { slugify?: unknown };
+    };
+    expect(typeof slugFieldEntry?.custom?.slugify).toBe('function');
+  });
+
+  it('exposes generateSlug checkbox companion to the slug field', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const checkbox = fields.find((f) => f.name === 'generateSlug') as { type?: string };
+    expect(checkbox?.type).toBe('checkbox');
+  });
+
+  it('has content as a richText field', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const contentField = fields.find((f) => f.name === 'content');
+    expect(contentField?.type).toBe('richText');
+  });
+
+  it('configures content field editor with EmbedFeature appended to default features', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const contentField = fields.find((f) => f.name === 'content') as {
+      editor?: { _config?: { features?: (args: { defaultFeatures: unknown[] }) => unknown[] } };
+    };
+
+    // eslint-disable-next-line no-underscore-dangle -- Payload uses `_config` internally
+    const featuresCallback = contentField?.editor?._config?.features;
+    expect(typeof featuresCallback).toBe('function');
+
+    const mockDefaultFeatures = [{ id: 'paragraph' }, { id: 'text' }];
+    const result = featuresCallback!({ defaultFeatures: mockDefaultFeatures });
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ id: 'paragraph' });
+    expect(result[1]).toEqual({ id: 'text' });
+    // EmbedFeature() is the third entry (BlocksFeature mock returns { _type: 'blocks', ... })
+    expect((result[2] as any)._type).toBe('blocks');
+  });
+
+  it('does not include date-window or front-page fields (unlike Posts)', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const fieldNames = fields.map((f) => f.name);
+    expect(fieldNames).not.toContain('startDate');
+    expect(fieldNames).not.toContain('endDate');
+    expect(fieldNames).not.toContain('showOnFrontPage');
+    expect(fieldNames).not.toContain('priority');
+  });
+
+  it('has legacyId as a unique number field', () => {
+    const fields = flattenRowFields(Pages.fields as Record<string, unknown>[]);
+    const legacyField = fields.find((f) => f.name === 'legacyId');
+    expect(legacyField?.type).toBe('number');
+    expect(legacyField?.unique).toBe(true);
+  });
+
+  it('has expected default columns', () => {
+    expect(Pages.admin?.defaultColumns).toContain('title');
+    expect(Pages.admin?.defaultColumns).toContain('slug');
+    expect(Pages.admin?.defaultColumns).toContain('_status');
+  });
+
+  it('includes title and slug in listSearchableFields', () => {
+    expect(Pages.admin?.listSearchableFields).toContain('title');
+    expect(Pages.admin?.listSearchableFields).toContain('slug');
+  });
+});

--- a/payload/src/collections/Pages.ts
+++ b/payload/src/collections/Pages.ts
@@ -53,6 +53,17 @@ export const Pages: CollectionConfig = {
     },
     slugField({ useAsSlug: 'title', slugify: pageSlugify }),
     {
+      name: 'headerImage',
+      type: 'upload',
+      relationTo: 'media',
+      admin: {
+        description:
+          'Optional banner graphic shown above the title. Some legacy pages used a '
+          + 'stylized image in place of a real text title — this preserves that banner '
+          + 'without losing a plain-text `title` for admin lists, search, and SEO.',
+      },
+    },
+    {
       name: 'content',
       type: 'richText',
       editor: lexicalEditor({

--- a/payload/src/collections/Pages.ts
+++ b/payload/src/collections/Pages.ts
@@ -1,0 +1,69 @@
+import type { CollectionConfig } from 'payload';
+import { slugField } from 'payload';
+import { lexicalEditor } from '@payloadcms/richtext-lexical';
+import { hasRole } from '../utils/auth';
+import { EmbedFeature } from '../features/embed';
+import { pageSlugify } from './hooks/slugUtils';
+import { legacyIdField } from './shared/legacyIdField';
+
+/**
+ * Evergreen custom-text pages addressed by a stable permalink (slug).
+ *
+ * Distinct from `Posts` (front-page stories with date windows): Pages are
+ * long-lived reference / marketing pages. Minimum fields per Chapter 15:
+ * title, slug (unique, matching legacy `custom_texts.permalink` values),
+ * content (richText + embed blocks), status, legacyId.
+ *
+ * PostgresCustomText reads from this table once content is migrated;
+ * `use_postgres_customtext` is the feature-flag safety net while migration
+ * happens per archetype.
+ */
+export const Pages: CollectionConfig = {
+  slug: 'pages',
+  labels: {
+    singular: 'Page',
+    plural: 'Pages',
+  },
+  versions: {
+    drafts: true,
+  },
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'slug', '_status', 'updatedAt'],
+    group: 'Content',
+    listSearchableFields: ['title', 'slug'],
+    description:
+      'Evergreen custom-text pages (donate, contests, rodney, etc.) addressed by a stable permalink.',
+  },
+  defaultSort: ['title'],
+  access: {
+    read: () => true,
+    create: ({ req }) => Boolean(req.user),
+    update: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+    delete: ({ req }) => hasRole(req.user, ['admin', 'editor']),
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+      admin: {
+        description: 'Page title displayed in the <h1>',
+      },
+    },
+    slugField({ useAsSlug: 'title', slugify: pageSlugify }),
+    {
+      name: 'content',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => [...defaultFeatures, EmbedFeature()],
+      }),
+      admin: {
+        description:
+          'Page body — use the rich text editor for formatted text, images, and embedded media',
+      },
+    },
+    legacyIdField,
+  ],
+  timestamps: true,
+};

--- a/payload/src/collections/collectionSchema.test.ts
+++ b/payload/src/collections/collectionSchema.test.ts
@@ -12,6 +12,7 @@ import { MadnessTournaments } from './MadnessTournaments';
 import { MadnessVotes } from './MadnessVotes';
 import { Media } from './Media';
 import { OnDemand } from './OnDemand';
+import { Pages } from './Pages';
 import { People } from './People';
 import { Posts } from './Posts';
 import { Records } from './Records';
@@ -83,6 +84,7 @@ const allCollections: Array<{ name: string; config: CollectionConfig }> = [
   { name: 'MadnessVotes', config: MadnessVotes },
   { name: 'Media', config: Media },
   { name: 'OnDemand', config: OnDemand },
+  { name: 'Pages', config: Pages },
   { name: 'People', config: People },
   { name: 'Posts', config: Posts },
   { name: 'Records', config: Records },

--- a/payload/src/collections/hooks/slugUtils.ts
+++ b/payload/src/collections/hooks/slugUtils.ts
@@ -232,12 +232,12 @@ export const postSlugify: Slugify = ({ data, valueToSlugify }) => {
 export const pageSlugify: Slugify = ({ data, valueToSlugify }) => {
   const title = data?.title;
   if (!title) {
-    return valueToSlugify ? slugifyText(String(valueToSlugify)) : undefined;
+    return valueToSlugify ? slugifyHeadline(String(valueToSlugify)) : undefined;
   }
   if (valueToSlugify && String(valueToSlugify) !== String(title)) {
-    return slugifyText(String(valueToSlugify));
+    return slugifyHeadline(String(valueToSlugify));
   }
-  return slugifyText(String(title)) || undefined;
+  return slugifyHeadline(String(title)) || undefined;
 };
 
 /**

--- a/payload/src/collections/hooks/slugUtils.ts
+++ b/payload/src/collections/hooks/slugUtils.ts
@@ -226,6 +226,21 @@ export const postSlugify: Slugify = ({ data, valueToSlugify }) => {
 };
 
 /**
+ * Custom slugify function for Pages (custom-text pages).
+ * Generates a simple, stable permalink slug from the page title — no date prefix.
+ */
+export const pageSlugify: Slugify = ({ data, valueToSlugify }) => {
+  const title = data?.title;
+  if (!title) {
+    return valueToSlugify ? slugifyText(String(valueToSlugify)) : undefined;
+  }
+  if (valueToSlugify && String(valueToSlugify) !== String(title)) {
+    return slugifyText(String(valueToSlugify));
+  }
+  return slugifyText(String(title)) || undefined;
+};
+
+/**
  * Custom slugify function for CdOfTheWeek.
  * Returns the slug pre-computed by setCdOfTheWeekSlugFromRecord (collection beforeChange hook
  * runs before field hooks). Falls back to valueToSlugify if no precomputed slug exists.

--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -29,12 +29,12 @@ class PostgresCustomText implements CustomText {
             SELECT 
                 id,
                 slug as permalink,
-                headline as title,
+                title,
                 content as html,
                 legacy_id
-            FROM posts
+            FROM pages
             WHERE _status = 'published'
-            ORDER BY headline ASC
+            ORDER BY title ASC
         ");
         
         $stmt->execute();
@@ -48,10 +48,10 @@ class PostgresCustomText implements CustomText {
             SELECT 
                 id,
                 slug as permalink,
-                headline as title,
+                title,
                 content as html,
                 legacy_id
-            FROM posts
+            FROM pages
             WHERE id = :id 
                 AND _status = 'published'
         ");
@@ -71,10 +71,10 @@ class PostgresCustomText implements CustomText {
             SELECT 
                 id,
                 slug as permalink,
-                headline as title,
+                title,
                 content as html,
                 legacy_id
-            FROM posts
+            FROM pages
             WHERE slug = :permalink 
                 AND _status = 'published'
         ");
@@ -113,9 +113,8 @@ class PostgresCustomText implements CustomText {
     public function isValidPermalink(string $permalink): bool {
         $stmt = $this->db->prepare("
             SELECT COUNT(*) as count
-            FROM posts
+            FROM pages
             WHERE slug = :permalink 
-                AND type = 'custom_text'
                 AND _status = 'published'
         ");
         

--- a/src/models/implementations/PostgresCustomText.php
+++ b/src/models/implementations/PostgresCustomText.php
@@ -111,6 +111,9 @@ class PostgresCustomText implements CustomText {
     }
 
     public function isValidPermalink(string $permalink): bool {
+        // This implementation checks the pages table only. The method is
+        // defined on the CustomText interface (which predates the pages/posts
+        // split); here it answers "is this permalink already taken in pages?".
         $stmt = $this->db->prepare("
             SELECT COUNT(*) as count
             FROM pages

--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -1111,6 +1111,52 @@ footer a:hover {
   }
 }
 
+/* Embed blocks (EmbedFeature from Payload / RendersLexicalEmbeds.php)
+ *
+ * The PHP helper emits .embed wrapper divs/iframes for Lexical embed blocks.
+ * Video embeds use a 16:9 aspect-ratio wrapper (.embed--video); audio embeds
+ * (Mixcloud, OpenDrive, Spotify, SoundCloud, generic) use a fixed-height iframe
+ * with class .embed--<provider>. The caption sits below in .embed-caption.
+ */
+.embed {
+  margin: 1em 0;
+}
+
+/* Responsive 16:9 wrapper emitted for video providers (YouTube, Vimeo) */
+.embed--video {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.embed--video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* Audio player iframes: full-width, fixed height per provider */
+.embed--mixcloud,
+.embed--opendrive,
+.embed--spotify,
+.embed--soundcloud,
+.embed--generic {
+  display: block;
+  width: 100%;
+  border: 0;
+}
+
+.embed-caption {
+  font-size: 0.875em;
+  color: #555;
+  margin-top: 0.25em;
+  text-align: center;
+}
+
 /* Respect reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
   * {


### PR DESCRIPTION
## Summary
- Several legacy custom_texts (year-end countdown pages, Modern Rock Madness, Top1000, Future Friday) use a stylized `<img>` banner in place of a real text title. The importer previously discarded that image entirely and fell back to a plain auto-cased title derived from the permalink — found during the 35-page migration audit (docs/payload-migration/15-custom-text-strategy.md).
- Adds a `headerImage` upload field to `Pages` (`relationTo: media`).
- The importer now detects an `<img>`-only title, extracts the `src` URL, imports it into Media/Cloudinary via the existing `importImageFromUrl` helper (`bin/migrations/shared/mediaImporter.ts` — already built for this, just never wired up), and links the result as `headerImage`. Falls back to the existing text-title behavior if the image import fails.
- Includes the DB migration for the new `header_image_id` column (on both `pages` and `_pages_v`).

## Test plan
- [x] `yarn vitest run bin/migrations/importCustomTexts.test.ts payload/src/collections/Pages.test.ts` — 32/32 passing, new coverage for image-title extraction, import-failure fallback, and no-image-in-title cases
- [x] `yarn lint` — clean
- [x] Manual, end-to-end against Neon dev with real Cloudinary credentials: re-ran the full 35-page import — 16 pages now have a real Cloudinary-hosted `headerImage`, correctly deduplicated where multiple pages shared the same legacy banner (e.g. `Top220of2020` / `Yearendpoll2020` both point at the same uploaded image)

Base branch is `copilot/continue-pages-collection-plan` (PR #804) since this depends on the `Pages` collection landing there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rMyo1v4dsZJoWZQFUj5Vk