### PR TITLE
fix: normalize legacy HTML artifacts in Lexical story text at render time

### DIFF
--- a/bin/seed-kitchen-sink-page.ts
+++ b/bin/seed-kitchen-sink-page.ts
@@ -1,0 +1,198 @@
+/* eslint-disable no-console */
+import { getPayloadHMR } from '@payloadcms/next/utilities';
+import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
+
+/**
+ * Seeds (or updates in place) a single "Kitchen Sink QA" Page covering every
+ * Lexical node type Pages.ts's editor config registers — the same set as
+ * bin/seed-kitchen-sink-post.ts plus paypalButton/paypalSmartButtons, which
+ * are only registered on Pages, not Posts. Also covers every legacy HTML
+ * artifact ConvertsLexicalToHtml.php recovers (nbsp, <font size 1-5>, <hr>,
+ * malformed b/i/em/u, hidden comments). Mirrors the fixture in
+ * src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php's
+ * testKitchenSinkDocumentConvertsEveryNodeTypeAndLegacyArtifact — keep the
+ * two in sync when either changes.
+ *
+ * Purpose: visual QA. After changing the Lexical editor config or the PHP
+ * renderer, run this and eyeball the rendered page (via PostgresCustomText)
+ * or the admin editor, rather than authoring test content by hand each time.
+ *
+ * Usage: yarn tsx bin/seed-kitchen-sink-page.ts
+ */
+
+const TITLE = 'Kitchen Sink QA — Pages Lexical Nodes + Legacy Artifacts';
+const SLUG = 'kitchen-sink-qa';
+
+async function seed() {
+  assertNotConnectedToProd();
+
+  const payload = await getPayloadHMR({ config });
+
+  const content = {
+    root: {
+      type: 'root',
+      children: [
+        { type: 'heading', tag: 'h1', children: [{ type: 'text', text: 'Heading One' }] },
+        { type: 'heading', tag: 'h2', children: [{ type: 'text', text: 'Heading Two' }] },
+        { type: 'heading', tag: 'h3', children: [{ type: 'text', text: 'Heading Three' }] },
+        { type: 'heading', tag: 'h4', children: [{ type: 'text', text: 'Heading Four' }] },
+        { type: 'heading', tag: 'h5', children: [{ type: 'text', text: 'Heading Five' }] },
+        { type: 'heading', tag: 'h6', children: [{ type: 'text', text: 'Heading Six' }] },
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', text: 'Bold', format: 1 },
+            { type: 'text', text: ' Italic', format: 2 },
+            { type: 'text', text: ' Underline', format: 8 },
+            { type: 'text', text: ' BoldItalic', format: 3 },
+            { type: 'linebreak' },
+            { type: 'text', text: 'Small state', $: { fontSize: 'small' } },
+          ],
+        },
+        {
+          type: 'paragraph',
+          format: 'center',
+          children: [{ type: 'text', text: 'Centered paragraph' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'link',
+              fields: { url: 'https://example.com', linkType: 'custom' },
+              children: [{ type: 'text', text: 'A link' }],
+            },
+            { type: 'text', text: ' and ' },
+            {
+              type: 'link',
+              fields: { url: 'https://example.com/new-tab', newTab: true, linkType: 'custom' },
+              children: [{ type: 'text', text: 'a new-tab link' }],
+            },
+          ],
+        },
+        {
+          type: 'list',
+          listType: 'bullet',
+          children: [
+            { type: 'listitem', children: [{ type: 'text', text: 'Bullet one' }] },
+            { type: 'listitem', children: [{ type: 'text', text: 'Bullet two' }] },
+          ],
+        },
+        {
+          type: 'list',
+          listType: 'number',
+          children: [{ type: 'listitem', children: [{ type: 'text', text: 'Numbered one' }] }],
+        },
+        { type: 'quote', children: [{ type: 'text', text: 'A quotation' }] },
+        { type: 'horizontalrule' },
+        {
+          type: 'table',
+          children: [
+            {
+              type: 'tablerow',
+              children: [
+                {
+                  type: 'tablecell',
+                  headerState: 1,
+                  children: [{ type: 'text', text: 'Header Cell' }],
+                },
+              ],
+            },
+            {
+              type: 'tablerow',
+              children: [{ type: 'tablecell', children: [{ type: 'text', text: 'Body Cell' }] }],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', text: '[Table]\nRank | Artist\n1 | Sample Band' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'block',
+              fields: { blockType: 'embed', url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'block',
+              fields: { blockType: 'paypalButton', hostedButtonId: '5EHFMBVNYRVA8' },
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'block',
+              fields: {
+                blockType: 'paypalSmartButtons',
+                orderDescription: 'Pick a tier',
+                items: [{ label: 'Tier One', price: 1 }],
+              },
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', text: '<!--Hidden legacy note.-->Visible after: ' },
+            { type: 'text', text: 'Lime Garden' },
+            { type: 'text', text: ' <font size=1>tiny</font> ' },
+            { type: 'text', text: '<font size=2>small</font> ' },
+            { type: 'text', text: '<font size=3>default</font> ' },
+            { type: 'text', text: '<font size=4>large</font> ' },
+            { type: 'text', text: '<font size=5>xlarge</font> ' },
+            { type: 'text', text: '<hr /> ' },
+            { type: 'text', text: '<b>recovered bold' },
+            { type: 'text', text: '</b> <i>recovered italic' },
+            { type: 'text', text: '</i> <u>recovered underline</u>' },
+          ],
+        },
+      ],
+    },
+  };
+
+  const existing = await payload.find({
+    collection: 'pages',
+    where: { slug: { equals: SLUG } },
+    limit: 1,
+  });
+
+  const data = {
+    title: TITLE,
+    slug: SLUG,
+    generateSlug: false,
+    content,
+    _status: 'published' as const,
+  };
+
+  if (existing.docs.length > 0) {
+    await payload.update({ collection: 'pages', id: existing.docs[0].id, data });
+    console.log(
+      `✅ Updated existing Kitchen Sink QA page (id ${existing.docs[0].id}, slug: ${SLUG})`,
+    );
+  } else {
+    const created = await payload.create({ collection: 'pages', data });
+    console.log(`✅ Created Kitchen Sink QA page (id ${created.id}, slug: ${SLUG})`);
+  }
+
+  console.log(
+    "   Visit it via PostgresCustomText's permalink route, or in /admin to eyeball the rendered HTML.",
+  );
+
+  process.exit(0);
+}
+
+seed().catch((error) => {
+  console.error('❌ Seed failed:', error);
+  console.error(JSON.stringify(error?.cause?.errors ?? error?.data?.errors, null, 2));
+  process.exit(1);
+});

