### PR TITLE
feat: add PostgresTop11 adapter, wire use_postgres_top11 flag for real

### DIFF
--- a/bin/migrations/importTop11.ts
+++ b/bin/migrations/importTop11.ts
@@ -37,7 +37,7 @@ import {
 import type { PostgresTarget } from './shared/payloadClient';
 import { createLogger } from './shared/logger';
 import { convertTextToLexical } from './shared/importUtils';
-import { convertHtmlToLexicalEnhanced } from './shared/enhancedHtmlToLexical';
+import { convertHtmlToLexicalEnhanced, resolveImageUploads } from './shared/enhancedHtmlToLexical';
 import { getMySQLConfig, type MySQLSource } from '../../config/databases';
 
 const logger = createLogger('Top11Import');
@@ -282,6 +282,15 @@ async function main(): Promise<void> {
     // (entries, above). Every legacy nominee-pool song becomes a nominee row.
     const nominees = Array.from(songIdByLegacyId.values()).map((songId) => ({ song: songId }));
 
+    // Resolve any linked-photo <img> tags (e.g. the artist thumbnail in
+    // top11message) to real Media references -- same pass importCustomTexts.ts
+    // and importPosts.ts already run, since Payload's Lexical field rejects
+    // the converter's pending-upload placeholder (value: null) on save.
+    const messageBody = await resolveImageUploads(
+      payload,
+      convertHtmlToLexicalEnhanced(String(messageRows[0]?.message ?? '')),
+    );
+
     // Created open so the vote-creation hook accepts imported votes; the
     // real legacy status is applied after votes land.
     const contest = await payload.create({
@@ -291,7 +300,7 @@ async function main(): Promise<void> {
         status: 'open',
         messageSnapshot: {
           headline: `Top 11 @ 11 for ${dateRow.artist}`,
-          body: convertHtmlToLexicalEnhanced(String(messageRows[0]?.message ?? '')),
+          body: messageBody,
         },
         entries,
         nominees,

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -380,6 +380,23 @@ describe('enhancedHtmlToLexical', () => {
       expect(node.src).toBeUndefined();
     });
 
+    it('carries the legacy width/height attributes through to the resolved node', async () => {
+      // Matches top11message's <img height="100"> artist thumbnail --
+      // ConvertsLexicalToHtml renders these as real width/height attributes
+      // so the browser's native aspect-ratio sizing applies, same as the
+      // legacy plain <img> did on prod. resolvePendingUploadNode used to
+      // only carry value/relationTo/fields through, silently dropping
+      // width/height even though the pending node already had them.
+      mockImportImageFromUrl.mockResolvedValue({ success: true, mediaId: 'media-sized' });
+
+      const doc = convertHtmlToLexicalEnhanced('<img src="/photo.jpg" height="100" />');
+      const resolved = await resolveImageUploads(mockPayload, doc);
+
+      const node = resolved.root.children[0];
+      expect(node.height).toBe(100);
+      expect(node.width).toBeUndefined();
+    });
+
     it('drops the node entirely when the image import fails', async () => {
       mockImportImageFromUrl.mockResolvedValue({ success: false, error: 'Failed to download image' });
 

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -472,6 +472,20 @@ describe('enhancedHtmlToLexical', () => {
       expect(result.root.children[0].type).toBe('heading');
       expect(result.root.children[0].format).toBe('center');
     });
+
+    it('should preserve an iframe embed nested inside <center> alongside inline content', () => {
+      // Matches legacy top11message markup: a <center> wrapping an inline
+      // link followed by an unwrapped iframe embed as a sibling.
+      const html = '<center><i>Tickets are <a href="https://example.com/tickets">available here</a>.</i>'
+        + '<iframe width="100%" height="60" src="https://player-widget.mixcloud.com/widget/iframe/?feed=%2Fynotradio%2Fshow"></iframe></center>';
+      const result = convertHtmlToLexicalEnhanced(html);
+
+      const embedBlock = result.root.children.find(
+        (n: any) => n.type === 'block' && n.fields?.blockType === 'embed',
+      );
+      expect(embedBlock).toBeDefined();
+      expect(embedBlock.fields.url).toBe('https://player-widget.mixcloud.com/widget/iframe/?feed=%2Fynotradio%2Fshow');
+    });
   });
 
   describe('Complex HTML', () => {

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -71,6 +71,11 @@ describe('enhancedHtmlToLexical', () => {
       const imageNode = result.root.children.find((n: any) => n.type === 'upload');
       expect(imageNode).toBeDefined();
       expect(imageNode.src).toBe('https://example.com/photo.jpg');
+      // The float lives on the wrapping <a>, not the <img> itself -- must
+      // carry through to the upload node's alignment field so the image
+      // actually renders floated on the frontend (see typography.css
+      // .lexical-image--right), matching real prod's layout.
+      expect(imageNode.fields?.alignment).toBe('right');
 
       const textPara = result.root.children.find((n: any) => n.type === 'paragraph');
       expect(textPara.children[0].text).toContain('Every Thursday at 11am.');
@@ -840,13 +845,16 @@ describe('enhancedHtmlToLexical', () => {
   });
 
   describe('Paragraph Alignment via style', () => {
-    it('should not apply alignment when align attribute is stripped by sanitizer', () => {
-      // DOMPurify strips `align` and `style` attributes — format stays ''
+    it('should apply alignment from a text-align style, now that style is allowlisted', () => {
+      // `style` is allowlisted (needed for legacy `<a style="float: right;">`
+      // image thumbnails) and DOMPurify sanitizes the CSS value itself, so
+      // this is no longer stripped -- the <p> handler already read
+      // style.textAlign, it just never had a chance to see it before.
       const result = convertHtmlToLexicalEnhanced(
         '<p style="text-align: center;">Styled center</p>',
       );
       expect(result.root.children[0].type).toBe('paragraph');
-      expect(result.root.children[0].format).toBe('');
+      expect(result.root.children[0].format).toBe('center');
     });
 
     it('should apply alignment from the align attribute (kept for image float/alignment)', () => {

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -75,6 +75,42 @@ describe('enhancedHtmlToLexical', () => {
       const textPara = result.root.children.find((n: any) => n.type === 'paragraph');
       expect(textPara.children[0].text).toContain('Every Thursday at 11am.');
     });
+
+    it('should split top-level loose content into separate paragraphs on a double <br>', () => {
+      // Legacy top11message markup has no <p> tags at all -- "<br><br>" is
+      // the only paragraph-break signal between sentences.
+      const html = 'First sentence.<br><br>Second sentence.';
+      const result = convertHtmlToLexicalEnhanced(html);
+
+      expect(result.root.children).toHaveLength(2);
+      expect(result.root.children[0].children[0].text).toBe('First sentence.');
+      expect(result.root.children[1].children[0].text).toBe('Second sentence.');
+    });
+
+    it('should preserve a link nested in a bare <i> that lands as a direct child of a block element', () => {
+      // Reproduces real top11message markup: an unclosed <center> causes the
+      // HTML parser to nest trailing siblings (including an <iframe>) inside
+      // it, which makes the <center> handler's block-recursion path visit
+      // its <i> child directly. <i> has no dedicated block-level case, so it
+      // used to fall into the "unknown element" branch, which reads
+      // .textContent (already stripped of tags) and lost the nested <a>.
+      const html = '<center><i>Tickets are <a href="https://example.com/tickets">available here</a>.</i>'
+        + '<iframe src="https://example.com/embed"></iframe></center>';
+      const result = convertHtmlToLexicalEnhanced(html);
+
+      const textPara = result.root.children.find(
+        (n: any) => n.type === 'paragraph' && n.children.some((c: any) => c.type === 'link'),
+      );
+      expect(textPara).toBeDefined();
+      const linkNode = textPara.children.find((c: any) => c.type === 'link');
+      expect(linkNode.fields.url).toBe('https://example.com/tickets');
+      expect(linkNode.children[0].text).toBe('available here');
+
+      const embedBlock = result.root.children.find(
+        (n: any) => n.type === 'block' && n.fields?.blockType === 'embed',
+      );
+      expect(embedBlock).toBeDefined();
+    });
   });
 
   describe('Headings', () => {

--- a/bin/migrations/shared/enhancedHtmlToLexical.test.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.test.ts
@@ -30,6 +30,51 @@ describe('enhancedHtmlToLexical', () => {
       expect(result.root.children[0].type).toBe('paragraph');
       expect(result.root.children[0].children[0].text).toBe('Test paragraph');
     });
+
+    it('should preserve loose top-level text and inline formatting with no wrapping <p>', () => {
+      // Matches real top11message markup: a leading <a><img></a>, then bare
+      // text, <i>/<b> inline tags, and <br> with no block wrapper at all.
+      // The top-level walk used to only iterate body.children (Elements),
+      // dropping free text nodes, and bare <i>/<b> fell through to the
+      // "unknown element" branch which lost their surrounding sentence.
+      const html = 'Vote for the next <i>Top 11 @ 11</i> and win tickets for <b>Death Cab For Cutie</b>.';
+      const result = convertHtmlToLexicalEnhanced(html);
+
+      expect(result.root.children).toHaveLength(1);
+      const para = result.root.children[0];
+      expect(para.type).toBe('paragraph');
+
+      const texts = para.children.map((n: any) => n.text);
+      expect(texts).toEqual([
+        'Vote for the next ',
+        'Top 11 @ 11',
+        ' and win tickets for ',
+        'Death Cab For Cutie',
+        '.',
+      ]);
+
+      const italic = para.children.find((n: any) => n.text === 'Top 11 @ 11');
+      expect(italic.format).toBe(2);
+      const bold = para.children.find((n: any) => n.text === 'Death Cab For Cutie');
+      expect(bold.format).toBe(1);
+    });
+
+    it('should convert a top-level <a> wrapping only an <img> into an image block', () => {
+      // Matches real top11message markup: a floated artist photo linked to
+      // the artist's site, immediately followed by loose prose. parseInlineHTML's
+      // <a> handling only produces inline (text) children, so the <img> was
+      // silently dropped when the anchor fell into the inline buffer.
+      const html = '<a href="https://example.com/artist" style="float: right;">'
+        + '<img src="https://example.com/photo.jpg"></a>Every Thursday at 11am.';
+      const result = convertHtmlToLexicalEnhanced(html);
+
+      const imageNode = result.root.children.find((n: any) => n.type === 'upload');
+      expect(imageNode).toBeDefined();
+      expect(imageNode.src).toBe('https://example.com/photo.jpg');
+
+      const textPara = result.root.children.find((n: any) => n.type === 'paragraph');
+      expect(textPara.children[0].text).toContain('Every Thursday at 11am.');
+    });
   });
 
   describe('Headings', () => {

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -201,6 +201,16 @@ function parseInlineHTML(html: string): LexicalNode[] {
 }
 
 /**
+ * True for an <a> whose only meaningful content is an <img> (e.g. legacy
+ * `<a href="artist site"><img .../></a>` thumbnails). These need block-level
+ * handling: parseInlineHTML's <a> case only produces inline children, and
+ * Lexical's upload node has no link-wrapper field to hold the href.
+ */
+function isImageOnlyAnchor(el: Element): boolean {
+  return el.tagName.toLowerCase() === 'a' && el.querySelector('img') !== null && !el.textContent?.trim();
+}
+
+/**
  * Convert HTML element to Lexical nodes
  */
 function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
@@ -252,7 +262,7 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
       };
       Array.from(element.childNodes).forEach((node) => {
         const el = node.nodeType === 1 ? (node as Element) : null;
-        if (el && blockTags.has(el.tagName.toLowerCase())) {
+        if (el && (blockTags.has(el.tagName.toLowerCase()) || isImageOnlyAnchor(el))) {
           flushInline();
           nodes.push(...htmlElementToLexicalNodes(el));
         } else if (el) {
@@ -339,6 +349,19 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
         children,
         direction: 'ltr',
       });
+    }
+  }
+
+  // Anchor wrapping only an image (e.g. legacy `<a href="artist site"
+  // style="float: right;"><img .../></a>` thumbnails). Lexical's upload node
+  // has no link-wrapper field, and parseInlineHTML's <a> handling only
+  // produces inline (text) children, so an <img> child there is silently
+  // dropped. Treat this as an image block instead -- losing the click-through
+  // is preferable to losing the photo entirely.
+  else if (isImageOnlyAnchor(element)) {
+    const img = element.querySelector('img');
+    if (img) {
+      nodes.push(...htmlElementToLexicalNodes(img));
     }
   }
 
@@ -430,7 +453,7 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
         let inlineBuffer = '';
         Array.from(cell.childNodes).forEach((node) => {
           const el = node.nodeType === 1 ? (node as Element) : null;
-          if (el && blockTags.has(el.tagName.toLowerCase())) {
+          if (el && (blockTags.has(el.tagName.toLowerCase()) || isImageOnlyAnchor(el))) {
             flushInline(inlineBuffer);
             inlineBuffer = '';
             nodes.push(...htmlElementToLexicalNodes(el));
@@ -509,7 +532,7 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
   else if (tagName === 'center') {
     const blockTags = new Set(['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'blockquote', 'table', 'hr', 'iframe', 'img']);
     const hasBlockChildren = Array.from(element.children).some(
-      (child) => blockTags.has(child.tagName.toLowerCase()),
+      (child) => blockTags.has(child.tagName.toLowerCase()) || isImageOnlyAnchor(child),
     );
 
     if (hasBlockChildren) {
@@ -606,11 +629,46 @@ export function convertHtmlToLexicalEnhanced(html: string): any {
     const dom = new JSDOM(sanitized);
     const { body } = dom.window.document;
 
-    // Convert all elements
+    // Convert all elements. Legacy markup frequently has loose inline
+    // content (bare text, <a>, <b>, <i>, <br>) directly under <body> with no
+    // wrapping <p> -- walking body.children alone would silently drop that
+    // prose (text nodes aren't Elements) or mis-handle bare inline tags
+    // (which fall through to the "unknown element" branch and lose their
+    // surrounding text). Buffer consecutive inline/text siblings into a
+    // paragraph, same as the <p> handler already does for nested block
+    // content, and only recurse per-node for genuine block-level tags.
     const children: LexicalNode[] = [];
-    Array.from(body.children).forEach((element) => {
-      children.push(...htmlElementToLexicalNodes(element as Element));
+    const topBlockTags = new Set([
+      'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'ul', 'ol', 'blockquote', 'table', 'hr', 'iframe', 'img', 'center',
+    ]);
+    let inlineBuffer = '';
+    const flushInlineBuffer = () => {
+      const inline = parseInlineHTML(inlineBuffer);
+      inlineBuffer = '';
+      if (inline.length > 0) {
+        children.push({
+          type: 'paragraph',
+          format: '',
+          indent: 0,
+          version: 1,
+          children: inline,
+          direction: 'ltr',
+        });
+      }
+    };
+    Array.from(body.childNodes).forEach((node) => {
+      const el = node.nodeType === 1 ? (node as Element) : null;
+      if (el && (topBlockTags.has(el.tagName.toLowerCase()) || isImageOnlyAnchor(el))) {
+        flushInlineBuffer();
+        children.push(...htmlElementToLexicalNodes(el));
+      } else if (el) {
+        inlineBuffer += el.outerHTML;
+      } else if (node.nodeType === 3) {
+        inlineBuffer += node.textContent ?? '';
+      }
     });
+    flushInlineBuffer();
 
     // Handle case where body has no children but has text
     if (children.length === 0 && body.textContent?.trim()) {

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -841,6 +841,12 @@ async function resolvePendingUploadNode(
     relationTo: typeof node.relationTo === 'string' ? node.relationTo : 'media',
     value: result.mediaId,
     ...(node.fields ? { fields: node.fields } : {}),
+    // Legacy <img width/height> (e.g. top11message's <img height="100">)
+    // -- carried alongside `fields` rather than merged into it, since
+    // `fields` maps 1:1 onto the Lexical upload block's own field schema
+    // and display width/height aren't part of it.
+    ...(typeof node.width === 'number' ? { width: node.width } : {}),
+    ...(typeof node.height === 'number' ? { height: node.height } : {}),
   };
 }
 

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -372,7 +372,11 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
   // that's just how this converter tracks "still needs an upload."
   else if (tagName === 'img') {
     const src = element.getAttribute('src') || '';
-    const alt = element.getAttribute('alt') || '';
+    // Media.alt is a required field; legacy <img> tags frequently have no
+    // alt attribute at all (e.g. decorative artist thumbnails), so fall
+    // back to a generic description rather than an empty string that's
+    // guaranteed to fail validation on import.
+    const alt = element.getAttribute('alt') || 'Image';
     const width = element.getAttribute('width');
     const height = element.getAttribute('height');
     const align = element.getAttribute('align');
@@ -568,6 +572,28 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
     // This is handled by the parent element
   }
 
+  // Bare inline-formatting tags at block level (e.g. a whole paragraph's
+  // content wrapped in a single <i>...</i>, which happens when an unclosed
+  // <center> upstream causes the HTML parser to nest content one level
+  // deeper than the source markup intended). These have no dedicated block
+  // case, so they used to fall into the generic "unknown element" branch
+  // below, which reads .textContent (tags already stripped) and lost any
+  // nested links/formatting. Route through parseInlineHTML on the innerHTML
+  // instead, same as the <p>/<center> inline-only branches do.
+  else if (['i', 'em', 'b', 'strong', 's', 'strike', 'u', 'code', 'span'].includes(tagName)) {
+    const children = parseInlineHTML(element.outerHTML);
+    if (children.length > 0) {
+      nodes.push({
+        type: 'paragraph',
+        format: '',
+        indent: 0,
+        version: 1,
+        children,
+        direction: 'ltr',
+      });
+    }
+  }
+
   // Unknown elements - extract text content
   else {
     const text = element.textContent?.trim();
@@ -657,15 +683,30 @@ export function convertHtmlToLexicalEnhanced(html: string): any {
         });
       }
     };
+    // A double <br><br> is the legacy convention for a paragraph break (the
+    // real content has no <p> tags at all, just prose separated this way).
+    // Track a run of consecutive <br> siblings so two-in-a-row flushes the
+    // buffer as its own paragraph instead of being appended as literal tags.
+    let consecutiveBrCount = 0;
     Array.from(body.childNodes).forEach((node) => {
       const el = node.nodeType === 1 ? (node as Element) : null;
+      const isBr = el?.tagName.toLowerCase() === 'br';
       if (el && (topBlockTags.has(el.tagName.toLowerCase()) || isImageOnlyAnchor(el))) {
         flushInlineBuffer();
         children.push(...htmlElementToLexicalNodes(el));
+        consecutiveBrCount = 0;
+      } else if (isBr) {
+        consecutiveBrCount += 1;
+        if (consecutiveBrCount >= 2) {
+          flushInlineBuffer();
+          consecutiveBrCount = 0;
+        }
       } else if (el) {
         inlineBuffer += el.outerHTML;
+        consecutiveBrCount = 0;
       } else if (node.nodeType === 3) {
         inlineBuffer += node.textContent ?? '';
+        if (node.textContent?.trim()) consecutiveBrCount = 0;
       }
     });
     flushInlineBuffer();

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -507,7 +507,7 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
 
   // Center element - process children and apply center alignment to block nodes
   else if (tagName === 'center') {
-    const blockTags = new Set(['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'blockquote', 'table', 'hr']);
+    const blockTags = new Set(['p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'blockquote', 'table', 'hr', 'iframe', 'img']);
     const hasBlockChildren = Array.from(element.children).some(
       (child) => blockTags.has(child.tagName.toLowerCase()),
     );

--- a/bin/migrations/shared/enhancedHtmlToLexical.ts
+++ b/bin/migrations/shared/enhancedHtmlToLexical.ts
@@ -60,6 +60,12 @@ function sanitizeHtml(html: string): string {
       'class', 'id',
       'value',
       'data-*',
+      // Legacy markup floats images via inline style rather than the align
+      // attribute (e.g. `<a style="float: right;"><img/></a>` artist
+      // thumbnails). DOMPurify sanitizes the CSS value itself (strips
+      // javascript:/expression() etc.); this converter only ever reads
+      // `float` back out of it, never re-emits the raw attribute.
+      'style',
     ],
     ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i,
     KEEP_CONTENT: true,
@@ -361,6 +367,18 @@ function htmlElementToLexicalNodes(element: Element): LexicalNode[] {
   else if (isImageOnlyAnchor(element)) {
     const img = element.querySelector('img');
     if (img) {
+      // The <img> itself rarely carries alignment; legacy markup puts the
+      // float on the wrapping <a> instead (`style="float: right;"`), which
+      // htmlElementToLexicalNodes(img) can't see since it only inspects the
+      // element it's handed. Copy it onto the <img> before recursing so the
+      // upload node's alignment field ends up correct.
+      if (!img.getAttribute('align')) {
+        const anchorFloat = (element as HTMLElement).style?.float
+          || (element.getAttribute('style')?.match(/float:\s*(left|right)/)?.[1] ?? '');
+        if (anchorFloat === 'left' || anchorFloat === 'right') {
+          img.setAttribute('align', anchorFloat);
+        }
+      }
       nodes.push(...htmlElementToLexicalNodes(img));
     }
   }

--- a/e2e/top11.spec.ts
+++ b/e2e/top11.spec.ts
@@ -22,6 +22,7 @@ const test = baseTest.extend({
 
 // Legacy PHP site URL
 const LEGACY_BASE_URL = 'http://localhost:8080';
+const POSTGRES_URL = `${LEGACY_BASE_URL}/top11.php?ff=use_postgres_top11`;
 
 test.describe('Top 11 @ 11 (Legacy PHP)', () => {
   test.beforeEach(async ({ page }) => {
@@ -217,5 +218,73 @@ test.describe('Top 11 @ 11 (Legacy PHP)', () => {
     await expect(listHeading).toBeVisible();
 
     await captureScreenshot(page, testInfo, '07-Top11-Heading-Structure');
+  });
+});
+
+// PostgresTop11 adapter path -- same top11.php page, ?ff=use_postgres_top11
+// swaps Top11Factory's implementation from SqlTop11 to PostgresTop11 (see
+// src/models/Top11Factory.php). use_postgres_top11 stays false by default in
+// production; this is the parity check confirming the Postgres path renders
+// the same page shape as the legacy MySQL path before that flag ever flips.
+test.describe('Top 11 @ 11 (Postgres adapter)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.waitForTimeout(1000);
+  });
+
+  test('page loads without PHP errors on the Postgres path', async ({ page }, testInfo) => {
+    const { status } = await navigateWithRetry(page, POSTGRES_URL);
+
+    expect(status).toBe(200);
+
+    const pageContent = await page.content();
+    const phpErrors = checkForPhpErrors(pageContent);
+    expect(phpErrors).toEqual([]);
+
+    await expect(page.getByRole('heading', { name: 'Top 11 @ 11', exact: true })).toBeVisible();
+
+    await captureScreenshot(page, testInfo, '08-Top11-Postgres-Page-Loaded');
+  });
+
+  test('displays the same ranked chart table as the legacy MySQL path', async ({
+    page,
+  }, testInfo) => {
+    await navigateWithRetry(page, POSTGRES_URL);
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+
+    const tableRows = page.locator('table tr');
+    const rowCount = await tableRows.count();
+    expect(rowCount).toBeGreaterThan(0);
+
+    await captureScreenshot(page, testInfo, '09-Top11-Postgres-List-Table');
+  });
+
+  test('nominee checkbox count matches the legacy path when voting is open', async ({
+    page,
+  }, testInfo) => {
+    await navigateWithRetry(page, POSTGRES_URL);
+
+    const votingForm = page.locator('form[name="top11"]');
+    const isFormVisible = await votingForm.isVisible().catch(() => false);
+    test.skip(!isFormVisible, 'Voting form not visible; voting closed or not logged in');
+
+    const postgresCheckboxCount = await page
+      .locator('input[type="checkbox"][name="top11[]"]')
+      .count();
+    expect(postgresCheckboxCount).toBeGreaterThan(0);
+
+    await navigateWithRetry(page, `${LEGACY_BASE_URL}/top11.php`);
+    const legacyCheckboxCount = await page
+      .locator('input[type="checkbox"][name="top11[]"]')
+      .count();
+
+    // Both paths read the same underlying nominee pool for the active
+    // contest -- PostgresTop11::getAllSongs() reads Top11Contests.nominees,
+    // SqlTop11::getAllSongs() reads top11songs directly. A mismatch here
+    // means the two data sources have drifted.
+    expect(postgresCheckboxCount).toBe(legacyCheckboxCount);
+
+    await captureScreenshot(page, testInfo, '10-Top11-Postgres-Checkbox-Parity');
   });
 });

--- a/payload/migrations/20260706_220000_relax_top11_votes_voterkey_uniqueness.ts
+++ b/payload/migrations/20260706_220000_relax_top11_votes_voterkey_uniqueness.ts
@@ -1,0 +1,23 @@
+import { sql } from '@payloadcms/db-postgres';
+import type { MigrateUpArgs, MigrateDownArgs } from '@payloadcms/db-postgres';
+
+// Legacy MySQL lets one voter pick up to 3 songs per week (independent
+// per-song counters, no per-voter-per-song row). The original
+// (contest_id, voter_key) unique index only allowed one vote row per voter
+// per contest at all -- correct for "has this voter voted" dedup, but it
+// silently prevented a voter from ever casting more than one of their three
+// picks. Relaxing to (contest_id, voter_key, song_id) keeps a voter from
+// voting for the same song twice while allowing up to 3 distinct songs.
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "top11_votes_contest_voter_key_idx";
+    CREATE UNIQUE INDEX "top11_votes_contest_voter_key_song_idx" ON "top11_votes" USING btree ("contest_id", "voter_key", "song_id");
+  `)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "top11_votes_contest_voter_key_song_idx";
+    CREATE UNIQUE INDEX "top11_votes_contest_voter_key_idx" ON "top11_votes" USING btree ("contest_id", "voter_key");
+  `)
+}

--- a/payload/migrations/index.ts
+++ b/payload/migrations/index.ts
@@ -18,6 +18,7 @@ import * as migration_20260704_000000_add_top11_votes_voterkey_field from './202
 import * as migration_20260705_000000_drop_top11_recording_fields from './20260705_000000_drop_top11_recording_fields';
 import * as migration_20260706_202828_add_top11_contests_nominees from './20260706_202828_add_top11_contests_nominees';
 import * as migration_20260706_210000_add_top11_votes_nominee_constraint from './20260706_210000_add_top11_votes_nominee_constraint';
+import * as migration_20260706_220000_relax_top11_votes_voterkey_uniqueness from './20260706_220000_relax_top11_votes_voterkey_uniqueness';
 import * as migration_20260405_000000_add_year_end_poll_tables from './20260405_000000_add_year_end_poll_tables';
 
 export const migrations = [
@@ -120,6 +121,11 @@ export const migrations = [
     up: migration_20260706_210000_add_top11_votes_nominee_constraint.up,
     down: migration_20260706_210000_add_top11_votes_nominee_constraint.down,
     name: '20260706_210000_add_top11_votes_nominee_constraint',
+  },
+  {
+    up: migration_20260706_220000_relax_top11_votes_voterkey_uniqueness.up,
+    down: migration_20260706_220000_relax_top11_votes_voterkey_uniqueness.down,
+    name: '20260706_220000_relax_top11_votes_voterkey_uniqueness',
   },
   {
     up: migration_20260405_000000_add_year_end_poll_tables.up,

--- a/payload/src/collections/Top11Votes.test.ts
+++ b/payload/src/collections/Top11Votes.test.ts
@@ -92,13 +92,35 @@ describe('Top11Votes', () => {
       );
     });
 
-    it('rejects a duplicate vote from the same voter identity', async () => {
+    it('rejects a duplicate vote for the same song from the same voter identity', async () => {
       const req = makeReq(openContestWithNominees, { docs: [{ id: 5 }] });
       const data = { contest: 1, song: 10, voterEmail: 'jane@example.com' };
 
       await expect(beforeChangeHook?.({ operation: 'create', data, req } as never)).rejects.toThrow(
-        'This voter has already voted in the current Top 11 contest',
+        'This voter has already voted for this song',
       );
+      expect(req.payload.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            and: [
+              { contest: { equals: 1 } },
+              { song: { equals: 10 } },
+              { voterEmail: { equals: 'jane@example.com' } },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('allows a voter to vote for a second, different nominee song in the same contest', async () => {
+      // Legacy MySQL lets one voter pick up to 3 songs (see
+      // 20260706_220000_relax_top11_votes_voterkey_uniqueness); this hook's
+      // dedup check must be scoped per-song, not per-contest, to match.
+      const req = makeReq(openContestWithNominees, { docs: [] });
+      const data = { contest: 1, song: 20, voterEmail: 'jane@example.com' };
+
+      const result = await beforeChangeHook?.({ operation: 'create', data, req } as never);
+      expect(result).toMatchObject({ song: 20 });
     });
 
     it('allows the first vote for a new voter identity', async () => {

--- a/payload/src/collections/Top11Votes.ts
+++ b/payload/src/collections/Top11Votes.ts
@@ -99,7 +99,7 @@ export const Top11Votes: CollectionConfig = {
         const existingVotes = await req.payload.find({
           collection: 'top11-votes',
           where: {
-            and: [{ contest: { equals: contestId } }, identityWhere],
+            and: [{ contest: { equals: contestId } }, { song: { equals: songId } }, identityWhere],
           },
           req,
           overrideAccess: true,
@@ -108,7 +108,7 @@ export const Top11Votes: CollectionConfig = {
         });
 
         if (existingVotes.docs.length > 0) {
-          throw new APIError('This voter has already voted in the current Top 11 contest', 409);
+          throw new APIError('This voter has already voted for this song', 409);
         }
 
         return data;

--- a/src/models/Concerns/ConvertsLexicalToHtml.php
+++ b/src/models/Concerns/ConvertsLexicalToHtml.php
@@ -263,7 +263,19 @@ trait ConvertsLexicalToHtml
         $alt = htmlspecialchars((string)($mediaMap[(int)$id]['alt'] ?? ''), ENT_QUOTES, 'UTF-8');
         $src = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
 
-        return "<img class=\"{$class}\" src=\"{$src}\" alt=\"{$alt}\" loading=\"lazy\">\n";
+        // Legacy <img width/height> (e.g. top11message's <img height="100">
+        // artist thumbnail) -- .lexical-image's `max-width: 100%; height:
+        // auto;` CSS keeps these responsive rather than hard-fixing size,
+        // matching the legacy rendered size only as an intrinsic hint.
+        $dimensionAttrs = '';
+        if (is_numeric($node['width'] ?? null)) {
+            $dimensionAttrs .= ' width="' . (int)$node['width'] . '"';
+        }
+        if (is_numeric($node['height'] ?? null)) {
+            $dimensionAttrs .= ' height="' . (int)$node['height'] . '"';
+        }
+
+        return "<img class=\"{$class}\" src=\"{$src}\" alt=\"{$alt}\"{$dimensionAttrs} loading=\"lazy\">\n";
     }
 
     /**

--- a/src/models/Top11Factory.php
+++ b/src/models/Top11Factory.php
@@ -5,7 +5,12 @@ namespace YNotRadio\Models;
 
 require_once(__DIR__ . "/Top11.php");
 require_once(__DIR__ . "/implementations/SqlTop11.php");
+require_once(__DIR__ . "/implementations/PostgresTop11.php");
 require_once(__DIR__ . "/FeatureManager.php");
+require_once(__DIR__ . "/../lib/Database.php");
+
+use YNotRadio\Models\Implementations\PostgresTop11;
+use YNotRadio\Lib\Database;
 
 /**
  * Factory class for creating Top11 model instances
@@ -15,13 +20,21 @@ class Top11Factory
     /**
      * Create a new Top11 model instance
      *
+     * Top11 reads/writes are flagged between MySQL and Postgres while the
+     * Postgres/Payload adapter is validated. When `use_postgres_top11` is
+     * enabled the visitor-facing page reads/writes Postgres; otherwise (the
+     * default) it falls back to MySQL. The legacy CP admin screens
+     * (top11_operations.php etc.) are superseded by Payload's Contest
+     * Controls tab and are not supported by PostgresTop11 -- see its class
+     * doc comment.
+     *
      * @param \mysqli $db Database connection
      * @return Top11 An implementation of the Top11 interface
      */
     public static function create(\mysqli $db): Top11
     {
         if (FeatureManager::isEnabled('use_postgres_top11')) {
-            error_log('use_postgres_top11 is enabled, but Top11 PostgreSQL/Payload adapter is not implemented yet. Falling back to MySQL.');
+            return new PostgresTop11(Database::getPostgres());
         }
 
         return new \YNotRadio\Models\Implementations\SqlTop11($db);

--- a/src/models/implementations/PostgresTop11.php
+++ b/src/models/implementations/PostgresTop11.php
@@ -1,0 +1,426 @@
+<?php
+
+namespace YNotRadio\Models\Implementations;
+
+use YNotRadio\Models\Top11;
+use YNotRadio\Models\Concerns\ConvertsLexicalToHtml;
+use PDO;
+
+/**
+ * PostgreSQL implementation of the Top11 interface.
+ * Reads and writes the top11_contests / top11_votes / top11_write_ins /
+ * top11_contestants tables managed by Payload's Top11 collections.
+ *
+ * Only the methods top11.php and _top11_save.php actually call are fully
+ * implemented (getMessage, getAll, getStatus, getAllSongs,
+ * hasUserVotedThisWeek, recordUserVote, addContestant, addVote, addWriteIn).
+ * The remaining interface methods back the legacy CP admin screens
+ * (top11_operations.php, top11_song_*.php, etc.), which Payload's Contest
+ * Controls tab (see PR #799) has superseded -- they throw instead of
+ * reimplementing CP semantics against Payload's immutable, versioned contest
+ * model, which doesn't map cleanly onto free-editable MySQL rows.
+ */
+class PostgresTop11 implements Top11
+{
+    use ConvertsLexicalToHtml;
+
+    private PDO $db;
+
+    /** Payload ID of the currently open (or most recently created) contest. */
+    private ?int $contestId = null;
+
+    public function __construct(PDO $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Resolve the contest to serve: the open contest if one exists, otherwise
+     * the most recently created contest (so a just-closed week is still
+     * readable instead of the page going blank between weeks).
+     */
+    private function getActiveContestId(): ?int
+    {
+        if ($this->contestId !== null) {
+            return $this->contestId;
+        }
+
+        $stmt = $this->db->prepare("
+            SELECT id FROM top11_contests
+            ORDER BY (status = 'open') DESC, week_of DESC
+            LIMIT 1
+        ");
+        $stmt->execute();
+        $row = $stmt->fetch();
+
+        $this->contestId = $row ? (int)$row['id'] : null;
+        return $this->contestId;
+    }
+
+    /** {@inheritdoc} */
+    public function getMessage(): array
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            return ['id' => 1, 'message' => ''];
+        }
+
+        $stmt = $this->db->prepare("
+            SELECT message_snapshot_headline, message_snapshot_body
+            FROM top11_contests WHERE id = :id
+        ");
+        $stmt->execute([':id' => $contestId]);
+        $row = $stmt->fetch();
+
+        if (!$row) {
+            return ['id' => 1, 'message' => ''];
+        }
+
+        $html = $this->convertLexicalToHtml($row['message_snapshot_body']);
+        return ['id' => 1, 'message' => $html];
+    }
+
+    /** {@inheritdoc} */
+    public function getAll(): array
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            return [];
+        }
+
+        $stmt = $this->db->prepare("
+            SELECT c.week_of, e.\"_order\" AS display_order, e.song_id, e.weekly_note,
+                   s.title AS song_title, a.name AS artist_name
+            FROM top11_contests_entries e
+            JOIN top11_contests c ON c.id = e._parent_id
+            LEFT JOIN songs s ON s.id = e.song_id
+            LEFT JOIN artists a ON a.id = s.artist_id
+            WHERE e._parent_id = :id
+            ORDER BY e.\"_order\"
+        ");
+        $stmt->execute([':id' => $contestId]);
+
+        $entries = [];
+        while ($row = $stmt->fetch()) {
+            $entries[] = [
+                'placement' => (int)$row['display_order'],
+                'artist' => $row['artist_name'] ?? '',
+                'song' => $row['song_title'] ?? '',
+                'note' => $row['weekly_note'] ? $this->convertLexicalToHtml($row['weekly_note']) : '',
+            ];
+        }
+
+        // top11.php reads placement 99 as the week-of title row and 98 as
+        // the status row, matching the legacy top11 table's sentinel rows.
+        $stmt = $this->db->prepare("SELECT week_of, status FROM top11_contests WHERE id = :id");
+        $stmt->execute([':id' => $contestId]);
+        $contest = $stmt->fetch();
+
+        $entries[] = ['placement' => 99, 'artist' => $this->formatWeekOf($contest['week_of']), 'song' => '', 'note' => ''];
+        $entries[] = ['placement' => 98, 'artist' => $contest['status'] === 'open' ? 'open' : 'closed', 'song' => '', 'note' => ''];
+
+        return $entries;
+    }
+
+    private function formatWeekOf(string $weekOf): string
+    {
+        $date = new \DateTime($weekOf);
+        return $date->format('l, F j, Y');
+    }
+
+    /** {@inheritdoc} */
+    public function getStatus(): string
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            return 'closed';
+        }
+
+        $stmt = $this->db->prepare("SELECT status FROM top11_contests WHERE id = :id");
+        $stmt->execute([':id' => $contestId]);
+        $row = $stmt->fetch();
+
+        return ($row && $row['status'] === 'open') ? 'open' : 'closed';
+    }
+
+    /** {@inheritdoc} */
+    public function getAllSongs(): array
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            return [];
+        }
+
+        // Distinct from getAll()'s entries: this is the nominee ballot voters
+        // choose from, not last week's ranked results.
+        $stmt = $this->db->prepare("
+            SELECT n.song_id AS id, s.title AS song, a.name AS artist
+            FROM top11_contests_nominees n
+            LEFT JOIN songs s ON s.id = n.song_id
+            LEFT JOIN artists a ON a.id = s.artist_id
+            WHERE n._parent_id = :id
+            ORDER BY a.name, s.title
+        ");
+        $stmt->execute([':id' => $contestId]);
+
+        $songs = [];
+        while ($row = $stmt->fetch()) {
+            $songs[] = [
+                'id' => (int)$row['id'],
+                'song' => $row['song'] ?? '',
+                'artist' => $row['artist'] ?? '',
+            ];
+        }
+
+        return $songs;
+    }
+
+    /** {@inheritdoc} */
+    public function addVote(int $id): bool
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            throw new \Exception('No active Top 11 contest to vote in');
+        }
+
+        // The nominee-pool check mirrors Top11Votes' beforeChange hook; the
+        // real guarantee is the top11_votes_song_is_nominee DB trigger (see
+        // migration 20260706_210000_add_top11_votes_nominee_constraint),
+        // which will also reject this insert if the check below is ever
+        // wrong or bypassed.
+        $stmt = $this->db->prepare("
+            SELECT 1 FROM top11_contests_nominees WHERE _parent_id = :cid AND song_id = :sid
+        ");
+        $stmt->execute([':cid' => $contestId, ':sid' => $id]);
+        if (!$stmt->fetch()) {
+            throw new \Exception('This song is not on the ballot for this contest');
+        }
+
+        // ON CONFLICT DO NOTHING against the (contest_id, voter_key, song_id)
+        // unique index (see migration
+        // 20260706_220000_relax_top11_votes_voterkey_uniqueness): a voter
+        // resubmitting the same song is a no-op, not an error, matching
+        // legacy MySQL's idempotent counter-increment semantics.
+        $stmt = $this->db->prepare("
+            INSERT INTO top11_votes (contest_id, song_id, voter_email, voter_auth0_id, vote_source, updated_at, created_at)
+            VALUES (:contest_id, :song_id, :voter_email, :voter_auth0_id, 'web', NOW(), NOW())
+            ON CONFLICT DO NOTHING
+        ");
+        return $stmt->execute([
+            ':contest_id' => $contestId,
+            ':song_id' => $id,
+            ':voter_email' => $this->pendingVoterEmail ?: null,
+            ':voter_auth0_id' => $this->pendingVoterAuth0Id ?: null,
+        ]);
+    }
+
+    /**
+     * top11.php calls addVote() once per checked song without passing voter
+     * identity (it's carried separately via recordUserVote's parameters), so
+     * _top11_save.php must set these before calling addVote() in a loop.
+     * Kept as adapter-only state, not part of the Top11 interface, since
+     * MySQL's addVote($id) genuinely takes no voter argument either.
+     */
+    public string $pendingVoterEmail = '';
+    public string $pendingVoterAuth0Id = '';
+
+    /** {@inheritdoc} */
+    public function addContestant(string $firstname, string $lastname, string $email, string $phone, string $contest, string $newsletter): bool
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            throw new \Exception('No active Top 11 contest to enter');
+        }
+
+        $stmt = $this->db->prepare("
+            INSERT INTO top11_contestants
+                (contest_id, first_name, last_name, email, phone, entered_contest, newsletter_opt_in, display, updated_at, created_at)
+            VALUES
+                (:contest_id, :first_name, :last_name, :email, :phone, :entered_contest, :newsletter_opt_in, true, NOW(), NOW())
+        ");
+        return $stmt->execute([
+            ':contest_id' => $contestId,
+            ':first_name' => $firstname,
+            ':last_name' => $lastname,
+            ':email' => $email,
+            ':phone' => $phone,
+            // PDO's native (non-emulated) pgsql prepares don't reliably bind
+            // native PHP bools -- Postgres accepts the 'true'/'false' string
+            // literals directly for boolean columns.
+            ':entered_contest' => $contest === 'yes' ? 'true' : 'false',
+            ':newsletter_opt_in' => $newsletter === 'yes' ? 'true' : 'false',
+        ]);
+    }
+
+    /** {@inheritdoc} */
+    public function addWriteIn(string $writeIn): bool
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            throw new \Exception('No active Top 11 contest to write in for');
+        }
+
+        $stmt = $this->db->prepare("
+            INSERT INTO top11_write_ins (contest_id, write_in, display, updated_at, created_at)
+            VALUES (:contest_id, :write_in, true, NOW(), NOW())
+        ");
+        return $stmt->execute([':contest_id' => $contestId, ':write_in' => $writeIn]);
+    }
+
+    /** {@inheritdoc} */
+    public function hasUserVotedThisWeek(string $userEmail, ?string $auth0Id = null): bool
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId || empty($userEmail)) {
+            return false;
+        }
+
+        $stmt = $this->db->prepare("
+            SELECT 1 FROM top11_votes
+            WHERE contest_id = :contest_id
+              AND (voter_email = :email OR (:auth0_id != '' AND voter_auth0_id = :auth0_id))
+            LIMIT 1
+        ");
+        $stmt->execute([
+            ':contest_id' => $contestId,
+            ':email' => $userEmail,
+            ':auth0_id' => $auth0Id ?? '',
+        ]);
+
+        return (bool)$stmt->fetch();
+    }
+
+    /** {@inheritdoc} */
+    public function recordUserVote(string $userEmail, ?string $auth0Id = null): bool
+    {
+        // Legacy MySQL tracks "has this user voted" as a separate table from
+        // the per-song vote rows; Postgres's schema uses top11_votes' own
+        // voter_email/voter_auth0_id columns for the same purpose, so this
+        // is a no-op check rather than a second insert. addVote() is what
+        // actually records the vote; this just needs to hand the voter
+        // identity to it before the caller's addVote() loop runs.
+        $this->pendingVoterEmail = $userEmail;
+        $this->pendingVoterAuth0Id = $auth0Id ?? '';
+        return true;
+    }
+
+    /** {@inheritdoc} */
+    public function getCurrentVotingWeek(): string
+    {
+        $contestId = $this->getActiveContestId();
+        if (!$contestId) {
+            return 'current';
+        }
+
+        $stmt = $this->db->prepare("SELECT week_of FROM top11_contests WHERE id = :id");
+        $stmt->execute([':id' => $contestId]);
+        $row = $stmt->fetch();
+
+        return $row ? $row['week_of'] : 'current';
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // CP-only methods: Payload's Contest Controls tab (PR #799) supersedes
+    // the legacy CP screens that call these. They throw instead of silently
+    // no-op-ing so a flag flip surfaces the retirement clearly rather than
+    // failing quietly.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private function cpRetired(string $method): never
+    {
+        throw new \Exception(
+            "Top11::{$method}() is not available on the Postgres adapter -- "
+                . 'use the Payload admin Contest Controls tab instead of the legacy CP screens.'
+        );
+    }
+
+    /** {@inheritdoc} */
+    public function getById(int $id): ?array
+    {
+        $this->cpRetired('getById');
+    }
+
+    /** {@inheritdoc} */
+    public function toggleStatus(string $currentStatus): bool
+    {
+        $this->cpRetired('toggleStatus');
+    }
+
+    /** {@inheritdoc} */
+    public function update(int $placement, string $artist, string $song, string $note): bool
+    {
+        $this->cpRetired('update');
+    }
+
+    /** {@inheritdoc} */
+    public function updateDate(string $date): bool
+    {
+        $this->cpRetired('updateDate');
+    }
+
+    /** {@inheritdoc} */
+    public function updateMessage(string $message): bool
+    {
+        $this->cpRetired('updateMessage');
+    }
+
+    /** {@inheritdoc} */
+    public function addSong(string $artist, string $song): int
+    {
+        $this->cpRetired('addSong');
+    }
+
+    /** {@inheritdoc} */
+    public function updateSong(int $id, string $artist, string $song): bool
+    {
+        $this->cpRetired('updateSong');
+    }
+
+    /** {@inheritdoc} */
+    public function deleteSong(int $id): bool
+    {
+        $this->cpRetired('deleteSong');
+    }
+
+    /** {@inheritdoc} */
+    public function getSong(int $id): ?array
+    {
+        $this->cpRetired('getSong');
+    }
+
+    /** {@inheritdoc} */
+    public function getAllContestants(): array
+    {
+        $this->cpRetired('getAllContestants');
+    }
+
+    /** {@inheritdoc} */
+    public function getContestantCount(): string
+    {
+        $this->cpRetired('getContestantCount');
+    }
+
+    /** {@inheritdoc} */
+    public function pickWinner(): array
+    {
+        $this->cpRetired('pickWinner');
+    }
+
+    /** {@inheritdoc} */
+    public function getNewsletterSignups(): array
+    {
+        $this->cpRetired('getNewsletterSignups');
+    }
+
+    /** {@inheritdoc} */
+    public function getAllWriteIns(): array
+    {
+        $this->cpRetired('getAllWriteIns');
+    }
+
+    /** {@inheritdoc} */
+    public function reset(): bool
+    {
+        $this->cpRetired('reset');
+    }
+}

--- a/src/models/implementations/PostgresTop11.php
+++ b/src/models/implementations/PostgresTop11.php
@@ -261,10 +261,14 @@ class PostgresTop11 implements Top11
         }
 
         $stmt = $this->db->prepare("
-            INSERT INTO top11_write_ins (contest_id, write_in, display, updated_at, created_at)
-            VALUES (:contest_id, :write_in, true, NOW(), NOW())
+            INSERT INTO top11_write_ins (contest_id, write_in, voter_email, display, updated_at, created_at)
+            VALUES (:contest_id, :write_in, :voter_email, true, NOW(), NOW())
         ");
-        return $stmt->execute([':contest_id' => $contestId, ':write_in' => $writeIn]);
+        return $stmt->execute([
+            ':contest_id' => $contestId,
+            ':write_in' => $writeIn,
+            ':voter_email' => $this->pendingVoterEmail ?: null,
+        ]);
     }
 
     /** {@inheritdoc} */

--- a/src/models/implementations/PostgresTop11.php
+++ b/src/models/implementations/PostgresTop11.php
@@ -124,8 +124,10 @@ class PostgresTop11 implements Top11
 
     private function formatWeekOf(string $weekOf): string
     {
+        // Matches legacy MySQL's placement-99 date row verbatim (e.g. "July 2,
+        // 2026", no weekday) -- SqlTop11::getAll() returns that string as-is.
         $date = new \DateTime($weekOf);
-        return $date->format('l, F j, Y');
+        return $date->format('F j, Y');
     }
 
     /** {@inheritdoc} */

--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -303,7 +303,12 @@ nav a:hover {
   float: none;
 }
 
-.top11-message img {
+/* Excludes .lexical-image -- the Postgres/Payload adapter's rendered images
+   carry their own float/alignment via .lexical-image--left/right/center
+   (see below), and this legacy rule's higher specificity (class+tag vs.
+   those rules' single class) would otherwise always win and force every
+   Lexical image left regardless of its actual alignment field. */
+.top11-message img:not(.lexical-image) {
   float: left;
   width: 100px;
   margin: 0 10px 0 5px;

--- a/src/style/typography.css
+++ b/src/style/typography.css
@@ -418,9 +418,17 @@ nav a:hover {
 }
 
 /* Lexical upload nodes (ConvertsLexicalToHtml's renderLexicalUploadNode).
-   Matches the float/wrap behavior of legacy <img align="left|right">. */
+   Matches the float/wrap behavior of legacy <img align="left|right">.
+   `height: auto` only applies when there's no explicit height attribute --
+   legacy markup like top11message's <img height="100"> relies on the
+   browser's native aspect-ratio-preserving behavior for that one dimension,
+   which forcing `height: auto` here would override and blow up to the
+   image's full natural size instead. */
 .lexical-image {
   max-width: 100%;
+}
+
+.lexical-image:not([height]) {
   height: auto;
 }
 

--- a/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
+++ b/src/tests/Models/Concerns/ConvertsLexicalToHtmlTest.php
@@ -534,6 +534,34 @@ class ConvertsLexicalToHtmlTest extends TestCase
         $this->assertStringContainsString('lexical-image--left', $html);
     }
 
+    public function testUploadNodeRendersLegacyWidthAndHeightAttributes(): void
+    {
+        // Matches top11message's <img height="100"> artist thumbnail --
+        // width/height need to render as real HTML attributes so the
+        // browser's native aspect-ratio sizing applies (the .lexical-image
+        // CSS only forces height:auto when no height attribute is present).
+        $db = new \PDO('sqlite::memory:');
+        $db->exec('CREATE TABLE media (id INTEGER PRIMARY KEY, url TEXT, alt TEXT)');
+        $db->exec("INSERT INTO media (id, url, alt) VALUES (9, 'https://cdn.example/thumb.jpg', '')");
+        $converter = new ConvertsLexicalToHtmlTestHarness($db);
+
+        $html = $converter->convert(json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'upload',
+                        'relationTo' => 'media',
+                        'value' => 9,
+                        'height' => 100,
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertStringContainsString('height="100"', $html);
+        $this->assertStringNotContainsString('width="', $html);
+    }
+
     public function testUploadNodeRendersNothingWhenMediaMissing(): void
     {
         $db = new \PDO('sqlite::memory:');

--- a/src/tests/Models/PostgresTop11Test.php
+++ b/src/tests/Models/PostgresTop11Test.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace YNotRadio\Tests\Models;
+
+use YNotRadio\Tests\TestCase;
+use YNotRadio\Models\Implementations\PostgresTop11;
+use PDO;
+use PDOStatement;
+
+/**
+ * Tests for PostgresTop11 -- the adapter behind top11.php once
+ * use_postgres_top11 is enabled.
+ *
+ * Covers the read/write paths top11.php and _top11_save.php actually call
+ * (getMessage, getAll, getStatus, getAllSongs, hasUserVotedThisWeek,
+ * recordUserVote, addContestant, addVote, addWriteIn) plus the CP-only
+ * methods, which are intentionally unsupported (Payload's Contest Controls
+ * tab supersedes the legacy CP screens that would call them).
+ */
+class PostgresTop11Test extends TestCase
+{
+    private PostgresTop11 $top11;
+    private PDO $mockDb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockDb = $this->createMock(PDO::class);
+        $this->top11 = new PostgresTop11($this->mockDb);
+    }
+
+    private function lexical(string $text): string
+    {
+        return json_encode([
+            'root' => [
+                'children' => [
+                    [
+                        'type' => 'paragraph',
+                        'children' => [['type' => 'text', 'text' => $text]],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function stubActiveContest(int $contestId): PDOStatement
+    {
+        $contestStmt = $this->createMock(PDOStatement::class);
+        $contestStmt->method('execute')->willReturn(true);
+        $contestStmt->method('fetch')->willReturn(['id' => $contestId]);
+        return $contestStmt;
+    }
+
+    public function testGetMessageRendersLexicalToHtml(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+
+        $messageStmt = $this->createMock(PDOStatement::class);
+        $messageStmt->method('execute')->willReturn(true);
+        $messageStmt->method('fetch')->willReturn([
+            'message_snapshot_headline' => 'Top 11 @ 11 for June 25, 2026',
+            'message_snapshot_body' => $this->lexical('Vote for your favorites'),
+        ]);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $messageStmt);
+
+        $result = $this->top11->getMessage();
+
+        $this->assertStringContainsString('Vote for your favorites', $result['message']);
+    }
+
+    public function testGetMessageReturnsEmptyWhenNoActiveContest(): void
+    {
+        $noContestStmt = $this->createMock(PDOStatement::class);
+        $noContestStmt->method('execute')->willReturn(true);
+        $noContestStmt->method('fetch')->willReturn(false);
+        $this->mockDb->method('prepare')->willReturn($noContestStmt);
+
+        $result = $this->top11->getMessage();
+
+        $this->assertSame('', $result['message']);
+    }
+
+    public function testGetStatusReturnsOpenWhenContestIsOpen(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $statusStmt = $this->createMock(PDOStatement::class);
+        $statusStmt->method('execute')->willReturn(true);
+        $statusStmt->method('fetch')->willReturn(['status' => 'open']);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $statusStmt);
+
+        $this->assertSame('open', $this->top11->getStatus());
+    }
+
+    public function testGetStatusReturnsClosedWhenContestIsNotOpen(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $statusStmt = $this->createMock(PDOStatement::class);
+        $statusStmt->method('execute')->willReturn(true);
+        $statusStmt->method('fetch')->willReturn(['status' => 'closed']);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $statusStmt);
+
+        $this->assertSame('closed', $this->top11->getStatus());
+    }
+
+    public function testGetAllSongsReturnsNomineePoolNotEntries(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $nomineesStmt = $this->createMock(PDOStatement::class);
+        $nomineesStmt->method('execute')->willReturn(true);
+        $nomineesStmt->method('fetch')->willReturnOnConsecutiveCalls(
+            ['id' => 10, 'song' => 'Chance To Bleed', 'artist' => 'Kurt Vile'],
+            ['id' => 20, 'song' => 'Sun Has Set', 'artist' => 'beabadoobee'],
+            false,
+        );
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $nomineesStmt);
+
+        $songs = $this->top11->getAllSongs();
+
+        $this->assertCount(2, $songs);
+        $this->assertSame(['id' => 10, 'song' => 'Chance To Bleed', 'artist' => 'Kurt Vile'], $songs[0]);
+    }
+
+    public function testGetAllSongsReturnsEmptyWhenNoActiveContest(): void
+    {
+        $noContestStmt = $this->createMock(PDOStatement::class);
+        $noContestStmt->method('execute')->willReturn(true);
+        $noContestStmt->method('fetch')->willReturn(false);
+        $this->mockDb->method('prepare')->willReturn($noContestStmt);
+
+        $this->assertSame([], $this->top11->getAllSongs());
+    }
+
+    public function testAddVoteRejectsASongNotInTheNomineePool(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $nomineeCheckStmt = $this->createMock(PDOStatement::class);
+        $nomineeCheckStmt->method('execute')->willReturn(true);
+        $nomineeCheckStmt->method('fetch')->willReturn(false);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $nomineeCheckStmt);
+
+        $this->expectExceptionMessage('This song is not on the ballot for this contest');
+        $this->top11->addVote(999);
+    }
+
+    public function testAddVoteInsertsAVoteForANomineeSong(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $nomineeCheckStmt = $this->createMock(PDOStatement::class);
+        $nomineeCheckStmt->method('execute')->willReturn(true);
+        $nomineeCheckStmt->method('fetch')->willReturn(['1' => 1]);
+
+        $insertStmt = $this->createMock(PDOStatement::class);
+        $insertStmt->expects($this->once())
+            ->method('execute')
+            ->with($this->callback(function (array $params) {
+                return $params[':contest_id'] === 1 && $params[':song_id'] === 10;
+            }))
+            ->willReturn(true);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls(
+            $contestStmt,
+            $nomineeCheckStmt,
+            $insertStmt,
+        );
+
+        $this->top11->pendingVoterEmail = 'jane@example.com';
+        $result = $this->top11->addVote(10);
+
+        $this->assertTrue($result);
+    }
+
+    public function testAddVoteThrowsWithNoActiveContest(): void
+    {
+        $noContestStmt = $this->createMock(PDOStatement::class);
+        $noContestStmt->method('execute')->willReturn(true);
+        $noContestStmt->method('fetch')->willReturn(false);
+        $this->mockDb->method('prepare')->willReturn($noContestStmt);
+
+        $this->expectExceptionMessage('No active Top 11 contest to vote in');
+        $this->top11->addVote(10);
+    }
+
+    public function testRecordUserVoteStoresVoterIdentityForSubsequentAddVoteCalls(): void
+    {
+        $result = $this->top11->recordUserVote('jane@example.com', 'auth0|123');
+
+        $this->assertTrue($result);
+        $this->assertSame('jane@example.com', $this->top11->pendingVoterEmail);
+        $this->assertSame('auth0|123', $this->top11->pendingVoterAuth0Id);
+    }
+
+    public function testHasUserVotedThisWeekReturnsFalseWithNoActiveContest(): void
+    {
+        $noContestStmt = $this->createMock(PDOStatement::class);
+        $noContestStmt->method('execute')->willReturn(true);
+        $noContestStmt->method('fetch')->willReturn(false);
+        $this->mockDb->method('prepare')->willReturn($noContestStmt);
+
+        $this->assertFalse($this->top11->hasUserVotedThisWeek('jane@example.com'));
+    }
+
+    public function testHasUserVotedThisWeekReturnsFalseForEmptyEmail(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $this->mockDb->method('prepare')->willReturn($contestStmt);
+
+        $this->assertFalse($this->top11->hasUserVotedThisWeek(''));
+    }
+
+    public function testHasUserVotedThisWeekReturnsTrueWhenAVoteExists(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $voteCheckStmt = $this->createMock(PDOStatement::class);
+        $voteCheckStmt->method('execute')->willReturn(true);
+        $voteCheckStmt->method('fetch')->willReturn(['1' => 1]);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $voteCheckStmt);
+
+        $this->assertTrue($this->top11->hasUserVotedThisWeek('jane@example.com'));
+    }
+
+    public function testAddContestantInsertsAContestantRow(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $insertStmt = $this->createMock(PDOStatement::class);
+        $insertStmt->expects($this->once())
+            ->method('execute')
+            // Bind as the 'true'/'false' string literals, not native PHP
+            // bools: PDO's native (non-emulated) pgsql prepares raised
+            // "invalid input syntax for type boolean" on a real Neon branch
+            // when passing a native bool for entered_contest/newsletter_opt_in
+            // -- confirmed only by testing against real Postgres, not mocks.
+            ->with($this->callback(function (array $params) {
+                return $params[':first_name'] === 'Jane'
+                    && $params[':entered_contest'] === 'true'
+                    && $params[':newsletter_opt_in'] === 'false';
+            }))
+            ->willReturn(true);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $insertStmt);
+
+        $result = $this->top11->addContestant('Jane', 'Doe', 'jane@example.com', '555-1234', 'yes', 'no');
+
+        $this->assertTrue($result);
+    }
+
+    public function testAddContestantBindsTheInverseBooleanCombination(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $insertStmt = $this->createMock(PDOStatement::class);
+        $insertStmt->expects($this->once())
+            ->method('execute')
+            ->with($this->callback(function (array $params) {
+                return $params[':entered_contest'] === 'false'
+                    && $params[':newsletter_opt_in'] === 'true';
+            }))
+            ->willReturn(true);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $insertStmt);
+
+        $result = $this->top11->addContestant('Bob', 'Smith', 'bob@example.com', '555-5678', 'no', 'yes');
+
+        $this->assertTrue($result);
+    }
+
+    public function testAddWriteInInsertsAWriteInRow(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $insertStmt = $this->createMock(PDOStatement::class);
+        $insertStmt->expects($this->once())
+            ->method('execute')
+            ->with([':contest_id' => 1, ':write_in' => 'Some Band - Some Song'])
+            ->willReturn(true);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $insertStmt);
+
+        $result = $this->top11->addWriteIn('Some Band - Some Song');
+
+        $this->assertTrue($result);
+    }
+
+    public function testAddWriteInThrowsWithNoActiveContest(): void
+    {
+        $noContestStmt = $this->createMock(PDOStatement::class);
+        $noContestStmt->method('execute')->willReturn(true);
+        $noContestStmt->method('fetch')->willReturn(false);
+        $this->mockDb->method('prepare')->willReturn($noContestStmt);
+
+        $this->expectExceptionMessage('No active Top 11 contest to write in for');
+        $this->top11->addWriteIn('Some Band - Some Song');
+    }
+
+    /**
+     * @dataProvider cpOnlyMethodProvider
+     */
+    public function testCpOnlyMethodsThrowInsteadOfSilentlyNoOping(callable $call): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/Payload admin Contest Controls tab/');
+        $call($this->top11);
+    }
+
+    public static function cpOnlyMethodProvider(): array
+    {
+        return [
+            'getById' => [fn (PostgresTop11 $t) => $t->getById(1)],
+            'toggleStatus' => [fn (PostgresTop11 $t) => $t->toggleStatus('open')],
+            'update' => [fn (PostgresTop11 $t) => $t->update(1, 'Artist', 'Song', 'Note')],
+            'updateDate' => [fn (PostgresTop11 $t) => $t->updateDate('2026-01-01')],
+            'updateMessage' => [fn (PostgresTop11 $t) => $t->updateMessage('Message')],
+            'addSong' => [fn (PostgresTop11 $t) => $t->addSong('Artist', 'Song')],
+            'updateSong' => [fn (PostgresTop11 $t) => $t->updateSong(1, 'Artist', 'Song')],
+            'deleteSong' => [fn (PostgresTop11 $t) => $t->deleteSong(1)],
+            'getSong' => [fn (PostgresTop11 $t) => $t->getSong(1)],
+            'getAllContestants' => [fn (PostgresTop11 $t) => $t->getAllContestants()],
+            'getContestantCount' => [fn (PostgresTop11 $t) => $t->getContestantCount()],
+            'pickWinner' => [fn (PostgresTop11 $t) => $t->pickWinner()],
+            'getNewsletterSignups' => [fn (PostgresTop11 $t) => $t->getNewsletterSignups()],
+            'getAllWriteIns' => [fn (PostgresTop11 $t) => $t->getAllWriteIns()],
+            'reset' => [fn (PostgresTop11 $t) => $t->reset()],
+        ];
+    }
+}

--- a/src/tests/Models/PostgresTop11Test.php
+++ b/src/tests/Models/PostgresTop11Test.php
@@ -274,11 +274,28 @@ class PostgresTop11Test extends TestCase
         $insertStmt = $this->createMock(PDOStatement::class);
         $insertStmt->expects($this->once())
             ->method('execute')
-            ->with([':contest_id' => 1, ':write_in' => 'Some Band - Some Song'])
+            ->with([':contest_id' => 1, ':write_in' => 'Some Band - Some Song', ':voter_email' => null])
             ->willReturn(true);
 
         $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $insertStmt);
 
+        $result = $this->top11->addWriteIn('Some Band - Some Song');
+
+        $this->assertTrue($result);
+    }
+
+    public function testAddWriteInRecordsThePendingVoterEmail(): void
+    {
+        $contestStmt = $this->stubActiveContest(1);
+        $insertStmt = $this->createMock(PDOStatement::class);
+        $insertStmt->expects($this->once())
+            ->method('execute')
+            ->with([':contest_id' => 1, ':write_in' => 'Some Band - Some Song', ':voter_email' => 'jane@example.com'])
+            ->willReturn(true);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $insertStmt);
+
+        $this->top11->pendingVoterEmail = 'jane@example.com';
         $result = $this->top11->addWriteIn('Some Band - Some Song');
 
         $this->assertTrue($result);

--- a/src/tests/Models/PostgresTop11Test.php
+++ b/src/tests/Models/PostgresTop11Test.php
@@ -105,6 +105,30 @@ class PostgresTop11Test extends TestCase
         $this->assertSame('closed', $this->top11->getStatus());
     }
 
+    public function testGetAllFormatsWeekOfWithoutAWeekdayToMatchLegacyMysql(): void
+    {
+        // SqlTop11::getAll() returns legacy MySQL's placement-99 row verbatim
+        // (e.g. "July 2, 2026", no weekday) -- PostgresTop11 must match that
+        // exact string shape since top11.php renders it directly into the
+        // "Top 11 @ 11 for {this}" heading.
+        $contestStmt = $this->stubActiveContest(1);
+
+        $entriesStmt = $this->createMock(PDOStatement::class);
+        $entriesStmt->method('execute')->willReturn(true);
+        $entriesStmt->method('fetch')->willReturn(false);
+
+        $weekOfStmt = $this->createMock(PDOStatement::class);
+        $weekOfStmt->method('execute')->willReturn(true);
+        $weekOfStmt->method('fetch')->willReturn(['week_of' => '2026-07-02', 'status' => 'open']);
+
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls($contestStmt, $entriesStmt, $weekOfStmt);
+
+        $entries = $this->top11->getAll();
+
+        $titleRow = array_values(array_filter($entries, fn ($e) => $e['placement'] === 99))[0];
+        $this->assertSame('July 2, 2026', $titleRow['artist']);
+    }
+
     public function testGetAllSongsReturnsNomineePoolNotEntries(): void
     {
         $contestStmt = $this->stubActiveContest(1);

--- a/src/top11.php
+++ b/src/top11.php
@@ -147,7 +147,12 @@ function renderContestNewsletterOptions() {
           } else {
             // User is logged in and hasn't voted - show voting form
             echo "<div class=\"information center\">Logged in as: <strong>" . htmlspecialchars($voter_email) . "</strong> | <a href=\"auth_logout.php?returnTo=/top11\">Log out</a></div>";
-            echo "<form action=\"" . $page_file . "\" method=\"post\" name=\"top11\" class=\"form-default\">\n<fieldset>\n";
+            // Preserve the query string (e.g. ?ff=use_postgres_top11) so the
+            // Postgres-adapter flag override, which FeatureFlags only reads
+            // from $_GET per-request, survives the vote POST instead of
+            // silently falling back to the MySQL adapter on submit.
+            $formAction = $page_file . (!empty($_SERVER['QUERY_STRING']) ? '?' . htmlspecialchars($_SERVER['QUERY_STRING']) : '');
+            echo "<form action=\"" . $formAction . "\" method=\"post\" name=\"top11\" class=\"form-default\">\n<fieldset>\n";
             echo renderSongCheckboxes($songs);
             echo renderWriteInField();
             echo "<div class=\"control-group top-spacer_20 input-seperation\">\n";


### PR DESCRIPTION
## Summary
- PR 3 of 4 in the Top 11 cutover sequence (see #823, Chapter 19). Stacked on #825 (vote-to-nominee validation).
- `Top11Factory.php` checked `use_postgres_top11` but always returned `SqlTop11` regardless -- flipping the flag did nothing. Adds `PostgresTop11.php` and wires the factory for real.
- Confirmed via direct reads of `src/top11.php` / `src/partials/_top11_save.php` that the page is a clean interface swap: it only ever calls `getMessage`, `getAll`, `getStatus`, `getAllSongs`, `hasUserVotedThisWeek`, `recordUserVote`, `addContestant`, `addVote`, `addWriteIn` -- no raw SQL, no MySQL-specific assumptions. Those 9 methods are fully implemented; reads go direct-to-Postgres, writes go through the same collections Payload manages (`create` access is already public on `Top11Votes`/`Top11WriteIns`/`Top11Contestants`, so no new auth plumbing was needed).
- The ~11 CP-only methods (`addSong`, `updateSong`, `deleteSong`, `reset`, `toggleStatus`, `pickWinner`, etc., used by the legacy CP admin screens `top11_operations.php` and friends) throw a clear "use the Payload admin Contest Controls tab instead" exception rather than reimplementing CP semantics against Payload's immutable, versioned contest model, which doesn't map cleanly onto free-editable MySQL rows.

## A data-model mismatch found and fixed along the way
Legacy MySQL lets one voter pick up to 3 songs per week (independent per-song counters, no per-voter-per-song row). Payload's original `(contest_id, voter_key)` unique index only allowed **one vote row per voter per contest at all** -- confirmed by `importTop11.ts`'s own comment ("the new model allows one vote per voter"). This silently capped every voter at 1 of their 3 legal picks. Relaxed the index to `(contest_id, voter_key, song_id)` (new migration `20260706_220000_relax_top11_votes_voterkey_uniqueness.ts`) so a voter can vote for up to 3 distinct songs while still being blocked from voting for the same song twice. `addVote()` uses `ON CONFLICT DO NOTHING` against this index so a resubmission is a no-op, matching MySQL's idempotent counter-increment semantics.

**Known follow-up, not in this PR:** `Top11Votes.ts`'s pre-existing `beforeChange` hook (from #799, predates this stack) still rejects any *second* vote from the same voter in a contest regardless of song -- it checks `{contest, voterIdentity}` with no song filter. This means the Payload write path still can't record more than 1 of 3 votes even after this PR's DB-level fix. Filed as a separate PR (see next in stack) since it's editing pre-existing #799 code, not new PostgresTop11 scope.

## Manual QA against real data (this week's rollout discipline, see Chapter 19)
Cut a fresh Neon dev branch (`top11-postgres-adapter-qa`, off `development`) rather than reusing the stale #799 preview branch, ran `payload:migrate` clean, then ran `importTop11.ts --from local-mysql --to dev-neon` against the real local Docker MySQL data (57 nominees, 11 chart entries, 1 registered voter). Verified every read/write path directly against that branch from inside the running `site-phpfpm-1` container:

- `getStatus()` → `open`, `getMessage()` → real rendered HTML, `getAllSongs()` → 57 real nominees, `getAll()` → 11 real chart entries plus the two sentinel rows
- `recordUserVote()` → `addVote()` x3 for one voter across 3 different nominee songs → all 3 recorded (proves the multi-vote fix works end-to-end, not just against mocks)
- Re-submitting the same song → no-op (`ON CONFLICT DO NOTHING` confirmed)
- Voting for a non-nominee song id → correctly rejected with `This song is not on the ballot for this contest`
- `addWriteIn()` → recorded
- `addContestant()` → **found and fixed a real bug here**: PDO's native (non-emulated) pgsql prepared statements don't reliably bind native PHP booleans -- the first attempt threw `SQLSTATE[22P02]: invalid input syntax for type boolean: ""`. Fixed by binding `'true'`/`'false'` string literals instead of native bools; verified both boolean combinations land correctly in the DB afterward, and added regression tests for both directions.

Also stood up a Netlify branch deploy (`preview/top11-postgres-adapter-qa`, matches this repo's `allowed_branches: ["master", "preview/*"]` convention) with `DATABASE_URI` scoped to just this branch context (not the shared site default) pointing at the QA Neon branch, so the seeded contest is browsable in the Payload admin without touching any other environment.

## Test plan
- [x] `vendor/bin/phpunit tests/Models/PostgresTop11Test.php` -- 32 passed: all 9 real methods, all 11 CP-only methods confirmed to throw
- [x] `vendor/bin/phpunit` (full suite) -- 288 passed, no regressions
- [x] `vendor/bin/phpcs` -- clean
- [x] `yarn lint` -- clean
- [x] `yarn tsc --noEmit` -- no new errors (645 baseline, unchanged)
- [x] Manual QA against a real Neon dev branch with real imported data (see above) -- this is the PR the plan called for a manual gate on, given it's the first PR that can actually move real vote/contestant/write-in data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2