### PR TITLE
feat: increment/decrement nominee voteCount on Year End Poll votes

### DIFF
--- a/payload/src/collections/YearEndPollVotes.ts
+++ b/payload/src/collections/YearEndPollVotes.ts
@@ -1,6 +1,12 @@
 import type { CollectionConfig } from 'payload';
 import { hasRole } from '../utils/auth';
-import { enforceUserId, rejectDuplicateVote, enforceMaxPicks } from './hooks/yearEndPollVoteHooks';
+import {
+  enforceUserId,
+  rejectDuplicateVote,
+  enforceMaxPicks,
+  incrementNomineeVoteCount,
+  decrementNomineeVoteCount,
+} from './hooks/yearEndPollVoteHooks';
 
 /**
  * YearEndPollVotes Collection
@@ -40,6 +46,8 @@ export const YearEndPollVotes: CollectionConfig = {
   hooks: {
     // Run in order: enforce identity → check dupe → check maxPicks
     beforeChange: [enforceUserId, rejectDuplicateVote, enforceMaxPicks],
+    afterChange: [incrementNomineeVoteCount],
+    afterDelete: [decrementNomineeVoteCount],
   },
   fields: [
     {

--- a/payload/src/collections/hooks/yearEndPollVoteHooks.test.ts
+++ b/payload/src/collections/hooks/yearEndPollVoteHooks.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { enforceUserId, rejectDuplicateVote, enforceMaxPicks } from './yearEndPollVoteHooks';
+import {
+  enforceUserId,
+  rejectDuplicateVote,
+  enforceMaxPicks,
+  incrementNomineeVoteCount,
+  decrementNomineeVoteCount,
+} from './yearEndPollVoteHooks';
 
 type HookArgs = Parameters<typeof enforceUserId>[0];
 
@@ -132,5 +138,97 @@ describe('enforceMaxPicks', () => {
 
     const result = await enforceMaxPicks({ data, req, operation: 'create', collection: {} as any });
     expect(result).toEqual(data);
+  });
+});
+
+describe('incrementNomineeVoteCount', () => {
+  it('increments the matching nominee voteCount on create', async () => {
+    const payloadMock = {
+      findByID: vi.fn().mockResolvedValue({
+        id: 1,
+        nominees: [
+          { id: 'n1', voteCount: 2 },
+          { id: 'n2', voteCount: 0 },
+        ],
+      }),
+      update: vi.fn().mockResolvedValue({}),
+    };
+    const req = { ...makeReq({ id: 1 }), payload: payloadMock as any };
+    const doc = { category: 1, nomineeId: 'n1', userId: 'u1' };
+
+    const result = await incrementNomineeVoteCount({
+      doc,
+      req,
+      operation: 'create',
+      collection: {} as any,
+    } as any);
+
+    expect(payloadMock.update).toHaveBeenCalledWith({
+      collection: 'year-end-poll-categories',
+      id: 1,
+      data: {
+        nominees: [
+          { id: 'n1', voteCount: 3 },
+          { id: 'n2', voteCount: 0 },
+        ],
+      },
+    });
+    expect(result).toEqual(doc);
+  });
+
+  it('does nothing on update operations', async () => {
+    const payloadMock = { findByID: vi.fn(), update: vi.fn() };
+    const req = { ...makeReq({ id: 1 }), payload: payloadMock as any };
+    const doc = { category: 1, nomineeId: 'n1', userId: 'u1' };
+
+    await incrementNomineeVoteCount({
+      doc,
+      req,
+      operation: 'update',
+      collection: {} as any,
+    } as any);
+
+    expect(payloadMock.findByID).not.toHaveBeenCalled();
+    expect(payloadMock.update).not.toHaveBeenCalled();
+  });
+
+  it('silently skips when the nominee no longer exists', async () => {
+    const payloadMock = {
+      findByID: vi.fn().mockResolvedValue({ id: 1, nominees: [{ id: 'n1', voteCount: 0 }] }),
+      update: vi.fn(),
+    };
+    const req = { ...makeReq({ id: 1 }), payload: payloadMock as any };
+    const doc = { category: 1, nomineeId: 'stale-nominee', userId: 'u1' };
+
+    await incrementNomineeVoteCount({
+      doc,
+      req,
+      operation: 'create',
+      collection: {} as any,
+    } as any);
+
+    expect(payloadMock.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('decrementNomineeVoteCount', () => {
+  it('decrements the matching nominee voteCount', async () => {
+    const payloadMock = {
+      findByID: vi.fn().mockResolvedValue({
+        id: 1,
+        nominees: [{ id: 'n1', voteCount: 3 }],
+      }),
+      update: vi.fn().mockResolvedValue({}),
+    };
+    const req = { ...makeReq({ id: 1 }), payload: payloadMock as any };
+    const doc = { category: 1, nomineeId: 'n1', userId: 'u1' };
+
+    await decrementNomineeVoteCount({ doc, req, collection: {} as any } as any);
+
+    expect(payloadMock.update).toHaveBeenCalledWith({
+      collection: 'year-end-poll-categories',
+      id: 1,
+      data: { nominees: [{ id: 'n1', voteCount: 2 }] },
+    });
   });
 });

--- a/payload/src/collections/hooks/yearEndPollVoteHooks.ts
+++ b/payload/src/collections/hooks/yearEndPollVoteHooks.ts
@@ -1,4 +1,8 @@
-import type { CollectionBeforeChangeHook } from 'payload';
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+  CollectionBeforeChangeHook,
+} from 'payload';
 
 /** Matches the `defaultValue` on the `maxPicks` field in YearEndPollCategories. */
 const DEFAULT_MAX_PICKS = 3;
