### PR TITLE
feat: add Top11Contests nominees field for the current week's ballot

### DIFF
--- a/bin/migrations/importTop11.ts
+++ b/bin/migrations/importTop11.ts
@@ -275,6 +275,13 @@ async function main(): Promise<void> {
       });
     }
 
+    const songIdByLegacyId = await importSongPool(payload, nomineeRows as NomineeRow[]);
+    logger.info(`Song pool ready: ${songIdByLegacyId.size} nominee songs`);
+
+    // Distinct: this week's votable ballot, not last week's ranked chart
+    // (entries, above). Every legacy nominee-pool song becomes a nominee row.
+    const nominees = Array.from(songIdByLegacyId.values()).map((songId) => ({ song: songId }));
+
     // Created open so the vote-creation hook accepts imported votes; the
     // real legacy status is applied after votes land.
     const contest = await payload.create({
@@ -287,13 +294,11 @@ async function main(): Promise<void> {
           body: convertHtmlToLexicalEnhanced(String(messageRows[0]?.message ?? '')),
         },
         entries,
+        nominees,
       },
     });
     const contestId = contest.id as number;
     logger.info(`Created contest ${contestId} for week of ${dateRow.artist}`);
-
-    const songIdByLegacyId = await importSongPool(payload, nomineeRows as NomineeRow[]);
-    logger.info(`Song pool ready: ${songIdByLegacyId.size} nominee songs`);
 
     const voteResult = await importVotes(
       payload,

--- a/payload/migrations/20260706_202828_add_top11_contests_nominees.ts
+++ b/payload/migrations/20260706_202828_add_top11_contests_nominees.ts
@@ -1,0 +1,23 @@
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TABLE "top11_contests_nominees" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"song_id" integer NOT NULL
+  );
+  ALTER TABLE "top11_contests_nominees" ADD CONSTRAINT "top11_contests_nominees_song_id_songs_id_fk" FOREIGN KEY ("song_id") REFERENCES "public"."songs"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "top11_contests_nominees" ADD CONSTRAINT "top11_contests_nominees_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."top11_contests"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "top11_contests_nominees_order_idx" ON "top11_contests_nominees" USING btree ("_order");
+  CREATE INDEX "top11_contests_nominees_parent_id_idx" ON "top11_contests_nominees" USING btree ("_parent_id");
+  CREATE INDEX "top11_contests_nominees_song_idx" ON "top11_contests_nominees" USING btree ("song_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "top11_contests_nominees" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "top11_contests_nominees" CASCADE;`)
+}

--- a/payload/migrations/index.ts
+++ b/payload/migrations/index.ts
@@ -16,6 +16,7 @@ import * as migration_20260701_221242_add_top11_display_title from './20260701_2
 import * as migration_20260703_000000_add_pages_collection from './20260703_000000_add_pages_collection';
 import * as migration_20260704_000000_add_top11_votes_voterkey_field from './20260704_000000_add_top11_votes_voterkey_field';
 import * as migration_20260705_000000_drop_top11_recording_fields from './20260705_000000_drop_top11_recording_fields';
