### PR TITLE
test: add coverage for Top11WriteIns and Top11WinnerDraws

### DIFF
--- a/payload/src/collections/Top11WinnerDraws.test.ts
+++ b/payload/src/collections/Top11WinnerDraws.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Top11WinnerDraws } from './Top11WinnerDraws';
+import { flattenRowFields } from './testUtils';
+
+describe('Top11WinnerDraws', () => {
+  it('has expected slug and group', () => {
+    expect(Top11WinnerDraws.slug).toBe('top11-winner-draws');
+    expect(Top11WinnerDraws.admin?.group).toBe('Top 11');
+  });
+
+  it('contains the audit trail fields for a draw', () => {
+    const allFields = flattenRowFields(Top11WinnerDraws.fields);
+    const names = allFields.map((field) => field.name);
+
+    expect(names).toContain('contest');
+    expect(names).toContain('contestant');
+    expect(names).toContain('contestantEmail');
+    expect(names).toContain('drawnBy');
+    expect(names).toContain('excludePriorWinners');
+  });
+
+  it('defaults excludePriorWinners to true, so the lookback exclusion applies unless explicitly overridden', () => {
+    const allFields = flattenRowFields(Top11WinnerDraws.fields);
+    const excludeField = allFields.find((field) => field.name === 'excludePriorWinners') as {
+      type?: string;
+      defaultValue?: boolean;
+    };
+
+    expect(excludeField.type).toBe('checkbox');
+    expect(excludeField.defaultValue).toBe(true);
+  });
+
+  it('restricts create/read to admin/editor and update/delete to admin only', () => {
+    const createFn = Top11WinnerDraws.access?.create as (args: {
+      req: { user: unknown };
+    }) => boolean;
+    const readFn = Top11WinnerDraws.access?.read as (args: { req: { user: unknown } }) => boolean;
+    const updateFn = Top11WinnerDraws.access?.update as (args: {
+      req: { user: unknown };
+    }) => boolean;
+    const deleteFn = Top11WinnerDraws.access?.delete as (args: {
+      req: { user: unknown };
+    }) => boolean;
+
+    expect(createFn({ req: { user: { role: 'editor' } } })).toBe(true);
+    expect(createFn({ req: { user: null } })).toBe(false);
+    expect(readFn({ req: { user: { role: 'editor' } } })).toBe(true);
+    expect(readFn({ req: { user: null } })).toBe(false);
+
+    expect(updateFn({ req: { user: { role: 'admin' } } })).toBe(true);
+    expect(updateFn({ req: { user: { role: 'editor' } } })).toBe(false);
+    expect(deleteFn({ req: { user: { role: 'admin' } } })).toBe(true);
+    expect(deleteFn({ req: { user: { role: 'editor' } } })).toBe(false);
+  });
+});

--- a/payload/src/collections/Top11WriteIns.test.ts
+++ b/payload/src/collections/Top11WriteIns.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { Top11WriteIns } from './Top11WriteIns';
+import { flattenRowFields } from './testUtils';
+
+describe('Top11WriteIns', () => {
+  it('has expected slug and group', () => {
+    expect(Top11WriteIns.slug).toBe('top11-write-ins');
+    expect(Top11WriteIns.admin?.group).toBe('Top 11');
+  });
+
+  it('contains write-in submission fields', () => {
+    const allFields = flattenRowFields(Top11WriteIns.fields);
+    const names = allFields.map((field) => field.name);
+
+    expect(names).toContain('contest');
+    expect(names).toContain('writeIn');
+    expect(names).toContain('voterEmail');
+    expect(names).toContain('display');
+  });
+
+  it('defaults the moderation display flag to visible', () => {
+    const allFields = flattenRowFields(Top11WriteIns.fields);
+    const displayField = allFields.find((field) => field.name === 'display') as {
+      type?: string;
+      defaultValue?: boolean;
+    };
+
+    expect(displayField.type).toBe('checkbox');
+    expect(displayField.defaultValue).toBe(true);
+  });
+
+  it('permits public write-in creation and restricts read to managers', () => {
+    const createFn = Top11WriteIns.access?.create as () => boolean;
+    const readFn = Top11WriteIns.access?.read as (args: { req: { user: unknown } }) => boolean;
+
+    expect(createFn()).toBe(true);
+    expect(readFn({ req: { user: { role: 'admin' } } })).toBe(true);
+    expect(readFn({ req: { user: { role: 'editor' } } })).toBe(true);
+    expect(readFn({ req: { user: null } })).toBe(false);
+  });
+
+  it('restricts update and delete to admin/editor', () => {
+    const updateFn = Top11WriteIns.access?.update as (args: { req: { user: unknown } }) => boolean;
+    const deleteFn = Top11WriteIns.access?.delete as (args: { req: { user: unknown } }) => boolean;
+
+    expect(updateFn({ req: { user: { role: 'editor' } } })).toBe(true);
+    expect(updateFn({ req: { user: null } })).toBe(false);
+    expect(deleteFn({ req: { user: { role: 'admin' } } })).toBe(true);
+    expect(deleteFn({ req: { user: null } })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Item 5 of chapter 19a's open fast-follow list: `Top11WriteIns` and `Top11WinnerDraws` had no dedicated tests, unlike Contests/Contestants/Votes.
- Adds schema-shape, field-default, and access-control coverage for both, matching the existing `Top11Contestants.test.ts` style.
- Vote dedup and winner-draw are the two places a silent bug becomes a fairness problem in front of Josh.

## Test plan
- [x] `yarn vitest run src/collections/Top11WriteIns.test.ts src/collections/Top11WinnerDraws.test.ts` — 9 passing
- [x] `yarn eslint` clean on both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2