### PR TITLE
fix: pin PHP CI checks to 7.4, matching prod

### DIFF
--- a/.buildkite/pipeline-ci.yml
+++ b/.buildkite/pipeline-ci.yml
@@ -101,35 +101,35 @@ steps:
       queue: "default"
 
   # PHP Lint (CodeSniffer) — skipped on JS-only PRs
+  # Runs inside the pinned PHP_VERSION image (php:7.4-fpm, same base prod
+  # runs — see bin/docker/phpfpm/Dockerfile) instead of composer:2, which
+  # tracks latest PHP and would silently pass code that fatals on prod's
+  # actual PHP 7.4 (e.g. trait constants, which need PHP 8.2+).
   - label: ":php: PHP Lint"
     key: "php-lint"
     command: |
       if [ "$${SKIP_PHP}" = "true" ]; then echo "No PHP changes — skipping."; exit 0; fi
-      cd src && \
-      composer install --no-interaction --prefer-dist && \
-      vendor/bin/phpcs --standard=phpcs.xml --warning-severity=0
-    plugins:
-      - docker#v5.11.0:
-          image: "composer:2"
-          propagate-environment: true
+      bash .buildkite/scripts/run-php-checks.sh lint
+    env:
+      GHCR_USERNAME: "${GHCR_USERNAME}"
+      GHCR_TOKEN: "${GHCR_TOKEN}"
     agents:
       queue: "default"
+      docker: "true"
 
   # PHP Unit Tests — skipped on JS-only PRs
+  # See php-lint above re: pinned PHP_VERSION image.
   - label: ":php: PHP Unit Tests"
     key: "php-test"
     command: |
       if [ "$${SKIP_PHP}" = "true" ]; then echo "No PHP changes — skipping."; exit 0; fi
-      docker-php-ext-install mysqli && \
-      cd src && \
-      composer install --no-interaction --prefer-dist && \
-      vendor/bin/phpunit --testdox
-    plugins:
-      - docker#v5.11.0:
-          image: "composer:2"
-          propagate-environment: true
+      bash .buildkite/scripts/run-php-checks.sh test
+    env:
+      GHCR_USERNAME: "${GHCR_USERNAME}"
+      GHCR_TOKEN: "${GHCR_TOKEN}"
     agents:
       queue: "default"
+      docker: "true"
 
   # === E2E Integration Tests ===
   # Only run after all fast checks pass — saves ~20 min on doomed builds.

--- a/.buildkite/scripts/run-php-checks.sh
+++ b/.buildkite/scripts/run-php-checks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# .buildkite/scripts/run-php-checks.sh
+# Runs PHP lint (phpcs) and/or unit tests (phpunit) inside the pinned PHP_VERSION
+# image (php:7.4-fpm, same base prod runs — see bin/docker/phpfpm/Dockerfile).
+#
+# The docker#v5.11.0 plugin has no registry-login step, so pulling the private
+# ghcr.io/ynotradio/site/phpfpm-dev image needs a manual `docker login` first;
+# this mirrors the pull-with-local-build-fallback pattern in run-e2e.sh so PR
+# builds without GHCR creds (e.g. from forks) still work.
+#
+# Usage: run-php-checks.sh <lint|test>
+
+set -euo pipefail
+
+CHECK="${1:?Usage: run-php-checks.sh <lint|test>}"
+IMAGE="ghcr.io/ynotradio/site/phpfpm-dev:latest"
+
+PULL_OK=false
+if [ -n "${GHCR_TOKEN:-}" ] && [ -n "${GHCR_USERNAME:-}" ]; then
+  if echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin; then
+    docker pull "$IMAGE" && PULL_OK=true || echo "⚠️ Failed to pull phpfpm image from GHCR, falling back to local build"
+  else
+    echo "⚠️ GHCR login failed, falling back to local build for phpfpm"
+  fi
+else
+  echo "⚠️ GHCR credentials not set, falling back to local build for phpfpm"
+fi
+
+[ "$PULL_OK" = true ] || docker build --load -t "$IMAGE" -f ./bin/docker/phpfpm/Dockerfile .
+
+case "$CHECK" in
+  lint)
+    docker run --rm -v "$PWD":/app -w /app/src "$IMAGE" \
+      sh -c "composer install --no-interaction --prefer-dist && vendor/bin/phpcs --standard=phpcs.xml --warning-severity=0"
+    ;;
+  test)
+    docker run --rm -v "$PWD":/app -w /app/src "$IMAGE" \
+      sh -c "composer install --no-interaction --prefer-dist && vendor/bin/phpunit --testdox"
+    ;;
+  *)
+    echo "Unknown check: $CHECK (expected 'lint' or 'test')" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- `pipeline-ci.yml` declared `PHP_VERSION: "7.4"` but never actually used it — the `php-lint` and `php-test` steps both ran in the `composer:2` image, which tracks the latest PHP release (8.4 today), not 7.4.
- Prod and local Docker both run PHP 7.4. This let PR #822 merge with a `const` inside a `trait` (PHP 8.2+ only) that CI passed clean but fatals immediately on real PHP 7.4 — causing ~6 minutes of 500s across every page rendering Lexical content on ynotradio.net before being reverted.
- Both PHP CI steps now run inside `ghcr.io/ynotradio/site/phpfpm-dev` (built from `bin/docker/phpfpm/Dockerfile`, `php:7.4-fpm` base — same image prod's `phpfpm` container runs), with a local-build fallback when GHCR creds aren't set (e.g. fork PRs), mirroring the existing pattern in `run-e2e.sh`.

## Test plan
- [x] Ran `.buildkite/scripts/run-php-checks.sh lint` and `test` locally (local-build fallback path) — 291 tests / 589 assertions pass against real PHP 7.4.
- [x] Re-applied PR #822's `ConvertsLexicalToHtml.php` diff and reran `run-php-checks.sh test` — now fails with `PHP Fatal error: Traits cannot have constants`, confirming this would have caught the incident before merge.

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2