--- a/bin/seed-kitchen-sink-post.ts
+++ b/bin/seed-kitchen-sink-post.ts
@@ -1,0 +1,182 @@
+/* eslint-disable no-console */
+import { getPayloadHMR } from '@payloadcms/next/utilities';
+import config from '@payload-config';
+import { assertNotConnectedToProd } from './migrations/shared/payloadClient';
+
+/**
+ * Seeds (or updates in place) a single "Kitchen Sink QA" Post covering every
+ * Lexical node type Posts.ts's editor config actually registers, plus every
+ * legacy HTML artifact ConvertsLexicalToHtml.php recovers (nbsp,
+ * <font size 1-5>, <hr>, malformed b/i/em/u, hidden comments). Posts.ts only
+ * registers EmbedFeature (not the PayPal blocks — those are Pages-only, see
+ * bin/seed-kitchen-sink-page.ts), so this omits paypalButton/
+ * paypalSmartButtons even though the PHP renderer supports them for any
+ * collection. Mirrors the fixture in
+ * src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php's
+ * testKitchenSinkDocumentConvertsEveryNodeTypeAndLegacyArtifact — keep the
+ * two in sync when either changes.
+ *
+ * Purpose: visual QA. After changing the Lexical editor config or the PHP
+ * renderer, run this and eyeball the front page / admin editor for the
+ * story it creates, rather than authoring test content by hand each time.
+ *
+ * Usage: yarn tsx bin/seed-kitchen-sink-post.ts
+ */
+
+const HEADLINE = 'Kitchen Sink QA — Posts Lexical Nodes + Legacy Artifacts';
+
+async function seed() {
+  assertNotConnectedToProd();
+
+  const payload = await getPayloadHMR({ config });
+
+  const content = {
+    root: {
+      type: 'root',
+      children: [
+        { type: 'heading', tag: 'h1', children: [{ type: 'text', text: 'Heading One' }] },
+        { type: 'heading', tag: 'h2', children: [{ type: 'text', text: 'Heading Two' }] },
+        { type: 'heading', tag: 'h3', children: [{ type: 'text', text: 'Heading Three' }] },
+        { type: 'heading', tag: 'h4', children: [{ type: 'text', text: 'Heading Four' }] },
+        { type: 'heading', tag: 'h5', children: [{ type: 'text', text: 'Heading Five' }] },
+        { type: 'heading', tag: 'h6', children: [{ type: 'text', text: 'Heading Six' }] },
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', text: 'Bold', format: 1 },
+            { type: 'text', text: ' Italic', format: 2 },
+            { type: 'text', text: ' Underline', format: 8 },
+            { type: 'text', text: ' BoldItalic', format: 3 },
+            { type: 'linebreak' },
+            { type: 'text', text: 'Small state', $: { fontSize: 'small' } },
+          ],
+        },
+        {
+          type: 'paragraph',
+          format: 'center',
+          children: [{ type: 'text', text: 'Centered paragraph' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'link',
+              fields: { url: 'https://example.com', linkType: 'custom' },
+              children: [{ type: 'text', text: 'A link' }],
+            },
+            { type: 'text', text: ' and ' },
+            {
+              type: 'link',
+              fields: { url: 'https://example.com/new-tab', newTab: true, linkType: 'custom' },
+              children: [{ type: 'text', text: 'a new-tab link' }],
+            },
+          ],
+        },
+        {
+          type: 'list',
+          listType: 'bullet',
+          children: [
+            { type: 'listitem', children: [{ type: 'text', text: 'Bullet one' }] },
+            { type: 'listitem', children: [{ type: 'text', text: 'Bullet two' }] },
+          ],
+        },
+        {
+          type: 'list',
+          listType: 'number',
+          children: [{ type: 'listitem', children: [{ type: 'text', text: 'Numbered one' }] }],
+        },
+        { type: 'quote', children: [{ type: 'text', text: 'A quotation' }] },
+        { type: 'horizontalrule' },
+        {
+          type: 'table',
+          children: [
+            {
+              type: 'tablerow',
+              children: [
+                {
+                  type: 'tablecell',
+                  headerState: 1,
+                  children: [{ type: 'text', text: 'Header Cell' }],
+                },
+              ],
+            },
+            {
+              type: 'tablerow',
+              children: [{ type: 'tablecell', children: [{ type: 'text', text: 'Body Cell' }] }],
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', text: '[Table]\nRank | Artist\n1 | Sample Band' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'block',
+              fields: { blockType: 'embed', url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', text: '<!--Hidden legacy note.-->Visible after: ' },
+            { type: 'text', text: 'Lime Garden' },
+            { type: 'text', text: ' <font size=1>tiny</font> ' },
+            { type: 'text', text: '<font size=2>small</font> ' },
+            { type: 'text', text: '<font size=3>default</font> ' },
+            { type: 'text', text: '<font size=4>large</font> ' },
+            { type: 'text', text: '<font size=5>xlarge</font> ' },
+            { type: 'text', text: '<hr /> ' },
+            { type: 'text', text: '<b>recovered bold' },
+            { type: 'text', text: '</b> <i>recovered italic' },
+            { type: 'text', text: '</i> <u>recovered underline</u>' },
+          ],
+        },
+      ],
+    },
+  };
+
+  const existing = await payload.find({
+    collection: 'posts',
+    where: { headline: { equals: HEADLINE } },
+    limit: 1,
+  });
+
+  const startDate = new Date();
+  const endDate = new Date();
+  endDate.setFullYear(endDate.getFullYear() + 10);
+
+  const data = {
+    headline: HEADLINE,
+    content,
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString(),
+    priority: 999,
+    showOnFrontPage: false,
+    _status: 'published' as const,
+  };
+
+  if (existing.docs.length > 0) {
+    await payload.update({ collection: 'posts', id: existing.docs[0].id, data });
+    console.log(`✅ Updated existing Kitchen Sink QA post (id ${existing.docs[0].id})`);
+  } else {
+    const created = await payload.create({ collection: 'posts', data });
+    console.log(`✅ Created Kitchen Sink QA post (id ${created.id})`);
+  }
+
+  console.log(
+    '   showOnFrontPage is false — visit it directly in /admin to eyeball the rendered HTML,',
+  );
+  console.log('   or flip showOnFrontPage on to see it on the front page.');
+
+  process.exit(0);
+}
+
+seed().catch((error) => {
+  console.error('❌ Seed failed:', error);
+  console.error(JSON.stringify(error?.cause?.errors ?? error?.data?.errors, null, 2));
+  process.exit(1);
+});

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -387,7 +387,7 @@ trait ConvertsLexicalToHtml
      */
     private function normalizeNbsp(string $html): string
     {
-        return str_replace(["\u{00a0}", '&nbsp;'], ' ', $html);
+        return str_replace(["\u{00a0}", '&amp;nbsp;', '&nbsp;'], ' ', $html);
     }
 
     /**
@@ -495,8 +495,11 @@ trait ConvertsLexicalToHtml
                 continue;
             }
 
-            $open = $stack[$openIndex];
-            array_splice($stack, $openIndex);
+            $popped = array_splice($stack, $openIndex);
+            $open = array_shift($popped);
+            foreach ($popped as $unmatchedOpen) {
+                $toDelete[] = ['offset' => $unmatchedOpen['offset'], 'length' => $unmatchedOpen['length']];
+            }
             $replacements[] = ['offset' => $open['offset'], 'length' => $open['length'], 'html' => $open['html']];
             $replacements[] = ['offset' => $offset, 'length' => $length, 'html' => $open['closeHtml']];
         }

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -49,7 +49,7 @@ trait ConvertsLexicalToHtml
             foreach ($lexical['root']['children'] as $node) {
                 $html .= $this->convertLexicalNodeToHtml($node, $forceNewTabLinks, $mediaMap);
             }
-            return $this->stripLegacyHtmlComments($html);
+            return $this->normalizeLegacyHtmlArtifacts($html);
         } catch (\Throwable $e) {
             error_log(static::class . ': Failed to convert Lexical to HTML: ' . $e->getMessage());
             return $lexicalJson;
@@ -345,6 +345,27 @@ trait ConvertsLexicalToHtml
     }
 
     /**
+     * Legacy MySQL story content was raw HTML, and content migrated from it
+     * (or still pasted in that style) carries HTML that Lexical has no node
+     * for — comments, `<font size>` small print, and formatting tags left
+     * broken by the original importer's best-effort parser. Since Lexical
+     * has no comment/font-size/tag-repair concept, all of this survives as
+     * literal text and gets `htmlspecialchars`-escaped in convertLexicalToHtml,
+     * showing up as visible garbage instead of the hidden/formatted content
+     * an author intended. Clean up each pattern on the final assembled HTML,
+     * where escaped markup from every text node sits side by side regardless
+     * of which Lexical node it originated in.
+     */
+    private function normalizeLegacyHtmlArtifacts(string $html): string
+    {
+        $html = $this->stripLegacyHtmlComments($html);
+        $html = $this->normalizeNbsp($html);
+        $html = $this->recoverLegacyHorizontalRules($html);
+        $html = $this->recoverLegacyFormattingTags($html);
+        return $html;
+    }
+
+    /**
      * DJs carried the habit of hiding stale copy inside `<!-- -->` from the
      * old raw-HTML story editor, where the browser rendered actual HTML
      * comments as invisible. Lexical has no comment node, so that markup is
@@ -356,6 +377,121 @@ trait ConvertsLexicalToHtml
     private function stripLegacyHtmlComments(string $html): string
     {
         return preg_replace('/&lt;!--.*?--&gt;/s', '', $html) ?? $html;
+    }
+
+    /**
+     * Non-breaking spaces pasted from Word/Google Docs are invisible in the
+     * editor, so nobody notices them until one lands mid-word on a narrow
+     * viewport and blocks a wrap that should happen there. A regular space
+     * lets the browser wrap wherever it actually needs to.
+     */
+    private function normalizeNbsp(string $html): string
+    {
+        return str_replace(["\u{00a0}", '&nbsp;'], ' ', $html);
+    }
+
+    /**
+     * A literal `<hr />`/`<hr>` in escaped text (e.g. old dividers between a
+     * CD-of-the-week review's byline and body) has a direct Lexical
+     * equivalent (the `horizontalrule` node already renders real `<hr>`), so
+     * unlike the tag-pair recovery below there's no ambiguity to resolve —
+     * just convert it.
+     */
+    private function recoverLegacyHorizontalRules(string $html): string
+    {
+        return preg_replace('/&lt;hr\s*\/?&gt;/i', '<hr>', $html) ?? $html;
+    }
+
+    /**
+     * Legacy formatting tags (`<b>`, `<strong>`, `<i>`, `<em>`, `<u>`,
+     * `<font size="1|2">`) that survived migration as literal escaped text
+     * are consistently split across sibling Lexical text nodes — sometimes
+     * even across paragraph boundaries — because the original importer gave
+     * up at exactly the point the legacy HTML's tags stopped nesting
+     * cleanly. There's no reliable position-only heuristic for a lone open
+     * or close tag (e.g. `</b>Shana</b>` — bold could plausibly start before
+     * or after "Shana"; a stray `</font>` with no open anywhere nearby, seen
+     * in real migrated content, would otherwise produce an orphaned closing
+     * span), so this only recovers a tag pair that both find a real match
+     * somewhere in the document via a stack scan; anything left unmatched
+     * is dropped rather than guessed, leaving the surrounding text plain.
+     *
+     * `<font size="1|2">` maps to the same `lexical-text--small` class
+     * SmallTextFeature produces (payload/src/features/text-size) rather
+     * than being dropped, to preserve its small-print intent.
+     */
+    private function recoverLegacyFormattingTags(string $html): string
+    {
+        $simpleTags = ['b' => 'strong', 'strong' => 'strong', 'i' => 'em', 'em' => 'em', 'u' => 'u'];
+        $pattern = '/&lt;(\/?)\s*(?:(b|strong|i|em|u)|font\s+size=(?:&quot;|&#0?39;)?[12](?:&quot;|&#0?39;)?\s*|(\/font))\s*&gt;/i';
+
+        if (!preg_match_all($pattern, $html, $matches, PREG_OFFSET_CAPTURE)) {
+            return $html;
+        }
+
+        $stack = [];
+        $toDelete = [];
+        $replacements = [];
+
+        foreach ($matches[0] as $i => $fullMatch) {
+            $simpleTag = $matches[2][$i][0] !== '' ? strtolower($matches[2][$i][0]) : null;
+            $isFontClose = $matches[3][$i][0] !== '';
+            $offset = $fullMatch[1];
+            $length = strlen($fullMatch[0]);
+
+            if ($simpleTag !== null) {
+                $isClosing = $matches[1][$i][0] !== '';
+                $tag = $simpleTags[$simpleTag];
+                $openHtml = "<$tag>";
+                $closeHtml = "</$tag>";
+            } else {
+                $isClosing = $isFontClose;
+                $tag = 'font';
+                $openHtml = '<span class="lexical-text--small">';
+                $closeHtml = '</span>';
+            }
+
+            if (!$isClosing) {
+                $stack[] = ['tag' => $tag, 'offset' => $offset, 'length' => $length, 'html' => $openHtml];
+                continue;
+            }
+
+            $openIndex = null;
+            for ($j = count($stack) - 1; $j >= 0; $j--) {
+                if ($stack[$j]['tag'] === $tag) {
+                    $openIndex = $j;
+                    break;
+                }
+            }
+
+            if ($openIndex === null) {
+                // Stray close with no matching open anywhere before it.
+                $toDelete[] = ['offset' => $offset, 'length' => $length];
+                continue;
+            }
+
+            $open = $stack[$openIndex];
+            array_splice($stack, $openIndex);
+            $replacements[] = ['offset' => $open['offset'], 'length' => $open['length'], 'html' => $open['html']];
+            $replacements[] = ['offset' => $offset, 'length' => $length, 'html' => $closeHtml];
+        }
+
+        // Anything still on the stack never found a close — drop it too.
+        foreach ($stack as $unmatched) {
+            $toDelete[] = ['offset' => $unmatched['offset'], 'length' => $unmatched['length']];
+        }
+
+        $edits = array_merge(
+            $replacements,
+            array_map(fn ($d) => ['offset' => $d['offset'], 'length' => $d['length'], 'html' => ''], $toDelete),
+        );
+
+        usort($edits, fn ($a, $b) => $b['offset'] <=> $a['offset']);
+        foreach ($edits as $edit) {
+            $html = substr_replace($html, $edit['html'], $edit['offset'], $edit['length']);
+        }
+
+        return $html;
     }
 
     /**

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -404,7 +404,7 @@ trait ConvertsLexicalToHtml
 
     /**
      * Legacy formatting tags (`<b>`, `<strong>`, `<i>`, `<em>`, `<u>`,
-     * `<font size="1|2">`) that survived migration as literal escaped text
+     * `<font size="N">`) that survived migration as literal escaped text
      * are consistently split across sibling Lexical text nodes — sometimes
      * even across paragraph boundaries — because the original importer gave
      * up at exactly the point the legacy HTML's tags stopped nesting
@@ -416,14 +416,23 @@ trait ConvertsLexicalToHtml
      * somewhere in the document via a stack scan; anything left unmatched
      * is dropped rather than guessed, leaving the surrounding text plain.
      *
-     * `<font size="1|2">` maps to the same `lexical-text--small` class
-     * SmallTextFeature produces (payload/src/features/text-size) rather
-     * than being dropped, to preserve its small-print intent.
+     * `<font size="N">` maps to a `lexical-text--*` size class matching the
+     * legacy site's real usage of the browser's built-in 1-7 HTML font-size
+     * scale (1=smallest subtitle .. 5=large DJ-name heading — this site
+     * never used 6/7), rather than one flat "small" treatment. size=3 is
+     * the browser default, so it's left unwrapped.
      */
