### PR TITLE
docs: split Top 11/YEP readiness into per-feature chapters

### DIFF
--- a/docs/payload-migration/19-top11-yep-readiness.md
+++ b/docs/payload-migration/19-top11-yep-readiness.md
@@ -1,263 +1,55 @@
-# Chapter 19: Top 11 & Year End Poll — Cutover Readiness
+# Chapter 19: Top 11 & Year End Poll — Cutover Overview
 
 [← Back to Index](./README.md)
 
-**Status:** In progress · **Last Updated:** July 2026
+**Status:** Top 11 landed, Year End Poll not started · **Last Updated:** July 2026
 
 ---
 
-Companion to [Chapter 18](./18-pages-readiness.md). Top 11 is the pressing
-feature — a working vote flow is needed for Josh to react to and give feedback
-on. Year End Poll can proceed mostly unsupervised since voting stays closed
-until December.
+Companion to [Chapter 18](./18-pages-readiness.md). Both features share the
+same cutover shape as Pages: the legacy PHP page stays exactly as it is, and
+its `*Factory.php` swaps a MySQL implementation for a new `Postgres*`
+implementation behind a feature flag. Neither feature has (or needs) a new
+Next.js frontend — `app/` in this repo exists only to serve the Payload admin
+panel and its REST API; the guest-facing site is PHP throughout.
 
-## The one thing both features are missing
+Detail lives in two dedicated chapters:
 
-Neither has a **PHP read/write adapter connecting the legacy visitor-facing
-page to Payload's Postgres tables.** All Payload work so far is collections,
-admin UI, and (for Top 11) an importer — the live vote flow for both features
-is still 100% legacy PHP/MySQL, same `top11.php`/`yearendpoll.php` pages as
-always. The remaining work is exactly the shape of Pages' `CustomTextFactory.php`
-→ `PostgresCustomText.php` swap, not a new frontend — there is no Next.js
-guest-facing page anywhere in this repo to build; `app/` exists only to serve
-the Payload admin panel and its REST API.
+- **[Chapter 19a: Top 11](./19a-top11-readiness.md)** — the pressing one.
+  Josh needs a working vote flow to react to. **PRs 1–4 are merged**;
+  `PostgresTop11.php` exists and is flag-gated (`use_postgres_top11`, still
+  `false` in prod). Current focus is weekly real-data re-imports for
+  confidence-building, an image+link Lexical block gap, and cleaning up seed
+  data from a Neon branch-targeting incident during QA.
+- **[Chapter 19b: Year End Poll](./19b-yearendpoll-readiness.md)** — can
+  proceed unsupervised since voting stays closed until December. Backend is
+  thinner than Top 11's (no tally mechanism, no flag scaffolding at all) but
+  the four-PR sequence Top 11 already proved is the template to follow.
 
-Confirmed by reading `src/top11.php` and `src/partials/_top11_save.php`
-directly: the page and its form handler only ever call `$top11Model->` methods
-(`getMessage`, `getAll`, `getStatus`, `getAllSongs`, `hasUserVotedThisWeek`,
-`recordUserVote`, `addContestant`, `addVote`, `addWriteIn`) — no raw SQL, no
-MySQL-specific assumptions. **This is a clean interface swap** — the PHP
-adapter work below can scope to the adapter class alone, no page edits needed.
+## Why Top 11 went first
 
-## Schema gap found in review, not yet in the codebase
+Top 11's flag/factory scaffolding was further along (wrong today, but
+present) than YEP's (absent) — but Top 11's schema had a harder blocker
+underneath that: no nominee-pool field, so there was nothing yet for a
+Postgres adapter or a validation hook to point at. That had to land first;
+the adapter, factory wiring, and tests sequenced after it. Once Top 11's
+sequence was proven end-to-end (schema → validation → adapter → flag), Year
+End Poll's four-PR shape mirrors it directly — see Chapter 19b's PR sequence.
 
-**There is no field anywhere that models this week's nominee pool** — the
-~57-song checklist voters pick 3 from. `Top11Contests.entries`
-(`payload/src/collections/Top11Contests.ts:640`) is a different list: last
-week's ranked results, capped at 11 rows with rank/movement metadata.
-`importTop11.ts` reads the legacy nominee table (`top11songs`) and imports each
-row as a canonical `Songs` doc — but discards pool membership once import
-finishes; nothing records "these N Songs are votable this week." Checked all
-three other in-flight Top11 branches (`preview/top11-operations`,
-`tj-nicolaides--top11-review`, `tj-nicolaides--top11-votes-voterkey-field`) —
-none add this field.
+## Shared decisions across both features
 
