### PR TITLE
fix: scope Top11Votes duplicate-vote check to (contest, voter, song)

### DIFF
--- a/payload/src/collections/Top11Votes.test.ts
+++ b/payload/src/collections/Top11Votes.test.ts
@@ -92,13 +92,35 @@ describe('Top11Votes', () => {
       );
     });
 
-    it('rejects a duplicate vote from the same voter identity', async () => {
+    it('rejects a duplicate vote for the same song from the same voter identity', async () => {
       const req = makeReq(openContestWithNominees, { docs: [{ id: 5 }] });
       const data = { contest: 1, song: 10, voterEmail: 'jane@example.com' };
 
       await expect(beforeChangeHook?.({ operation: 'create', data, req } as never)).rejects.toThrow(
-        'This voter has already voted in the current Top 11 contest',
+        'This voter has already voted for this song',
       );
+      expect(req.payload.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            and: [
+              { contest: { equals: 1 } },
+              { song: { equals: 10 } },
+              { voterEmail: { equals: 'jane@example.com' } },
+            ],
+          },
+        }),
+      );
+    });
+
+    it('allows a voter to vote for a second, different nominee song in the same contest', async () => {
+      // Legacy MySQL lets one voter pick up to 3 songs (see
+      // 20260706_220000_relax_top11_votes_voterkey_uniqueness); this hook's
+      // dedup check must be scoped per-song, not per-contest, to match.
+      const req = makeReq(openContestWithNominees, { docs: [] });
+      const data = { contest: 1, song: 20, voterEmail: 'jane@example.com' };
+
+      const result = await beforeChangeHook?.({ operation: 'create', data, req } as never);
+      expect(result).toMatchObject({ song: 20 });
     });
 
     it('allows the first vote for a new voter identity', async () => {

--- a/payload/src/collections/Top11Votes.ts
+++ b/payload/src/collections/Top11Votes.ts
@@ -99,7 +99,7 @@ export const Top11Votes: CollectionConfig = {
         const existingVotes = await req.payload.find({
           collection: 'top11-votes',
           where: {
-            and: [{ contest: { equals: contestId } }, identityWhere],
+            and: [{ contest: { equals: contestId } }, { song: { equals: songId } }, identityWhere],
           },
           req,
           overrideAccess: true,
@@ -108,7 +108,7 @@ export const Top11Votes: CollectionConfig = {
         });
 
         if (existingVotes.docs.length > 0) {
-          throw new APIError('This voter has already voted in the current Top 11 contest', 409);
+          throw new APIError('This voter has already voted for this song', 409);
         }
 
         return data;


### PR DESCRIPTION
## Summary
- PR 3.5, follow-up to #826. Stacked on the PostgresTop11 adapter branch.
- Found while manually QA-ing #826: `Top11Votes.ts`'s `beforeChange` hook (from #799, predates this stack) filters its duplicate-vote check by `{contest, voterIdentity}` only -- no song filter. That meant a voter could never cast more than 1 of their 3 legal picks through Payload's own `create` API, even after #826's DB constraint relaxation to `(contest_id, voter_key, song_id)` allowed exactly that at the database level. The application-level hook was silently more restrictive than the DB it's supposed to be a friendly error in front of.
- Fix: add `{ song: { equals: songId } }` to the `existingVotes` query, and reword the rejection message from "already voted in the current Top 11 contest" to "already voted for this song" to match the new, narrower guarantee.

## Test plan
- [x] `yarn vitest run payload/src/collections/Top11Votes.test.ts` -- 13 passed, including a new case proving a voter can vote for a second distinct nominee song, and an updated duplicate-vote case asserting the `find` call is now scoped by song too
- [x] `yarn lint` -- clean
- [x] `yarn tsc --noEmit` -- no new errors
- [x] Verified against a real Neon dev branch via Payload's Local API (not just mocks): one voter successfully cast 3 votes for 3 distinct nominee songs in the same contest; a 4th attempt to re-vote for an already-voted song was correctly rejected with the new message. Confirms the DB constraint (#826) and this hook fix work together end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2