+    private const LEGACY_FONT_SIZE_CLASSES = [
+        '1' => 'lexical-text--tiny',
+        '2' => 'lexical-text--small',
+        '4' => 'lexical-text--large',
+        '5' => 'lexical-text--xlarge',
+    ];
+
     private function recoverLegacyFormattingTags(string $html): string
     {
         $simpleTags = ['b' => 'strong', 'strong' => 'strong', 'i' => 'em', 'em' => 'em', 'u' => 'u'];
-        $pattern = '/&lt;(\/?)\s*(?:(b|strong|i|em|u)|font\s+size=(?:&quot;|&#0?39;)?[12](?:&quot;|&#0?39;)?\s*|(\/font))\s*&gt;/i';
+        $pattern = '/&lt;(\/?)\s*(?:(b|strong|i|em|u)|font\s+size=(?:&quot;|&#0?39;)?([1-5])(?:&quot;|&#0?39;)?\s*|(\/font))\s*&gt;/i';
 
         if (!preg_match_all($pattern, $html, $matches, PREG_OFFSET_CAPTURE)) {
             return $html;
@@ -435,7 +444,8 @@ trait ConvertsLexicalToHtml
 
         foreach ($matches[0] as $i => $fullMatch) {
             $simpleTag = $matches[2][$i][0] !== '' ? strtolower($matches[2][$i][0]) : null;
-            $isFontClose = $matches[3][$i][0] !== '';
+            $fontSize = $matches[3][$i][0] !== '' ? $matches[3][$i][0] : null;
+            $isFontClose = $matches[4][$i][0] !== '';
             $offset = $fullMatch[1];
             $length = strlen($fullMatch[0]);
 
@@ -444,15 +454,30 @@ trait ConvertsLexicalToHtml
                 $tag = $simpleTags[$simpleTag];
                 $openHtml = "<$tag>";
                 $closeHtml = "</$tag>";
+            } elseif ($fontSize !== null) {
+                // size=3 is the browser default — no wrapper needed, but the
+                // tag still needs tracking so its matching </font> is
+                // recognized and dropped rather than left as an orphan.
+                $isClosing = false;
+                $tag = 'font';
+                $class = self::LEGACY_FONT_SIZE_CLASSES[$fontSize] ?? null;
+                $openHtml = $class !== null ? "<span class=\"$class\">" : '';
+                $closeHtml = $class !== null ? '</span>' : '';
             } else {
+                // Closing </font> — its rendered HTML comes from the
+                // matched open's stored 'closeHtml' below, not from here.
                 $isClosing = $isFontClose;
                 $tag = 'font';
-                $openHtml = '<span class="lexical-text--small">';
-                $closeHtml = '</span>';
             }
 
             if (!$isClosing) {
-                $stack[] = ['tag' => $tag, 'offset' => $offset, 'length' => $length, 'html' => $openHtml];
+                $stack[] = [
+                    'tag' => $tag,
+                    'offset' => $offset,
+                    'length' => $length,
+                    'html' => $openHtml,
+                    'closeHtml' => $closeHtml,
+                ];
                 continue;
             }
 
@@ -473,7 +498,7 @@ trait ConvertsLexicalToHtml
             $open = $stack[$openIndex];
             array_splice($stack, $openIndex);
             $replacements[] = ['offset' => $open['offset'], 'length' => $open['length'], 'html' => $open['html']];
-            $replacements[] = ['offset' => $offset, 'length' => $length, 'html' => $closeHtml];
+            $replacements[] = ['offset' => $offset, 'length' => $length, 'html' => $open['closeHtml']];
         }
 
         // Anything still on the stack never found a close — drop it too.

--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -451,6 +451,26 @@ nav a:hover {
   font-size: 0.85em;
 }
 
+/* Recovered legacy <font size="N"> text (see ConvertsLexicalToHtml.php's
+   recoverLegacyFormattingTags) that survived migration as literal escaped
+   text rather than a real Lexical node. The legacy site relied on browsers'
+   built-in HTML font-size scale (1=smallest .. 7=largest, 3=default), used
+   across a real range — size=1 subtitles, size=5 DJ-name headings, size=4
+   call-to-action banners — not just a single "small print" tier. size=2 and
+   size=3 map to the existing small/default tiers above; these cover the
+   rest of that scale actually seen in migrated content. */
+.lexical-text--tiny {
+  font-size: 0.7em;
+}
+
+.lexical-text--large {
+  font-size: 1.3em;
+}
+
+.lexical-text--xlarge {
+  font-size: 1.6em;
+}
+
 .pagination {
   padding: 20px;
 }

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -756,4 +756,112 @@ class ConvertsLexicalToHtmlTest extends TestCase
 
         $this->assertStringContainsString('Next paragraph still renders.', $html);
     }
