### PR TITLE
Add option to hide Mixcloud cover image on embeds

### DIFF
--- a/docs/payload-migration/16-rich-text-embeds.md
+++ b/docs/payload-migration/16-rich-text-embeds.md
@@ -60,6 +60,9 @@ stacks.**
   show URL → `player-widget…?feed=<encoded path>` (widget URLs pass through);
   OpenDrive `/player/<id>` as-is; Vimeo/Spotify/SoundCloud → their embed URLs;
   everything else → generic iframe.
+- The `embed` block has a `hideCoverImage` checkbox (default on, only shown in
+  the admin UI for Mixcloud URLs) controlling the widget's `hide_cover` param —
+  editors can opt back into showing the cover art per embed.
 
 **Trade-off:** the provider logic is duplicated across TypeScript and PHP. Kept
 honest by mirrored unit tests and "keep in sync" comments, but it is genuine
@@ -94,7 +97,7 @@ drift risk (see Option C).
 
 ## Alternatives considered
 
-### Option A — Generic embed block + runtime detection *(chosen, shipped)*
+### Option A — Generic embed block + runtime detection _(chosen, shipped)_
 
 One block, paste any URL, detect provider at render time.
 

--- a/payload/src/features/embed/client.stories.tsx
+++ b/payload/src/features/embed/client.stories.tsx
@@ -69,6 +69,14 @@ export const MixcloudShow: Story = {
   },
 };
 
+export const MixcloudShowWithCoverImage: Story = {
+  args: {
+    url: 'https://www.mixcloud.com/ynotradio/rodney-anonymous-tells-you-how-to-live-6526/',
+    caption: 'Rodney Anonymous Tells You How To Live (cover image shown)',
+    hideCoverImage: false,
+  },
+};
+
 export const MixcloudMiniPlayer: Story = {
   args: {
     url: 'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&mini=1&feed=%2Fynotradio%2Frodney-anonymous-6526%2F',

--- a/payload/src/features/embed/client.test.tsx
+++ b/payload/src/features/embed/client.test.tsx
@@ -169,8 +169,26 @@ describe('EmbedComponent', () => {
 
       render(<EmbedComponent url={testUrl} />);
 
-      expect(spy).toHaveBeenCalledWith(testUrl);
+      expect(spy).toHaveBeenCalledWith(testUrl, { hideCoverImage: undefined });
       spy.mockRestore();
+    });
+  });
+
+  describe('Mixcloud cover image', () => {
+    const mixcloudUrl = 'https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/';
+
+    it('should hide the cover image by default', () => {
+      const { container } = render(<EmbedComponent url={mixcloudUrl} />);
+
+      const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframe.src).toContain('hide_cover=1');
+    });
+
+    it('should show the cover image when hideCoverImage is false', () => {
+      const { container } = render(<EmbedComponent url={mixcloudUrl} hideCoverImage={false} />);
+
+      const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+      expect(iframe.src).toContain('hide_cover=0');
     });
   });
 });

--- a/payload/src/features/embed/client.tsx
+++ b/payload/src/features/embed/client.tsx
@@ -6,11 +6,12 @@ import { detectEmbedType } from './utils';
 export interface EmbedComponentProps {
   url: string;
   caption?: string;
+  hideCoverImage?: boolean;
 }
 
-export const EmbedComponent: React.FC<EmbedComponentProps> = ({ url, caption }) => {
+export const EmbedComponent: React.FC<EmbedComponentProps> = ({ url, caption, hideCoverImage }) => {
   // Convert to proper embed URL if needed
-  const { embedUrl, type } = detectEmbedType(url);
+  const { embedUrl, type } = detectEmbedType(url, { hideCoverImage });
 
   return (
     <div className={`embed-container embed-container--${type}`}>

--- a/payload/src/features/embed/server.ts
+++ b/payload/src/features/embed/server.ts
@@ -35,6 +35,16 @@ export const EmbedBlock: Block = {
         description: 'Optional caption displayed below the embed',
       },
     },
+    {
+      name: 'hideCoverImage',
+      type: 'checkbox',
+      label: 'Hide cover image',
+      defaultValue: true,
+      admin: {
+        description: 'Mixcloud only: hides the show cover art in the player. Uncheck to show it.',
+        condition: (_data, siblingData) => typeof siblingData?.url === 'string' && siblingData.url.includes('mixcloud.com'),
+      },
+    },
   ],
 };
 