-## At a glance
-
-| Aspect                     | Top 11                                        | Year End Poll                                                      |
-| -------------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
-| Collections                | 5                                             | 4                                                                  |
-| Lifecycle endpoints        | 7                                             | 0                                                                  |
-| Nominee pool field         | Missing entirely                              | Exists (per-category `nominees`)                                   |
-| Vote-to-nominee validation | Missing (blocked on field above)              | Partial (nominees validated on write, not checked at vote time)    |
-| Vote tally                 | Live via `/stats`                             | Nothing computes it (`voteCount` exists but nothing increments it) |
-| Postgres PHP adapter       | None (factory always returns `SqlTop11`)      | None (factory has no flag check at all)                            |
-| Importer                   | Real, current-week only                       | None exists                                                        |
-| Unit tests                 | Partial (Votes/WriteIns/WinnerDraws untested) | Fuller (all 4 collections + hooks)                                 |
-| E2E                        | Legacy PHP only                               | Legacy PHP only                                                    |
-
-## Top 11 — the pressing one
-
-Backend is the most mature of anything in this migration — full lifecycle,
-admin controls tab, winner-draw audit trail, a real (if narrow) legacy
-importer. The gap is entirely "the PHP page has no way to read or write
-Payload's Postgres tables yet."
-
-1. **Add the nominee-pool field to `Top11Contests`.** Nothing today models
-   "these ~57 songs are votable this week" — `entries` is a different, smaller
-   field (last week's ranked chart, max 11 rows).
-   - Add a `nominees` array field to `Top11Contests.ts`, alongside `entries`:
-     `relationTo: 'songs'`, `hasMany: true`, no row cap (legacy pool runs ~57).
-   - Write a migration adding the column, backfilling the current contest by
-     **re-running `importTop11.ts`'s pool-import logic against legacy MySQL**
-     — not derived from `Top11Votes`, which would only recover songs that
-     received at least one vote, undercounting the true pool.
-   - Update `importTop11.ts`: after `importSongPool` resolves
-     `songIdByLegacyId`, write that full set onto the new contest's `nominees`
-     field instead of discarding it.
-   - Add a `Top11Contests.test.ts` case asserting `nominees` persists and
-     round-trips through the importer.
-   - This blocks both the vote-validation fix below and the PHP adapter —
-     there's no query today that answers "what's on the ballot this week."
-
-2. **Validate `Top11Votes.song` against the contest's `nominees`.**
-   - Add a `beforeChange` hook rejecting a vote if `song` isn't in
-     `contest.nominees` (mirrors `YearEndPollCategories.validateNominees` for
-     consistency across features).
-   - Add a **DB-level constraint** (trigger or FK-style check on
-     `top11_votes.song_id` against the contest's nominee set) as the actual
-     source of truth. Both the Payload hook and any PHP-side pre-check become
-     fast, friendly rejections in front of it — if they ever drift apart, the
-     failure mode is a worse error message, not bad data.
-   - Add unit tests: valid nominee vote passes, non-nominee vote rejected,
-     vote against a closed/archived contest still rejected.
-   - Without this, a vote for a song not on this week's list is silently
-     accepted today.
-
-3. **Build `PostgresTop11.php`, the read/write adapter `top11.php` actually
-   needs.**
-   - Add `src/models/implementations/PostgresTop11.php`, implementing the same
-     interface `SqlTop11.php` does today (confirmed complete list: `getMessage`,
-     `getAll`, `getStatus`, `getAllSongs`, `hasUserVotedThisWeek`,
-     `recordUserVote`, `addContestant`, `addVote`, `addWriteIn`).
-   - Reads (`getMessage`, `getAll`, `getAllSongs`, `getStatus`) go
-     direct-to-Postgres, same style as `PostgresCustomText.php`/
-     `PostgresModernRockMadness.php`.
-   - **Writes (`recordUserVote`, `addContestant`, `addVote`, `addWriteIn`) call
-     Payload's REST API** rather than raw PDO inserts. This deliberately
-     departs from `PostgresModernRockMadness.php`'s precedent — MRM's
-     `recordVote()` writes directly via PDO and reimplements its own
-     `hasVoted()` dedup check in PHP — because Top11's validation surface
-     (nominee-pool check, `voterKey` dedup) is more involved, and centralizing
-     it in Payload's hooks avoids a second, drift-prone copy of that logic.
-   - Add `src/tests/Models/PostgresTop11Test.php`, mirroring
-     `PostgresCustomTextTest.php`.
-   - Manual QA gate before this PR merges: cast a real vote, submit a
-     write-in, and enter as a contestant against a Netlify preview backed by a
-     **fresh Neon dev branch cut from current master** — not the #799 preview
-     branch, since #811's `voterKey` fix and #818's importer/migration changes
-     landed after that branch was cut.
-   - This is the actual unblocking step for Josh — no new frontend needed, and
-     no `top11.php` edits needed either, since the page already only talks to
-     the model interface.
-
-4. **Wire `Top11Factory.php` to actually use the flag.** Today it checks
-   `use_postgres_top11`, logs a warning, and unconditionally returns
-   `SqlTop11` anyway — flipping the flag currently does nothing.
-   - Once `PostgresTop11.php` exists, make the factory branch on the flag for
-     real, same shape as `CustomTextFactory.php`.
-   - Leave the flag `false` in prod until the nominee field, validation, and
-     adapter are all verified against a Neon dev branch — same rollout
-     discipline as the Pages cutover.
-
-5. **Unit-test `Top11Votes`, `Top11WriteIns`, `Top11WinnerDraws`.** Only
-   Contests and Contestants have dedicated tests today.
-   - `Top11Votes.test.ts`: dedup via `voterKey`, rejection on closed contest,
-     the new nominee-validation hook.
-   - `Top11WriteIns.test.ts`: moderation-flag default, normalization used by
-     the stats grouping.
-   - `Top11WinnerDraws.test.ts`: prior-winner lookback exclusion at boundary
-     values (0, N, more entries than history).
-   - Vote dedup and winner-draw are the two places a silent bug becomes a
-     fairness problem in front of Josh.
-
-6. **Decide the historical-backfill question.** `importTop11.ts` only imports
-   the single current week, idempotently, and hasn't been confirmed run
-   against real prod data. If Josh only needs to see the live contest working,
-   this can wait; if past-weeks history needs to show anywhere, it can't.
-
-7. **Extend the e2e coverage for both adapters.** `e2e/top11.spec.ts` only
-   exercises legacy `top11.php` and predates the Payload collections entirely.
-   - Extend the existing spec (still targeting `top11.php` — the page itself
-     doesn't change) to run once against `use_postgres_top11=false` and once
-     against `=true`, asserting identical behavior: load contest, submit a
-     valid vote, attempt an invalid (non-nominee) vote and assert rejection,
-     submit a write-in.
-   - Once the flag flips permanently and `SqlTop11` is retired, drop the
-     flag-parameterized run and keep the single Postgres-path spec.
-
-### This week's PR sequence
-
-1. **PR 1** — `nominees` field + migration + importer wiring. Everything
-   downstream reads this field — nothing else can start review until it
-   merges.
-2. **PR 2** — vote-to-nominee validation (Payload hook + DB constraint).
-   Small, isolated, easy to review on its own — depends only on PR 1.
-3. **PR 3** — `PostgresTop11.php` adapter, with the manual QA gate on a fresh
-   Neon dev branch. The actual "Josh can see it working" milestone —
-   reviewable independently of the flag wiring.
-4. **PR 4** — flag wiring + e2e parity test. Flag stays `false` in prod after
-   merge — flip is a separate, later, deliberate action, keeping "ship the
-   code" and "cut prod traffic over" as two distinct, separately-approved
-   steps.
-
-Unit tests for `Top11WriteIns`/`Top11WinnerDraws` and the
-historical-backfill-beyond-current-contest decision can land as fast-follow
-PRs after PR 4 — neither blocks Josh seeing a working vote flow.
-
-## Year End Poll — can proceed mostly unsupervised
-
-Backend is thinner than Top 11's — no lifecycle endpoints, no tally mechanism,
-no feature flag scaffolding at all — but the safety margin is real: nobody can
-vote today regardless of what ships, so this can move at its own pace.
-
-1. **Build the vote-tally mechanism.** `voteCount` exists on each nominee row
-   but nothing increments it, and no endpoint counts `YearEndPollVotes` rows
-   per nominee.
-   - Add an `afterChange` hook on `YearEndPollVotes` that increments the
-     matching nominee's `voteCount` on the parent `YearEndPollCategories` row
-     — or compute on read via a `/stats`-style endpoint (matching Top11's
-     pattern), which avoids drift if a vote is later deleted.
-   - If keeping `voteCount`: add an `afterDelete` hook too, so retracted votes
-     decrement correctly.
-   - Add unit tests asserting the count is correct after create/delete
-     sequences.
-   - This blocks any results page, including the already-designed
-     `YearEndPollResults` collection, currently hidden from admin nav for
-     exactly this reason.
-
-2. **Close the vote-to-nominee validation gap.** `rejectDuplicateVote`/
-   `enforceMaxPicks` check dedup and pick caps but never confirm `nomineeId`
-   is actually in the category's `nominees` array.
-   - Add a check in the existing hook chain (`yearEndPollVoteHooks.ts`): fetch
-     the category, verify `nomineeId` matches one of its `nominees` rows.
-   - Extend `yearEndPollVoteHooks.test.ts` with an invalid-nominee-id case.
-   - Lower urgency than Top 11's equivalent gap since voting is closed, but
-     should land before December, not during it.
-
-3. **Build `PostgresYearEndPoll.php`, the read/write adapter for
-   `yearendpoll.php` and `yearendstaffpicks.php`.** Same pattern as Top 11's
-   adapter — no new frontend, the legacy PHP pages stay and swap their data
-   layer.
-   - Implement against the same interface `SqlYearEndPoll.php` uses today:
-     fetch the open `YearEndPolls` record, its `YearEndPollCategories` with
-     `nominees`/`maxPicks`/voting windows, and write votes respecting the
-     vote-to-nominee check from item 2.
-   - Wire `yearendstaffpicks.php` against `YearEndPollResults`'s
-     `StaffPicksBlock` — no Payload path exists today despite the collection
-     being designed for it (Chapter 13).
-   - Results display reads from `YearEndPollResults` blocks once populated
-     (depends on item 1's tally being trustworthy first).
-   - No time pressure until the poll opens later in the year — but "no time
-     pressure" is also why this is the easiest item to let slip past a safe
-     window.
-
-4. **Write the legacy-to-Payload importer.** None exists. The
-   `YEAR_END_POLL_*.md` docs under `src/db/migrations/` describe the old
-   annual MySQL-refresh runbook (Google Sheets → CSV → MySQL), not a path into
-   Payload.
-   - Model it on `importTop11.ts`'s structure (same prod-write guardrails via
-     `shared/payloadClient.ts`).
-   - Decide scope: current year only (mirrors Top11's current-week-only
-     precedent) vs. full historical backfill of past polls/categories/results.
-
-5. **Wire a feature flag.** `YearEndPollFactory.php` has no `FeatureManager`
-   check at all — further from cutover scaffolding than Top 11.
-   - Add `use_postgres_yearendpoll` to `features.php`, hardcoded false
-     initially, same pattern as `use_postgres_top11`.
-   - Once `PostgresYearEndPoll.php` exists, make the factory branch on it for
-     real.
-
-6. **Unhide `YearEndPollResults` from admin nav** once the tally mechanism
-   (item 1) lands. Currently hidden deliberately because there's nothing
-   correct to show yet.
-
-YEP's PR shape mirrors Top 11's four-PR sequence once its own
-nominee-validation and tally gaps are closed — treat it as the same sequence,
-run at a slower, unsupervised pace since voting stays closed until December.
-
-## Decisions locked
-
-| Question                  | Decision                                                                                                                                                                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Nominee-pool scope        | `nominees` added to the `Top11Contests` schema itself — every contest carries the field going forward. Backfilled by re-running `importTop11.ts` (or a variant) against legacy MySQL.                                                                                                |
-| Write path in PHP adapter | Reads go direct-to-Postgres; writes call Payload's REST API. Confirmed departure from `PostgresModernRockMadness.php`'s precedent (direct PDO writes, dedup reimplemented in PHP) — chosen because Top11's validation surface is more involved than MRM's single `hasVoted()` check. |
-| Validation drift          | A DB-level constraint is the real source of truth. Payload's hook and any PHP pre-check are fast, friendly rejections in front of it — drift becomes a UX papercut, not a data-integrity bug.                                                                                        |
-| Branch strategy           | Separate PRs per step, not one stacked branch — this touches real vote data, so each step should be independently revertible.                                                                                                                                                        |
-| Flag flip timing          | `use_postgres_top11` stays `false` in prod this week. Goal is code verified against a Neon dev branch / preview deploy for Josh to react to — the prod flip happens later, deployed separately from the code.                                                                        |
-| Manual QA gate            | Before the adapter PR merges: cast a real vote, submit a write-in, and enter as a contestant against a Netlify preview backed by a fresh Neon dev branch cut from current master.                                                                                                    |
+| Question            | Decision                                                                                                                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Cutover shape       | Legacy page unchanged; `*Factory.php` branches on a feature flag between the `Sql*` and new `Postgres*` implementation of the same interface. No new frontend for either feature.                                                                |
+| Write path          | PHP adapter reads go direct-to-Postgres; writes call Payload's REST API rather than raw PDO, so Payload's validation hooks (nominee checks, dedup) are the single source of truth instead of a second, drift-prone PHP copy.                     |
+| Validation drift    | A DB-level constraint (trigger or FK-style check) is the real source of truth in every case. Payload's hook and any PHP pre-check are fast, friendly rejections in front of it.                                                                  |
+| Branch strategy     | Separate PRs per step, not one stacked branch — both features touch real vote/contest data, so each step should be independently revertible.                                                                                                     |
+| Flag flip timing    | Flags stay `false` in prod after their PR sequence merges. Code verified against a Neon dev branch; the prod traffic cutover is a separate, later, deliberately-approved action — never bundled with the code merge.                             |
+| Manual QA gate      | Before an adapter PR merges: exercise the real write paths (vote, write-in/entry, contestant) against a Netlify preview backed by a fresh Neon dev branch cut from current master.                                                               |
+| Neon branch hygiene | `neonctl connection-string` has returned the wrong branch's endpoint at least once (see Chapter 19a's postmortem) — always cross-check the returned host's `branch_id` via Neon's REST API before writing to a branch believed to be disposable. |
 
 ---
 
-Compiled from PR #799, #811, #818, #819, commit 7e1e8d1c, and direct reads of
-Top11\*/YearEndPoll\* collections, PHP factories, and e2e specs.
+Compiled from PR #799, #811, #818, #819, #824–#827, commit 7e1e8d1c, and
+direct reads of Top11*/YearEndPoll* collections, PHP factories, and e2e specs
+· companion to the [Pages Migration Content Readiness Plan](./18-pages-readiness.md).

--- a/docs/payload-migration/19a-top11-readiness.md
+++ b/docs/payload-migration/19a-top11-readiness.md
@@ -1,0 +1,203 @@
+# Chapter 19a: Top 11 — Cutover Readiness
+
+[← Back to Index](./README.md) · [← Chapter 19: Top 11 & Year End Poll Overview](./19-top11-yep-readiness.md)
+
+**Status:** PR 1–4 landed · **Last Updated:** July 2026
+
+---
+
+## Status update: PRs 1–4 landed
+
+PRs #824–#827 (the four-PR sequence below) are merged. `nominees` field,
+vote-to-nominee validation, `PostgresTop11.php`, and the real
+`Top11Factory.php` flag wiring all exist and are tested. `use_postgres_top11`
+stays `false` in prod, as planned — code is verified, the traffic cutover is
+still a separate, later action.
+
+A side-by-side parity pass against `ynotradio.net/top11` (real prod data,
+imported via `importTop11.ts --from prod-mysql`, rendered through the
+Postgres adapter on a Neon dev branch) surfaced and fixed eight real bugs
+along the way, all covered by new tests:
+
+- Vote form's `action` attribute dropped the `?ff=` query string, so a vote
+  cast from a Postgres-rendered page silently fell back to writing MySQL.
+- `PostgresTop11::addWriteIn()` never recorded `voter_email`.
+- The HTML→Lexical converter dropped an `<iframe>` embed, an artist photo,
+  and body text/link/paragraph structure whenever they sat inside legacy
+  markup's malformed or unclosed tags (`<center>` without a closing tag is
+  common in `top11message`'s real content).
+- The ranked-chart heading inserted a weekday legacy MySQL never had
+  (`"Thursday, July 2, 2026"` vs. `"July 2, 2026"`).
+- An image floated via the wrapping `<a style="float: right">` (not the
+  `<img>` itself) lost its position, then a legacy CSS rule
+  (`.top11-message img`) outranked the new alignment class by specificity
+  and forced it left regardless.
+- Legacy `<img width/height>` attributes were captured during conversion but
+  never carried through to the rendered tag, so images lost their intended
+  size.
+
+**What's next**, roughly in the order below:
+
+1. A **Lexical block that combines an image upload with a hyperlink** in one
+   unit — the artist-photo-linked-to-tour-page pattern shows up constantly in
+   `top11message`, and today it only survives as a plain image (the link is
+   dropped) because Payload's built-in upload node has no link-wrapper field.
+2. Keep **re-running `importTop11.ts --from prod-mysql` against the current
+   contest** on a Neon dev/preview branch each week, rather than flipping the
+   flag, until the adapter's output is trusted enough to cut over for real.
+3. **Clean up the seed/test Top 11 data that landed on production** — see
+   [Postmortem: seed data landed on prod](#postmortem-seed-data-landed-on-prod)
+   below.
+4. Prototype **cloning this week's contest into next week's** — a real
+   content-ops need (Josh currently re-enters everything by hand every
+   Thursday) that also doubles as a clean test of the adapter's write path
+   before the flag ever flips.
+
+### Postmortem: seed data landed on prod
+
+While cutting a disposable Neon branch for QA (import + screenshot parity
+work), `neonctl connection-string --branch-id <disposable-branch-id>`
+returned **production's real endpoint**, not the disposable branch's actual
+endpoint — confirmed after the fact via Neon's REST API
+(`GET /projects/{id}/endpoints`), which showed the disposable branch had its
+own distinct, genuinely-isolated endpoint all along. The CLI simply resolved
+and returned the wrong host, with no error or warning. Every write made
+believing it targeted the disposable branch — QA vote/write-in test rows, a
+prod-MySQL import of the current contest (a real week, 125 real votes), and
+a real Cloudinary photo upload — landed on production instead.
+
+The data itself turned out to be legitimate (a real current contest week,
+imported from real prod MySQL) and was left in place rather than reverted.
+The cleanup item above is about the leftover **synthetic QA rows**
+(`qa-test%`-style emails, demo vote/write-in fixtures) mixed in alongside it,
+not the real contest data.
+
+**Fix going forward:** never trust `neonctl connection-string` alone before a
+write. Cross-check the returned host's `branch_id` via the REST API, or make
+one trivial write and confirm it does _not_ appear on the branch you believe
+is untouched, before running real import/seed work.
+
+---
+
+## The one thing this feature was missing
+
+Neither Top 11 nor Year End Poll had a **PHP read/write adapter connecting
+the legacy visitor-facing page to Payload's Postgres tables.** All Payload
+work so far was collections, admin UI, and (for Top 11) an importer — the
+live vote flow was still 100% legacy PHP/MySQL, same `top11.php` page as
+always. The work below is exactly the shape of Pages' `CustomTextFactory.php`
+→ `PostgresCustomText.php` swap, not a new frontend — there is no Next.js
+guest-facing page anywhere in this repo to build; `app/` exists only to serve
+the Payload admin panel and its REST API.
+
+Confirmed by reading `src/top11.php` and `src/partials/_top11_save.php`
+directly: the page and its form handler only ever call `$top11Model->` methods
+(`getMessage`, `getAll`, `getStatus`, `getAllSongs`, `hasUserVotedThisWeek`,
+`recordUserVote`, `addContestant`, `addVote`, `addWriteIn`) — no raw SQL, no
+MySQL-specific assumptions. **This was a clean interface swap.**
+
+## Schema gap found in review, now closed
+
+**There was no field anywhere that modeled this week's nominee pool** — the
+~57-song checklist voters pick 3 from. `Top11Contests.entries`
+(`payload/src/collections/Top11Contests.ts:640`) is a different list: last
+week's ranked results, capped at 11 rows with rank/movement metadata.
+`importTop11.ts` reads the legacy nominee table (`top11songs`) and imports each
+row as a canonical `Songs` doc — but was discarding pool membership once
+import finished; nothing recorded "these N Songs are votable this week."
+This shipped as PR 1 below (`nominees` field on `Top11Contests`).
+
+## Backend maturity
+
+Backend is the most mature of anything in this migration — full lifecycle,
+admin controls tab, winner-draw audit trail, a real (if narrow) legacy
+importer, and (as of PRs #824–#827) a working Postgres read/write adapter.
+
+1. **`nominees` field on `Top11Contests`.** `relationTo: 'songs'`, `hasMany:
+true`, no row cap (legacy pool runs ~57). Backfilled by re-running
+   `importTop11.ts`'s pool-import logic against legacy MySQL — not derived
+   from `Top11Votes`, which would only recover songs that received at least
+   one vote, undercounting the true pool. — **Shipped in #824.**
+
+2. **Vote-to-nominee validation.** A `beforeChange` hook on `Top11Votes`
+   rejects a vote if `song` isn't in `contest.nominees` (mirrors
+   `YearEndPollCategories.validateNominees` for consistency across
+   features), backed by a **DB-level constraint** (trigger on
+   `top11_votes.song_id` against the contest's nominee set) as the actual
+   source of truth. The Payload hook and any PHP-side pre-check are fast,
+   friendly rejections in front of it — if they ever drift apart, the
+   failure mode is a worse error message, not bad data. — **Shipped in
+   #825.**
+
+3. **`PostgresTop11.php`, the read/write adapter `top11.php` needed.**
+   Implements the same interface `SqlTop11.php` does (`getMessage`,
+   `getAll`, `getStatus`, `getAllSongs`, `hasUserVotedThisWeek`,
+   `recordUserVote`, `addContestant`, `addVote`, `addWriteIn`). Reads go
+   direct-to-Postgres, same style as `PostgresCustomText.php`/
+   `PostgresModernRockMadness.php`. **Writes call Payload's REST API**
+   rather than raw PDO inserts — a deliberate departure from
+   `PostgresModernRockMadness.php`'s precedent (MRM's `recordVote()` writes
+   directly via PDO and reimplements its own `hasVoted()` dedup check in
+   PHP), because Top11's validation surface (nominee-pool check, `voterKey`
+   dedup) is more involved, and centralizing it in Payload's hooks avoids a
+   second, drift-prone copy of that logic. Manual QA gate (cast a real vote,
+   submit a write-in, enter as a contestant against a Neon dev branch) ran
+   before merge. — **Shipped in #826**, plus the eight parity-testing fixes
+   listed in the status update above.
+
+4. **`Top11Factory.php` wired to the flag for real.** Previously checked
+   `use_postgres_top11`, logged a warning, and unconditionally returned
+   `SqlTop11` anyway — flipping the flag did nothing. Now branches for real,
+   same shape as `CustomTextFactory.php`. Flag stays `false` in prod until
+   the "re-import weekly" step in "What's next" above builds enough
+   confidence to flip it. — **Shipped in #827**, alongside the
+   `(contest, voter, song)` vote-dedup scoping fix.
+
+## Open fast-follow items
+
+5. **Unit-test `Top11WriteIns`, `Top11WinnerDraws`.** Only Contests,
+   Contestants, and Votes have dedicated tests today.
+   - `Top11WriteIns.test.ts`: moderation-flag default, normalization used by
+     the stats grouping.
+   - `Top11WinnerDraws.test.ts`: prior-winner lookback exclusion at boundary
+     values (0, N, more entries than history).
+   - Vote dedup and winner-draw are the two places a silent bug becomes a
+     fairness problem in front of Josh.
+
+6. **Decide the historical-backfill question.** `importTop11.ts` only imports
+   the single current week, idempotently. If Josh only needs to see the live
+   contest working, this can wait; if past-weeks history needs to show
+   anywhere, it can't.
+
+7. **Extend the e2e coverage for both adapters.** `e2e/top11.spec.ts` only
+   exercises legacy `top11.php` and predates the Payload collections
+   entirely.
+   - Extend the existing spec (still targeting `top11.php` — the page itself
+     doesn't change) to run once against `use_postgres_top11=false` and once
+     against `=true`, asserting identical behavior: load contest, submit a
+     valid vote, attempt an invalid (non-nominee) vote and assert rejection,
+     submit a write-in.
+   - Once the flag flips permanently and `SqlTop11` is retired, drop the
+     flag-parameterized run and keep the single Postgres-path spec.
+
+8. **The image+link Lexical block** and **weekly re-import cadence** from
+   "What's next" above are both open, ongoing items — not one-time PRs.
+
+## Decisions locked
+
+| Question                  | Decision                                                                                                                                                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Nominee-pool scope        | `nominees` added to the `Top11Contests` schema itself — every contest carries the field going forward. Backfilled by re-running `importTop11.ts` (or a variant) against legacy MySQL.                                                                                                |
+| Write path in PHP adapter | Reads go direct-to-Postgres; writes call Payload's REST API. Confirmed departure from `PostgresModernRockMadness.php`'s precedent (direct PDO writes, dedup reimplemented in PHP) — chosen because Top11's validation surface is more involved than MRM's single `hasVoted()` check. |
+| Validation drift          | A DB-level constraint is the real source of truth. Payload's hook and any PHP pre-check are fast, friendly rejections in front of it — drift becomes a UX papercut, not a data-integrity bug.                                                                                        |
+| Branch strategy           | Separate PRs per step, not one stacked branch — this touches real vote data, so each step should be independently revertible.                                                                                                                                                        |
+| Flag flip timing          | `use_postgres_top11` stays `false` in prod. Weekly re-imports against real prod MySQL (see "What's next" above) are the current substitute for flipping the flag — code verified, traffic cutover still a separate, later action.                                                    |
+| Manual QA gate            | Before the adapter PR merges: cast a real vote, submit a write-in, and enter as a contestant against a Netlify preview backed by a fresh Neon dev branch cut from current master.                                                                                                    |
+| Neon branch verification  | After the prod-data incident above: never trust `neonctl connection-string` alone. Cross-check the returned host's `branch_id` via the REST API before any write.                                                                                                                    |
+
+---
+
+Compiled from PR #799, #811, #818, #819, #824–#827, commit 7e1e8d1c, and
+direct reads of Top11* collections, PHP factories, and e2e specs · see
+[Chapter 19b](./19b-yearendpoll-readiness.md) for Year End Poll, the sibling
+feature on the same cutover pattern.

--- a/docs/payload-migration/19b-yearendpoll-readiness.md
+++ b/docs/payload-migration/19b-yearendpoll-readiness.md
@@ -1,0 +1,120 @@
+# Chapter 19b: Year End Poll — Cutover Readiness
+
+[← Back to Index](./README.md) · [← Chapter 19: Top 11 & Year End Poll Overview](./19-top11-yep-readiness.md)
+
+**Status:** Not started — can proceed unsupervised · **Last Updated:** July 2026
+
+---
+
+Year End Poll can proceed mostly unsupervised since voting stays closed until
+December. See [Chapter 19a](./19a-top11-readiness.md) for Top 11, which has
+landed its equivalent four-PR sequence and is the reference shape for this
+one.
+
+## Backend maturity
+
+Backend is thinner than Top 11's — no lifecycle endpoints, no tally
+mechanism, no feature flag scaffolding at all — but the safety margin is
+real: nobody can vote today regardless of what ships, so this can move at its
+own pace without a live audience.
+
+1. **Build the vote-tally mechanism.** `voteCount` exists on each nominee row
+   but nothing increments it, and no endpoint counts `YearEndPollVotes` rows
+   per nominee.
+   - Add an `afterChange` hook on `YearEndPollVotes` that increments the
+     matching nominee's `voteCount` on the parent `YearEndPollCategories` row
+     — or compute on read via a `/stats`-style endpoint (matching Top11's
+     pattern), which avoids drift if a vote is later deleted.
+   - If keeping `voteCount`: add an `afterDelete` hook too, so retracted votes
+     decrement correctly.
+   - Add unit tests asserting the count is correct after create/delete
+     sequences.
+   - This blocks any results page, including the already-designed
+     `YearEndPollResults` collection, currently hidden from admin nav for
+     exactly this reason.
+
+2. **Close the vote-to-nominee validation gap.** `rejectDuplicateVote`/
+   `enforceMaxPicks` check dedup and pick caps but never confirm `nomineeId`
+   is actually in the category's `nominees` array.
+   - Add a check in the existing hook chain (`yearEndPollVoteHooks.ts`): fetch
+     the category, verify `nomineeId` matches one of its `nominees` rows.
+   - Extend `yearEndPollVoteHooks.test.ts` with an invalid-nominee-id case.
+   - Lower urgency than Top 11's equivalent gap since voting is closed, but
+     should land before December, not during it.
+
+3. **Build `PostgresYearEndPoll.php`, the read/write adapter for
+   `yearendpoll.php` and `yearendstaffpicks.php`.** Same pattern as Top 11's
+   adapter — no new frontend, the legacy PHP pages stay and swap their data
+   layer.
+   - Implement against the same interface `SqlYearEndPoll.php` uses today:
+     fetch the open `YearEndPolls` record, its `YearEndPollCategories` with
+     `nominees`/`maxPicks`/voting windows, and write votes respecting the
+     vote-to-nominee check from item 2.
+   - Wire `yearendstaffpicks.php` against `YearEndPollResults`'s
+     `StaffPicksBlock` — no Payload path exists today despite the collection
+     being designed for it (Chapter 13).
+   - Results display reads from `YearEndPollResults` blocks once populated
+     (depends on item 1's tally being trustworthy first).
+   - No time pressure until the poll opens later in the year — but "no time
+     pressure" is also why this is the easiest item to let slip past a safe
+     window.
+
+4. **Write the legacy-to-Payload importer.** None exists. The
+   `YEAR_END_POLL_*.md` docs under `src/db/migrations/` describe the old
+   annual MySQL-refresh runbook (Google Sheets → CSV → MySQL), not a path into
+   Payload.
+   - Model it on `importTop11.ts`'s structure (same prod-write guardrails via
+     `shared/payloadClient.ts`).
+   - Decide scope: current year only (mirrors Top11's current-week-only
+     precedent) vs. full historical backfill of past polls/categories/results.
+
+5. **Wire a feature flag.** `YearEndPollFactory.php` has no `FeatureManager`
+   check at all — further from cutover scaffolding than Top 11.
+   - Add `use_postgres_yearendpoll` to `features.php`, hardcoded false
+     initially, same pattern as `use_postgres_top11`.
+   - Once `PostgresYearEndPoll.php` exists, make the factory branch on it for
+     real.
+
+6. **Unhide `YearEndPollResults` from admin nav** once the tally mechanism
+   (item 1) lands. Currently hidden deliberately because there's nothing
+   correct to show yet.
+
+## PR sequence
+
+YEP's PR shape mirrors Top 11's landed four-PR sequence (see [Chapter
+19a](./19a-top11-readiness.md#backend-maturity)) once its own
+nominee-validation and tally gaps are closed:
+
+1. **PR 1** — vote-tally mechanism (item 1). Nothing downstream can show
+   correct numbers until this exists.
+2. **PR 2** — vote-to-nominee validation (item 2). Small, isolated, low
+   urgency but should land before December.
+3. **PR 3** — `PostgresYearEndPoll.php` adapter (item 3), with the same
+   manual-QA-on-a-Neon-dev-branch gate Top 11 used.
+4. **PR 4** — flag wiring (item 5) + unhide results nav (item 6). Flag stays
+   `false` in prod after merge — flip is a separate, later, deliberate
+   action.
+
+Item 4 (the legacy-to-Payload importer) can land in parallel with PR 1–2,
+since it doesn't depend on the tally or validation work.
+
+Run at a slower, unsupervised pace than Top 11 since voting stays closed
+until December — but "no time pressure" is also why this is the easiest
+feature to let slip past a safe window. Treat the December voting-open date
+as the real deadline for PR 1–4, not a suggestion.
+
+## Decisions locked
+
+| Question         | Decision                                                                                                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| PR shape         | Mirrors Top 11's landed four-PR sequence exactly — same adapter pattern, same flag-stays-false-after-merge discipline, same Neon-dev-branch manual QA gate.                                            |
+| Tally mechanism  | Compute-on-read via a `/stats`-style endpoint (matching Top11's pattern) is preferred over a denormalized `voteCount` counter, to avoid delete-drift — final choice deferred to PR 1's implementation. |
+| Historical scope | Current year only mirrors Top11's current-week-only precedent; full backfill of past polls/categories/results is a separate decision, not blocking PR 1–4.                                             |
+| Urgency          | Lower than Top 11's — voting stays closed until December — but PR 1–4 should land well before that date, not during crunch.                                                                            |
+
+---
+
+Compiled from PR #799, #811, #818, #819, commit 7e1e8d1c, and direct reads of
+YearEndPoll* collections, PHP factories, and e2e specs · see [Chapter
+19a](./19a-top11-readiness.md) for Top 11, the sibling feature on the same
+cutover pattern.

--- a/docs/payload-migration/README.md
+++ b/docs/payload-migration/README.md
@@ -48,7 +48,9 @@ Legacy MySQL/admin still owns:
 12. [Rich-Text Embeds (Custom Text Phase 1)](16-rich-text-embeds.md)
 13. [PHP Deletion](17-php-deletion.md)
 14. [Pages Readiness](18-pages-readiness.md)
-15. [Top 11 & Year End Poll Readiness](19-top11-yep-readiness.md)
+15. [Top 11 & Year End Poll — Cutover Overview](19-top11-yep-readiness.md)
+    - [Top 11 Readiness](19a-top11-readiness.md)
+    - [Year End Poll Readiness](19b-yearendpoll-readiness.md)
 
 ## Historical / Planning References
 


### PR DESCRIPTION
## Summary
- Chapter 19 had grown to cover Top 11's full landed status (PRs #824-#827, the parity-testing postmortem, next-up items) alongside Year End Poll's still-unstarted plan in one doc.
- Split into a slim parent overview (shared cutover pattern, shared decisions table) plus:
  - **19a** — Top 11, now current: status update on PRs 1-4, the eight parity-testing bugs found and fixed, a postmortem on a Neon connection-string incident during QA, and open next-steps.
  - **19b** — Year End Poll: unchanged plan content, now framed as mirroring Top 11's proven four-PR sequence.
- README index updated to nest 19a/19b under 19.

## Test plan
- [x] Docs only, no code changes — `yarn lint` runs prettier on markdown via lint-staged, applied cleanly on commit.
- [x] Verified all cross-links (19 ↔ 19a ↔ 19b, README index) resolve to the correct files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2