@@ -82,4 +86,68 @@ export const enforceMaxPicks: CollectionBeforeChangeHook = async ({ data, req, o
   }
 
   return data;
+};
+
+/**
+ * Adjusts the matching nominee's denormalized `voteCount` on the parent
+ * category by `delta`. Ignores nominee ids that no longer exist (e.g. a
+ * nominee removed after votes were cast) rather than throwing, since the
+ * vote record itself is the source of truth and shouldn't be blocked by a
+ * stale tally.
+ */
+type NomineeRow = { id?: string; voteCount?: number };
+
+const adjustNomineeVoteCount = async (
+  payload: import('payload').Payload,
+  categoryId: string | number,
+  nomineeId: string,
+  delta: number,
+): Promise<void> => {
+  const categoryDoc = await payload.findByID({
+    collection: 'year-end-poll-categories',
+    id: categoryId,
+  });
+
+  const rawNominees = (categoryDoc as { nominees?: unknown }).nominees;
+  const nominees: NomineeRow[] = Array.isArray(rawNominees) ? rawNominees : [];
+
+  const index = nominees.findIndex((nominee) => nominee.id === nomineeId);
+  if (index === -1) return;
+
+  const updatedNominees = nominees.map((nominee, i) => {
+    if (i !== index) return nominee;
+    return { ...nominee, voteCount: (nominee.voteCount ?? 0) + delta };
+  });
+
+  await payload.update({
+    collection: 'year-end-poll-categories',
+    id: categoryId,
+    data: { nominees: updatedNominees },
+  });
+};
+
+/**
+ * Increments the voted-for nominee's `voteCount` after a vote is cast.
+ */
+export const incrementNomineeVoteCount: CollectionAfterChangeHook = async ({
+  doc,
+  req,
+  operation,
+}) => {
+  if (operation !== 'create') return doc;
+
+  const categoryId = typeof doc.category === 'object' ? doc.category?.id : doc.category;
+  await adjustNomineeVoteCount(req.payload, categoryId, doc.nomineeId, 1);
+
+  return doc;
+};
+
+/**
+ * Decrements the voted-for nominee's `voteCount` when a vote is retracted.
+ */
+export const decrementNomineeVoteCount: CollectionAfterDeleteHook = async ({ doc, req }) => {
+  const categoryId = typeof doc.category === 'object' ? doc.category?.id : doc.category;
+  await adjustNomineeVoteCount(req.payload, categoryId, doc.nomineeId as string, -1);
+
+  return doc;
 };


### PR DESCRIPTION
## Summary
- PR 1 of chapter 19b's four-PR sequence: nothing tallied `YearEndPollVotes` rows into nominee `voteCount` yet, so no results page (including `YearEndPollResults`) could show correct numbers.
- Wires `afterChange`/`afterDelete` hooks on `YearEndPollVotes` that increment/decrement the matching nominee's `voteCount` on the parent category, mirroring the denormalized-counter pattern already described in the nominee field's admin copy.
- Silently skips adjustment if the nominee id no longer exists on the category (e.g. removed after votes were cast) — the vote record is the source of truth, not the tally.

## Test plan
- [x] `yarn vitest run src/collections/hooks/yearEndPollVoteHooks.test.ts src/collections/YearEndPollVotes.test.ts` — 50 passing
- [x] `yarn eslint` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2