--- a/payload/src/features/embed/utils.test.ts
+++ b/payload/src/features/embed/utils.test.ts
@@ -252,6 +252,20 @@ describe('detectEmbedType', () => {
       const result = detectEmbedType(url);
       expect(result.type).toBe('generic');
     });
+
+    it('should hide the cover image by default', () => {
+      const url = 'https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/';
+      const result = detectEmbedType(url);
+      expect(result.embedUrl).toContain('hide_cover=1');
+    });
+
+    it('should show the cover image when hideCoverImage is false', () => {
+      const url = 'https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/';
+      const result = detectEmbedType(url, { hideCoverImage: false });
+      expect(result.embedUrl).toBe(
+        'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=0&feed=%2Fynotradio%2Frodney-anonymous-6526%2F',
+      );
+    });
   });
 
   describe('OpenDrive detection', () => {

--- a/payload/src/features/embed/utils.ts
+++ b/payload/src/features/embed/utils.ts
@@ -1,11 +1,5 @@
 export type EmbedType =
-  | 'youtube'
-  | 'vimeo'
-  | 'spotify'
-  | 'soundcloud'
-  | 'mixcloud'
-  | 'opendrive'
-  | 'generic';
+  'youtube' | 'vimeo' | 'spotify' | 'soundcloud' | 'mixcloud' | 'opendrive' | 'generic';
 
 export interface EmbedInfo {
   type: EmbedType;
@@ -61,32 +55,57 @@ export function extractMixcloudFeed(url: string): string | null {
   return `/${segments.join('/')}/`;
 }
 
-export function detectEmbedType(url: string): EmbedInfo {
+export interface DetectEmbedTypeOptions {
+  /**
+   * Mixcloud only: hide the show's cover art in the player widget.
+   * Defaults to true — most Mixcloud embeds on this site hide the cover.
+   */
+  hideCoverImage?: boolean;
+}
+
+export function detectEmbedType(url: string, options: DetectEmbedTypeOptions = {}): EmbedInfo {
+  const { hideCoverImage = true } = options;
   if (url.includes('youtube.com') || url.includes('youtu.be')) {
     const videoId = extractYouTubeId(url);
     if (videoId) {
-      return { type: 'youtube', embedUrl: `https://www.youtube.com/embed/${videoId}`, originalUrl: url };
+      return {
+        type: 'youtube',
+        embedUrl: `https://www.youtube.com/embed/${videoId}`,
+        originalUrl: url,
+      };
     }
   }
 
   if (url.includes('vimeo.com')) {
     const videoId = extractVimeoId(url);
     if (videoId) {
-      return { type: 'vimeo', embedUrl: `https://player.vimeo.com/video/${videoId}`, originalUrl: url };
+      return {
+        type: 'vimeo',
+        embedUrl: `https://player.vimeo.com/video/${videoId}`,
+        originalUrl: url,
+      };
     }
   }
 
   if (url.includes('spotify.com')) {
     const info = extractSpotifyInfo(url);
     if (info) {
-      return { type: 'spotify', embedUrl: `https://open.spotify.com/embed/${info.type}/${info.id}`, originalUrl: url };
+      return {
+        type: 'spotify',
+        embedUrl: `https://open.spotify.com/embed/${info.type}/${info.id}`,
+        originalUrl: url,
+      };
     }
   }
 
   if (url.includes('soundcloud.com')) {
     const trackInfo = extractSoundCloudInfo(url);
     if (trackInfo) {
-      return { type: 'soundcloud', embedUrl: `https://w.soundcloud.com/player/?url=https://soundcloud.com/${trackInfo}`, originalUrl: url };
+      return {
+        type: 'soundcloud',
+        embedUrl: `https://w.soundcloud.com/player/?url=https://soundcloud.com/${trackInfo}`,
+        originalUrl: url,
+      };
     }
   }
 
@@ -100,7 +119,7 @@ export function detectEmbedType(url: string): EmbedInfo {
     if (feed) {
       return {
         type: 'mixcloud',
-        embedUrl: `https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed=${encodeURIComponent(feed)}`,
+        embedUrl: `https://player-widget.mixcloud.com/widget/iframe/?hide_cover=${hideCoverImage ? 1 : 0}&feed=${encodeURIComponent(feed)}`,
         originalUrl: url,
       };
     }

--- a/src/models/Concerns/RendersLexicalEmbeds.php
+++ b/src/models/Concerns/RendersLexicalEmbeds.php
@@ -26,7 +26,8 @@ trait RendersLexicalEmbeds
             return '';
         }
 
-        $embed = $this->normalizeEmbedUrl($url);
+        $hideCoverImage = !array_key_exists('hideCoverImage', $fields) || $fields['hideCoverImage'] !== false;
+        $embed = $this->normalizeEmbedUrl($url, $hideCoverImage);
         $src = htmlspecialchars($embed['src'], ENT_QUOTES, 'UTF-8');
 
         if ($embed['layout'] === 'video') {
@@ -61,7 +62,7 @@ trait RendersLexicalEmbeds
      *
      * @return array{provider:string, src:string, layout:string, height:int}
      */
-    protected function normalizeEmbedUrl(string $url): array
+    protected function normalizeEmbedUrl(string $url, bool $hideCoverImage = true): array
     {
         // YouTube -> /embed/<id>
         if (str_contains($url, 'youtube.com') || str_contains($url, 'youtu.be')) {
@@ -96,7 +97,8 @@ trait RendersLexicalEmbeds
             }
             $feed = $this->extractMixcloudFeed($url);
             if ($feed !== null) {
-                $src = 'https://player-widget.mixcloud.com/widget/iframe/?hide_cover=1&feed='
+                $hideCover = $hideCoverImage ? '1' : '0';
+                $src = "https://player-widget.mixcloud.com/widget/iframe/?hide_cover={$hideCover}&feed="
                     . rawurlencode($feed);
                 return ['provider' => 'mixcloud', 'src' => $src, 'layout' => 'audio', 'height' => 120];
             }

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -121,11 +121,14 @@ class ConvertsLexicalToHtmlTest extends TestCase
     /**
      * Build a Lexical document containing a single embed block.
      */
-    private function embedBlockJson(string $url, ?string $caption = null): string
+    private function embedBlockJson(string $url, ?string $caption = null, ?bool $hideCoverImage = null): string
     {
         $fields = ['blockType' => 'embed', 'url' => $url];
         if ($caption !== null) {
             $fields['caption'] = $caption;
+        }
+        if ($hideCoverImage !== null) {
+            $fields['hideCoverImage'] = $hideCoverImage;
         }
 
         return json_encode([
@@ -160,6 +163,28 @@ class ConvertsLexicalToHtmlTest extends TestCase
             'feed=%2Fynotradio%2Frodney-anonymous-6526%2F',
             $html
         );
+    }
+
+    public function testEmbedBlockConvertsMixcloudUrlHidingCoverByDefault(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson('https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/')
+        );
+
+        $this->assertStringContainsString('hide_cover=1', $html);
+    }
+
+    public function testEmbedBlockShowsCoverImageWhenHideCoverImageIsFalse(): void
+    {
+        $html = $this->converter->convert(
+            $this->embedBlockJson(
+                'https://www.mixcloud.com/ynotradio/rodney-anonymous-6526/',
+                null,
+                false
+            )
+        );
+
+        $this->assertStringContainsString('hide_cover=0', $html);
     }
 
     public function testEmbedBlockPassesThroughMixcloudWidgetUrl(): void


### PR DESCRIPTION
Adds a "Hide cover image" checkbox to the embed block (default on, shown
only for Mixcloud URLs) so editors can opt back into showing the cover
art per embed instead of it always being hidden. Wired through both
render paths: the TS admin/editor side (detectEmbedType, EmbedBlock,
EmbedComponent) and the legacy PHP renderer (RendersLexicalEmbeds).