### PR TITLE
fix: strip legacy <!-- --> comments from Lexical story text

### DIFF
--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -49,7 +49,7 @@ trait ConvertsLexicalToHtml
             foreach ($lexical['root']['children'] as $node) {
                 $html .= $this->convertLexicalNodeToHtml($node, $forceNewTabLinks, $mediaMap);
             }
-            return $html;
+            return $this->stripLegacyHtmlComments($html);
         } catch (\Throwable $e) {
             error_log(static::class . ': Failed to convert Lexical to HTML: ' . $e->getMessage());
             return $lexicalJson;
@@ -342,6 +342,20 @@ trait ConvertsLexicalToHtml
         }
 
         return "<{$tag}{$style}>{$content}</{$tag}>\n";
+    }
+
+    /**
+     * DJs carried the habit of hiding stale copy inside `<!-- -->` from the
+     * old raw-HTML story editor, where the browser rendered actual HTML
+     * comments as invisible. Lexical has no comment node, so that markup is
+     * now typed as literal text and escaped to `&lt;!--...--&gt;`, showing up
+     * as visible garbage on the front end. Strip escaped comment spans from
+     * the assembled HTML so this old habit still hides content as authors
+     * expect.
+     */
+    private function stripLegacyHtmlComments(string $html): string
+    {
+        return preg_replace('/&lt;!--.*?--&gt;/s', '', $html) ?? $html;
     }
 
     /**

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -705,4 +705,55 @@ class ConvertsLexicalToHtmlTest extends TestCase
         $this->assertStringContainsString('client-id=test-client-id-123', $html);
         $this->assertStringNotContainsString('attacker-controlled-client-id', $html);
     }
+
+    public function testLegacyHtmlCommentTypedAsTextIsHidden(): void
+    {
+        $lexicalJson = json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            ['type' => 'text', 'text' => 'Keep this. '],
+                            ['type' => 'text', 'text' => '<!--Stale copy from last month.-->'],
+                            ['type' => 'text', 'text' => ' Keep this too.'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = $this->converter->convert($lexicalJson);
+
+        $this->assertStringContainsString('Keep this.', $html);
+        $this->assertStringContainsString('Keep this too.', $html);
+        $this->assertStringNotContainsString('Stale copy from last month.', $html);
+        $this->assertStringNotContainsString('&lt;!--', $html);
+    }
+
+    public function testUnterminatedLegacyHtmlCommentDoesNotSwallowFollowingContent(): void
+    {
+        $lexicalJson = json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            ['type' => 'text', 'text' => '<!--No closing marker here.'],
+                        ],
+                    ],
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            ['type' => 'text', 'text' => 'Next paragraph still renders.'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = $this->converter->convert($lexicalJson);
+
+        $this->assertStringContainsString('Next paragraph still renders.', $html);
+    }
 }


### PR DESCRIPTION
## Summary
- DJs hide stale promo copy inside `<!-- -->` comments — a habit from the old raw-HTML story editor where browsers rendered them invisibly.
- The Lexical-based Postgres pipeline has no comment node, so that literal text now gets `htmlspecialchars`-escaped and rendered as visible `&lt;!--...--&gt;` garbage on the front page (confirmed live on 6 stories, e.g. "Support Y-Not Radio", "Words With Nerds").
- Strip escaped comment spans from the assembled HTML in `ConvertsLexicalToHtml::convertLexicalToHtml()` so old authoring habits keep working as DJs expect.

## Test plan
- [x] Added regression tests: comment hidden across sibling text nodes, unterminated comment doesn't swallow following content
- [x] Full PHP suite passes (256 tests)
- [x] phpcs clean
- [x] Verified locally against real Neon dev data (PHP built-in server + Playwright screenshot) — previously-broken stories render clean with no visible comment garbage or layout gaps

https://claude.ai/code/session_01SeqX4Gwos7x8vaoLBuxPRC