+import * as migration_20260706_202828_add_top11_contests_nominees from './20260706_202828_add_top11_contests_nominees';
 import * as migration_20260405_000000_add_year_end_poll_tables from './20260405_000000_add_year_end_poll_tables';
 
 export const migrations = [
@@ -108,6 +109,11 @@ export const migrations = [
     up: migration_20260705_000000_drop_top11_recording_fields.up,
     down: migration_20260705_000000_drop_top11_recording_fields.down,
     name: '20260705_000000_drop_top11_recording_fields',
+  },
+  {
+    up: migration_20260706_202828_add_top11_contests_nominees.up,
+    down: migration_20260706_202828_add_top11_contests_nominees.down,
+    name: '20260706_202828_add_top11_contests_nominees',
   },
   {
     up: migration_20260405_000000_add_year_end_poll_tables.up,

--- a/payload/src/collections/Top11Contests.test.ts
+++ b/payload/src/collections/Top11Contests.test.ts
@@ -37,6 +37,43 @@ describe('Top11Contests', () => {
     expect(entriesField.maxRows).toBe(11);
   });
 
+  describe('nominees field', () => {
+    const nomineesField = Top11Contests.fields.find((field) => field.name === 'nominees') as {
+      type?: string;
+      minRows?: number;
+      maxRows?: number;
+      validate?: (value: unknown) => true | string;
+    };
+
+    it('is an unbounded array distinct from entries', () => {
+      expect(nomineesField.type).toBe('array');
+      expect(nomineesField.minRows).toBeUndefined();
+      expect(nomineesField.maxRows).toBeUndefined();
+    });
+
+    it('accepts an empty or undefined nominee pool', () => {
+      expect(nomineesField.validate?.(undefined)).toBe(true);
+      expect(nomineesField.validate?.([])).toBe(true);
+    });
+
+    it('accepts a nominee pool larger than 11 songs', () => {
+      const pool = Array.from({ length: 57 }, (_, i) => ({ song: i + 1 }));
+      expect(nomineesField.validate?.(pool)).toBe(true);
+    });
+
+    it('rejects a nominee row with no song', () => {
+      expect(nomineesField.validate?.([{ song: undefined }])).toBe(
+        'Each nominee must reference a valid song',
+      );
+    });
+
+    it('rejects a duplicate song in the nominee pool', () => {
+      expect(nomineesField.validate?.([{ song: 5 }, { song: 5 }])).toBe(
+        'A song can only appear once in the nominee pool',
+      );
+    });
+  });
+
   it('does not have a title field; a derived displayTitle is used as the admin title', () => {
     const allFields = flattenRowFields(Top11Contests.fields);
     expect(allFields.some((field) => field.name === 'title')).toBe(false);

--- a/payload/src/collections/Top11Contests.ts
+++ b/payload/src/collections/Top11Contests.ts
@@ -146,6 +146,49 @@ const validateContestEntries = (value: unknown): true | string => {
   return true;
 };
 
+const validateNominees = (value: unknown): true | string => {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  if (!Array.isArray(value)) {
+    return 'Nominees must be an array';
+  }
+
+  const songs = new Set<number>();
+  let validationError: string | null = null;
+
+  value.forEach((row) => {
+    if (validationError) {
+      return;
+    }
+
+    if (!row || typeof row !== 'object') {
+      validationError = 'Each nominee must be an object';
+      return;
+    }
+
+    const typedRow = row as { song?: unknown };
+    const songId = Number(typedRow.song);
+    if (!Number.isInteger(songId) || songId <= 0) {
+      validationError = 'Each nominee must reference a valid song';
+      return;
+    }
+
+    if (songs.has(songId)) {
+      validationError = 'A song can only appear once in the nominee pool';
+      return;
+    }
+    songs.add(songId);
+  });
+
+  if (validationError) {
+    return validationError;
+  }
+
+  return true;
+};
+
 export const Top11Contests: CollectionConfig = {
   slug: 'top11-contests',
   enableRichTextLink: false,
@@ -671,6 +714,23 @@ export const Top11Contests: CollectionConfig = {
       admin: {
         description:
           'Top 11 songs for the week. Songs must come from the canonical Songs collection.',
+      },
+    },
+    {
+      name: 'nominees',
+      type: 'array',
+      validate: validateNominees,
+      fields: [
+        {
+          name: 'song',
+          type: 'relationship',
+          relationTo: 'songs',
+          required: true,
+        },
+      ],
+      admin: {
+        description:
+          "This week's nominee pool -- the full ballot voters choose from. Distinct from entries, which is last week's ranked results chart.",
       },
     },
     {


### PR DESCRIPTION
## Summary
- PR 1 of 4 in the Top 11 cutover sequence (see #823, Chapter 19). Stacked on the docs branch since it's not merged yet.
- `Top11Contests.entries` only models last week's ranked results chart (max 11 rows) -- nothing tracked which ~57 songs are votable *this* week. `importTop11.ts` already reads the legacy nominee table (`top11songs`) to attach vote counts to `entries`, but discarded pool membership once import finished.
- Adds `nominees` as its own array field (`relationTo: 'songs'`, unbounded, dedup-validated), a migration for the join table, and wires `importTop11.ts` to populate it from the pool it already resolves.
- No page/API changes -- this is schema only. PR 2 will add vote-to-nominee validation against this field; PR 3 will build the PHP read/write adapter that queries it.

## Test plan
- [x] `yarn vitest run payload/src/collections/Top11Contests.test.ts` -- 85 passed, including new `nominees field` coverage (empty/undefined pool, >11 rows accepted, missing-song rejection, duplicate-song rejection)
- [x] `yarn tsc --noEmit` -- no new errors introduced (confirmed by diffing against the pre-existing baseline error count on an unrelated branch)
- [x] `yarn lint` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2