+
+    /**
+     * Build a single-paragraph Lexical document from a list of plain text
+     * node strings, for testing legacy-artifact normalization across
+     * sibling text nodes.
+     */
+    private function textNodesJson(array $texts): string
+    {
+        return json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => array_map(
+                            fn ($text) => ['type' => 'text', 'text' => $text],
+                            $texts,
+                        ),
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testNonBreakingSpaceIsNormalizedToRegularSpace(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson(["Lime\u{00a0}Garden"]));
+
+        $this->assertStringContainsString('Lime Garden', $html);
+        $this->assertStringNotContainsString("\u{00a0}", $html);
+    }
+
+    public function testLegacyFontSizeSmallPrintBecomesSemanticSmallTextSpan(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson([
+            '<font size=2>Terms and conditions apply.</font>',
+        ]));
+
+        $this->assertStringContainsString(
+            '<span class="lexical-text--small">Terms and conditions apply.</span>',
+            $html,
+        );
+        $this->assertStringNotContainsString('&lt;font', $html);
+    }
+
+    public function testLegacyFontSizeWithQuotedAttributeIsRecognized(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson([
+            '<font size="1">Fine print.</font>',
+        ]));
+
+        $this->assertStringContainsString(
+            '<span class="lexical-text--small">Fine print.</span>',
+            $html,
+        );
+    }
+
+    public function testLegacyHorizontalRuleTextIsRecovered(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson(['<hr />']));
+
+        $this->assertStringContainsString('<hr>', $html);
+        $this->assertStringNotContainsString('&lt;hr', $html);
+    }
+
+    public function testMatchedLegacyBoldTagAcrossSiblingTextNodesIsRecovered(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson([
+            'Album of the year: ',
+            '<b>The Canyon',
+            '</b> by JJerome87.',
+        ]));
+
+        $this->assertStringContainsString('<strong>The Canyon</strong> by JJerome87.', $html);
+        $this->assertStringNotContainsString('&lt;b&gt;', $html);
+        $this->assertStringNotContainsString('&lt;/b&gt;', $html);
+    }
+
+    public function testMatchedLegacyItalicAndUnderlineTagsAreRecovered(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson([
+            '<i>The Amazing Spider-Man 2',
+            '</i>, opening this Friday.',
+        ]));
+        $this->assertStringContainsString('<em>The Amazing Spider-Man 2</em>, opening this Friday.', $html);
+
+        $underlineHtml = $this->converter->convert($this->textNodesJson(['<u>Show Cancellations:</u>']));
+        $this->assertStringContainsString('<u>Show Cancellations:</u>', $underlineHtml);
+    }
+
+    /**
+     * Real example from a legacy story: a stray closing </b> with no
+     * preceding open, followed by an open <b> and an open <i> that never
+     * close anywhere in the document. None of the three should be guessed
+     * into a formatting span — only the tags themselves are dropped.
+     */
+    public function testUnmatchedLegacyTagsAreDroppedWithoutGuessing(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson([
+            'the man who started it all, </b>Jim McGuinn<b>! <i>Plus, check out photos',
+        ]));
+
+        $this->assertStringContainsString('the man who started it all, Jim McGuinn! Plus, check out photos', $html);
+        $this->assertStringNotContainsString('<strong>', $html);
+        $this->assertStringNotContainsString('<em>', $html);
+        $this->assertStringNotContainsString('&lt;b&gt;', $html);
+        $this->assertStringNotContainsString('&lt;/b&gt;', $html);
+        $this->assertStringNotContainsString('&lt;i&gt;', $html);
+    }
 }

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -927,4 +927,253 @@ class ConvertsLexicalToHtmlTest extends TestCase
         $this->assertStringNotContainsString('&lt;/b&gt;', $html);
         $this->assertStringNotContainsString('&lt;i&gt;', $html);
     }
+
+    /**
+     * "Kitchen sink" regression fixture — one Lexical document covering
+     * every node type convertLexicalNodeToHtml() handles, plus every legacy
+     * artifact normalizeLegacyHtmlArtifacts() recovers. The renderer is
+     * collection-agnostic (it doesn't know or care whether the JSON came
+     * from Posts or Pages), so this single test covers both, including the
+     * paypalButton/paypalSmartButtons blocks that only Pages' editor
+     * actually allows authoring today — see bin/seed-kitchen-sink-post.ts
+     * (Posts-authorable subset) and bin/seed-kitchen-sink-page.ts (full
+     * set, matching this fixture) for the real-Payload-authoring
+     * counterparts used for visual QA; keep those two and this test in sync
+     * when any of them changes. The point of testing everything in one
+     * document (not just in isolated per-feature tests elsewhere in this
+     * file) is to catch interactions between passes — e.g. the
+     * orphaned-</span> bug from a <font> that spanned a paragraph boundary
+     * only showed up once nbsp normalization, comment stripping, and tag
+     * recovery all ran on the same real HTML.
+     */
+    public function testKitchenSinkDocumentConvertsEveryNodeTypeAndLegacyArtifact(): void
+    {
+        putenv('PAYPAL_SMART_BUTTON_CLIENT_ID=test-client-id-123');
+
+        $lexicalJson = json_encode([
+            'root' => [
+                'children' => [
+                    // Headings h1-h6
+                    ['type' => 'heading', 'tag' => 'h1', 'children' => [['type' => 'text', 'text' => 'Heading One']]],
+                    ['type' => 'heading', 'tag' => 'h2', 'children' => [['type' => 'text', 'text' => 'Heading Two']]],
+                    ['type' => 'heading', 'tag' => 'h3', 'children' => [['type' => 'text', 'text' => 'Heading Three']]],
+                    ['type' => 'heading', 'tag' => 'h4', 'children' => [['type' => 'text', 'text' => 'Heading Four']]],
+                    ['type' => 'heading', 'tag' => 'h5', 'children' => [['type' => 'text', 'text' => 'Heading Five']]],
+                    ['type' => 'heading', 'tag' => 'h6', 'children' => [['type' => 'text', 'text' => 'Heading Six']]],
+                    // Text formatting: bold, italic, underline, combined
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            ['type' => 'text', 'text' => 'Bold', 'format' => 1],
+                            ['type' => 'text', 'text' => ' Italic', 'format' => 2],
+                            ['type' => 'text', 'text' => ' Underline', 'format' => 8],
+                            ['type' => 'text', 'text' => ' BoldItalic', 'format' => 3],
+                            ['type' => 'linebreak'],
+                            ['type' => 'text', 'text' => 'Small state', '$' => ['fontSize' => 'small']],
+                        ],
+                    ],
+                    // Paragraph alignment
+                    [
+                        'type' => 'paragraph',
+                        'format' => 'center',
+                        'children' => [['type' => 'text', 'text' => 'Centered paragraph']],
+                    ],
+                    // Links: default and new-tab
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'link',
+                                'fields' => ['url' => 'https://example.com'],
+                                'children' => [['type' => 'text', 'text' => 'A link']],
+                            ],
+                            ['type' => 'text', 'text' => ' and '],
+                            [
+                                'type' => 'link',
+                                'fields' => ['url' => 'https://example.com/new-tab', 'newTab' => true],
+                                'children' => [['type' => 'text', 'text' => 'a new-tab link']],
+                            ],
+                        ],
+                    ],
+                    // Lists: bullet and numbered
+                    [
+                        'type' => 'list',
+                        'listType' => 'bullet',
+                        'children' => [
+                            ['type' => 'listitem', 'children' => [['type' => 'text', 'text' => 'Bullet one']]],
+                            ['type' => 'listitem', 'children' => [['type' => 'text', 'text' => 'Bullet two']]],
+                        ],
+                    ],
+                    [
+                        'type' => 'list',
+                        'listType' => 'number',
+                        'children' => [
+                            ['type' => 'listitem', 'children' => [['type' => 'text', 'text' => 'Numbered one']]],
+                        ],
+                    ],
+                    // Quote and horizontal rule
+                    ['type' => 'quote', 'children' => [['type' => 'text', 'text' => 'A quotation']]],
+                    ['type' => 'horizontalrule'],
+                    // Real Lexical table
+                    [
+                        'type' => 'table',
+                        'children' => [
+                            [
+                                'type' => 'tablerow',
+                                'children' => [
+                                    [
+                                        'type' => 'tablecell',
+                                        'headerState' => 1,
+                                        'children' => [['type' => 'text', 'text' => 'Header Cell']],
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type' => 'tablerow',
+                                'children' => [
+                                    [
+                                        'type' => 'tablecell',
+                                        'children' => [['type' => 'text', 'text' => 'Body Cell']],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    // Legacy "[Table]" text-marker convention
+                    [
+                        'type' => 'paragraph',
+                        'children' => [['type' => 'text', 'text' => "[Table]\nRank | Artist\n1 | Sample Band"]],
+                    ],
+                    // Upload (image) with alignment
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'upload',
+                                'value' => ['id' => 1],
+                                'fields' => ['alignment' => 'center'],
+                            ],
+                        ],
+                    ],
+                    // Embed block
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'block',
+                                'fields' => ['blockType' => 'embed', 'url' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+                            ],
+                        ],
+                    ],
+                    // PayPal button block
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'block',
+                                'fields' => ['blockType' => 'paypalButton', 'hostedButtonId' => '5EHFMBVNYRVA8'],
+                            ],
+                        ],
+                    ],
+                    // PayPal smart buttons block
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            [
+                                'type' => 'block',
+                                'fields' => [
+                                    'blockType' => 'paypalSmartButtons',
+                                    'orderDescription' => 'Pick a tier',
+                                    'items' => [['label' => 'Tier One', 'price' => 1]],
+                                ],
+                            ],
+                        ],
+                    ],
+                    // Legacy artifacts: comment, nbsp, font sizes 1-5, hr,
+                    // malformed b/i/em/u split across sibling text nodes —
+                    // all inside a single paragraph, matching how migrated
+                    // legacy content actually looks.
+                    [
+                        'type' => 'paragraph',
+                        'children' => [
+                            ['type' => 'text', 'text' => '<!--Hidden legacy note.-->Visible after: '],
+                            ['type' => 'text', 'text' => "Lime\u{00a0}Garden"],
+                            ['type' => 'text', 'text' => ' <font size=1>tiny</font> '],
+                            ['type' => 'text', 'text' => '<font size=2>small</font> '],
+                            ['type' => 'text', 'text' => '<font size=3>default</font> '],
+                            ['type' => 'text', 'text' => '<font size=4>large</font> '],
+                            ['type' => 'text', 'text' => '<font size=5>xlarge</font> '],
+                            ['type' => 'text', 'text' => '<hr /> '],
+                            ['type' => 'text', 'text' => '<b>recovered bold'],
+                            ['type' => 'text', 'text' => '</b> <i>recovered italic'],
+                            ['type' => 'text', 'text' => '</i> <u>recovered underline</u>'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = $this->converter->convert($lexicalJson);
+
+        // Headings
+        $this->assertStringContainsString('<h1>Heading One</h1>', $html);
+        $this->assertStringContainsString('<h6>Heading Six</h6>', $html);
+        // Real Lexical text formatting
+        $this->assertStringContainsString('<strong>Bold</strong>', $html);
+        $this->assertStringContainsString('<em> Italic</em>', $html);
+        $this->assertStringContainsString('<u> Underline</u>', $html);
+        $this->assertStringContainsString('<span class="lexical-text--small">Small state</span>', $html);
+        // Alignment
+        $this->assertStringContainsString('style="text-align: center;"', $html);
+        // Links
+        $this->assertStringContainsString('<a href="https://example.com">A link</a>', $html);
+        $this->assertStringContainsString('target="_blank" rel="noopener noreferrer">a new-tab link</a>', $html);
+        // Lists
+        $this->assertStringContainsString('<ul><li>Bullet one</li>', $html);
+        $this->assertStringContainsString('<ol><li>Numbered one</li>', $html);
+        // Quote and hr (real Lexical node)
+        $this->assertStringContainsString('<blockquote>A quotation</blockquote>', $html);
+        $this->assertStringContainsString('<hr>', $html);
+        // Real table
+        $this->assertStringContainsString('<th>Header Cell</th>', $html);
+        $this->assertStringContainsString('<td>Body Cell</td>', $html);
+        // Legacy [Table] marker
+        $this->assertStringContainsString('bgcolor="#000000"', $html);
+        $this->assertStringContainsString('Sample Band', $html);
+        // Embed block
+        $this->assertStringContainsString('youtube.com/embed/dQw4w9WgXcQ', $html);
+        // PayPal blocks
+        $this->assertStringContainsString('5EHFMBVNYRVA8', $html);
+        $this->assertStringContainsString('client-id=test-client-id-123', $html);
+        $this->assertStringContainsString('Tier One', $html);
+
+        // Legacy artifact recovery
+        $this->assertStringNotContainsString('&lt;!--', $html);
+        $this->assertStringNotContainsString('Hidden legacy note.', $html);
+        $this->assertStringContainsString('Lime Garden', $html);
+        $this->assertStringNotContainsString("\u{00a0}", $html);
+        $this->assertStringContainsString('<span class="lexical-text--tiny">tiny</span>', $html);
+        $this->assertStringContainsString('<span class="lexical-text--small">small</span>', $html);
+        $this->assertStringContainsString('default', $html);
+        $this->assertStringContainsString('<span class="lexical-text--large">large</span>', $html);
+        $this->assertStringContainsString('<span class="lexical-text--xlarge">xlarge</span>', $html);
+        $this->assertStringContainsString('<strong>recovered bold</strong>', $html);
+        $this->assertStringContainsString('<em>recovered italic</em>', $html);
+        $this->assertStringContainsString('<u>recovered underline</u>', $html);
+        // No escaped legacy markup should survive anywhere in the document
+        $this->assertStringNotContainsString('&lt;b&gt;', $html);
+        $this->assertStringNotContainsString('&lt;/b&gt;', $html);
+        $this->assertStringNotContainsString('&lt;i&gt;', $html);
+        $this->assertStringNotContainsString('&lt;/i&gt;', $html);
+        $this->assertStringNotContainsString('&lt;u&gt;', $html);
+        $this->assertStringNotContainsString('&lt;font', $html);
+        $this->assertStringNotContainsString('&lt;/font&gt;', $html);
+        $this->assertStringNotContainsString('&lt;hr', $html);
+        // No orphaned spans — every </span> pairs with a lexical-text-- open
+        $this->assertSame(
+            substr_count($html, '<span class="lexical-text--'),
+            substr_count($html, '</span>'),
+            'Found an orphaned </span> with no matching lexical-text-- opener',
+        );
+    }
 }

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -803,13 +803,76 @@ class ConvertsLexicalToHtmlTest extends TestCase
     public function testLegacyFontSizeWithQuotedAttributeIsRecognized(): void
     {
         $html = $this->converter->convert($this->textNodesJson([
-            '<font size="1">Fine print.</font>',
+            '<font size="2">Fine print.</font>',
         ]));
 
         $this->assertStringContainsString(
             '<span class="lexical-text--small">Fine print.</span>',
             $html,
         );
+    }
+
+    /**
+     * The legacy site used the browser's built-in 1-7 HTML font-size scale
+     * across a real range, not just one "small print" tier: size=1 for
+     * smallest subtitles, size=4 for call-to-action banners, size=5 for
+     * large DJ-name headings (real examples from the legacy MySQL dump).
+     */
+    public function testLegacyFontSizeTinyTierIsRecovered(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson(['<font size=1>TELLS YOU HOW TO LIVE</font>']));
+
+        $this->assertStringContainsString(
+            '<span class="lexical-text--tiny">TELLS YOU HOW TO LIVE</span>',
+            $html,
+        );
+    }
+
+    public function testLegacyFontSizeLargeTierIsRecovered(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson(['<font size=4>CLICK HERE TO ORDER</font>']));
+
+        $this->assertStringContainsString(
+            '<span class="lexical-text--large">CLICK HERE TO ORDER</span>',
+            $html,
+        );
+    }
+
+    public function testLegacyFontSizeXLargeTierIsRecovered(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson(['<font size=5>Josh T. Landow</font>']));
+
+        $this->assertStringContainsString(
+            '<span class="lexical-text--xlarge">Josh T. Landow</span>',
+            $html,
+        );
+    }
+
+    public function testLegacyFontSizeThreeIsBrowserDefaultAndLeftUnwrapped(): void
+    {
+        $html = $this->converter->convert($this->textNodesJson(['<font size=3>Normal body text.</font>']));
+
+        $this->assertStringContainsString('Normal body text.', $html);
+        $this->assertStringNotContainsString('<span', $html);
+        $this->assertStringNotContainsString('&lt;font', $html);
+        $this->assertStringNotContainsString('&lt;/font', $html);
+    }
+
+    public function testLegacyFontSizeMatchingAcrossSiblingTextNodesIsRecovered(): void
+    {
+        // Real example from the legacy dump: DJ name at size=5, role/show at
+        // size=3 (default, unwrapped) in a following sibling text node.
+        $html = $this->converter->convert($this->textNodesJson([
+            '<font size=5>Rob Huff',
+            '</font>',
+            '<font size=3>Transmission',
+            '</font>',
+        ]));
+
+        $this->assertStringContainsString('<span class="lexical-text--xlarge">Rob Huff</span>', $html);
+        $this->assertStringContainsString('Transmission', $html);
+        $this->assertStringNotContainsString('&lt;font', $html);
+        $this->assertStringNotContainsString('&lt;/font', $html);
     }
 
     public function testLegacyHorizontalRuleTextIsRecovered(): void


### PR DESCRIPTION
## Summary
- DJs paste/migrate content with HTML that has no Lexical equivalent — non-breaking spaces (Word/Docs paste), `<font size>` small print, and formatting tags left broken by the original MySQL importer. All of it survives as literal escaped text, showing as visible garbage or unexpected mid-word line breaks (e.g. today's "Lime Garden" report).
- Rather than restrict what DJs can paste, this normalizes on render in `ConvertsLexicalToHtml.php`:
  - `&nbsp;`/` ` → regular space
  - `<font size="1|2">` → the same `lexical-text--small` span `SmallTextFeature` already produces
  - literal `<hr>` → a real `<hr>`
  - `<b>`/`<strong>`/`<i>`/`<em>`/`<u>` pairs recovered via a stack scan across the whole document — matching open/close tags are consistently split across sibling text nodes (sometimes even paragraphs) by the original importer. Unmatched tags are dropped rather than guessed, since a lone open or close tag has no reliable position-only interpretation (e.g. `</b>Shana</b>` — bold could plausibly start before or after "Shana").
- Out of scope (by design, discussed and confirmed): literal `<a href>` recovery (1 old post, cosmetic, needs URL-safety validation) and `<form>`/`<input>` PayPal remnants (2 old expired-promo posts — should be migrated to the existing `PayPalButtonBlock`/`PayPalSmartButtonsBlock`, not string-repaired).

## Test plan
- [x] New regression tests: nbsp normalization, font→small-text (plain and quoted attr), hr recovery, matched b/i/u pairs across sibling nodes, unmatched-tag drop (real case from a legacy post), full suite (263 tests) passes, phpcs clean
- [x] Verified against all 29 real posts in dev Neon carrying this class of artifact (scanned via direct DB query) — zero remaining escaped tags or orphaned spans after the fix
- [x] Verified locally on `localhost:8080` against dev Neon with Playwright — front page renders clean, zero `&lt;` anywhere

https://claude.ai/code/session_01SeqX4Gwos7x8vaoLBuxPRC