### PR TITLE
chore: add Top11 prod seed-contest inspection and cleanup scripts

### DIFF
--- a/bin/migrations/cleanupSeedTop11Contest.ts
+++ b/bin/migrations/cleanupSeedTop11Contest.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env tsx
+/**
+ * Deletes a specific Top11 seed/QA contest and its dependent rows
+ * (Contestants, Votes, WriteIns, WinnerDraws) on production Postgres.
+ *
+ * Defaults to a dry run that only counts what would be deleted. Pass
+ * --confirm to actually delete. Requires --contest-id, so this can never
+ * accidentally target the wrong contest via a stale default.
+ *
+ * See bin/migrations/inspectTop11Prod.ts to identify the seed contest id
+ * before running this.
+ *
+ * Usage:
+ *   YES_I_MEAN_PROD=true yarn tsx --import ./bin/preload-nextenv-fix.mjs \
+ *     bin/migrations/cleanupSeedTop11Contest.ts --contest-id 2
+ *
+ *   YES_I_MEAN_PROD=true yarn tsx --import ./bin/preload-nextenv-fix.mjs \
+ *     bin/migrations/cleanupSeedTop11Contest.ts --contest-id 2 --confirm
+ */
+
+import { getPayloadClient } from './shared/payloadClient';
+
+function parseArgs(): { contestId: number; confirm: boolean } {
+  const args = process.argv.slice(2);
+  let contestId: number | null = null;
+  let confirm = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--contest-id') {
+      contestId = Number(args[i + 1]);
+      i += 1;
+    } else if (args[i] === '--confirm') {
+      confirm = true;
+    }
+  }
+
+  if (!contestId || Number.isNaN(contestId)) {
+    throw new Error('Usage: cleanupSeedTop11Contest.ts --contest-id <id> [--confirm]');
+  }
+
+  return { contestId, confirm };
+}
+
+const DEPENDENT_COLLECTIONS = [
+  'top11-contestants',
+  'top11-votes',
+  'top11-write-ins',
+  'top11-winner-draws',
+] as const;
+
+async function main() {
+  const { contestId, confirm } = parseArgs();
+  const payload = await getPayloadClient('prod-neon');
+
+  const contest = await payload.findByID({ collection: 'top11-contests', id: contestId });
+  if (!contest) {
+    throw new Error(`No top11-contests row with id=${contestId}`);
+  }
+
+  console.log(`\nTarget contest: id=${contestId} status=${(contest as any).status}\n`);
+
+  for (const collection of DEPENDENT_COLLECTIONS) {
+    const result = await payload.find({
+      collection,
+      where: { contest: { equals: contestId } },
+      limit: 0,
+    });
+
+    console.log(
+      `${collection}: ${result.totalDocs} row(s) ${confirm ? 'to delete' : 'would be deleted'}`,
+    );
+
+    if (confirm && result.totalDocs > 0) {
+      await payload.delete({
+        collection,
+        where: { contest: { equals: contestId } },
+      });
+      console.log(`  deleted ${result.totalDocs} row(s) from ${collection}`);
+    }
+  }
+
+  console.log(
+    `\ntop11-contests id=${contestId}: 1 row ${confirm ? 'to delete' : 'would be deleted'}`,
+  );
+  if (confirm) {
+    await payload.delete({ collection: 'top11-contests', id: contestId });
+    console.log(`  deleted contest id=${contestId}`);
+  }
+
+  if (!confirm) {
+    console.log('\nDry run only. Re-run with --confirm to actually delete.\n');
+  } else {
+    console.log('\nCleanup complete.\n');
+  }
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('Cleanup failed:', error);
+  process.exit(1);
+});

--- a/bin/migrations/inspectTop11Prod.ts
+++ b/bin/migrations/inspectTop11Prod.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only inspection of Top 11 data on production Postgres.
+ *
+ * Lists every Top11Contests row, flags which one matches the contest
+ * currently live on ynotradio.net/top11, and reports row counts per
+ * related collection (Contestants, Votes, WriteIns, WinnerDraws) per
+ * contest. Prints a cleanup plan. Deletes nothing.
+ *
+ * Usage:
+ *   YES_I_MEAN_PROD=true yarn tsx --import ./bin/preload-nextenv-fix.mjs \
+ *     bin/migrations/inspectTop11Prod.ts
+ */
+
+import { getPayloadClient } from './shared/payloadClient';
+
+const LIVE_CONTEST_DATE = 'July 2, 2026';
+const LIVE_SONGS = [
+  'Yip Yip Yow',
+  'Chance To Bleed',
+  'Sun Has Set',
+  'G.O.D. And The Broken Ribs',
+  'Switch Up',
+  'Burning Out',
+  'A Good Day for Dying',
+  'Call It In',
+  'Going Shopping',
+  'Violins*',
+  'Hot Slob',
+];
+
+async function main() {
+  const payload = await getPayloadClient('prod-neon');
+
+  const contests = await payload.find({
+    collection: 'top11-contests',
+    limit: 1000,
+    depth: 1,
+  });
+
+  console.log(`\nFound ${contests.totalDocs} Top11Contests rows on production.\n`);
+
+  for (const contest of contests.docs) {
+    const entries = Array.isArray((contest as any).entries) ? (contest as any).entries : [];
+    const entrySongTitles = entries
+      .map((e: any) => (typeof e.song === 'object' ? e.song?.title : e.song))
+      .filter(Boolean);
+
+    const matchCount = entrySongTitles.filter((title: string) =>
+      LIVE_SONGS.some((liveSong) => title?.includes(liveSong.replace('*', ''))),
+    ).length;
+
+    const isLikelyLive = matchCount >= 8;
+
+    const [contestants, votes, writeIns, winnerDraws] = await Promise.all([
+      payload.find({
+        collection: 'top11-contestants',
+        where: { contest: { equals: contest.id } },
+        limit: 0,
+      }),
+      payload.find({
+        collection: 'top11-votes',
+        where: { contest: { equals: contest.id } },
+        limit: 0,
+      }),
+      payload.find({
+        collection: 'top11-write-ins',
+        where: { contest: { equals: contest.id } },
+        limit: 0,
+      }),
+      payload.find({
+        collection: 'top11-winner-draws',
+        where: { contest: { equals: contest.id } },
+        limit: 0,
+      }),
+    ]);
+
+    console.log(
+      `Contest id=${contest.id} status=${(contest as any).status} ` +
+        `entries=${entries.length} matchedLiveSongs=${matchCount}/11 ` +
+        `${isLikelyLive ? `<-- LIKELY THE LIVE CONTEST (${LIVE_CONTEST_DATE})` : ''}`,
+    );
+    console.log(
+      `  contestants=${contestants.totalDocs} votes=${votes.totalDocs} ` +
+        `writeIns=${writeIns.totalDocs} winnerDraws=${winnerDraws.totalDocs}`,
+    );
+
+    if (process.env.VERBOSE === 'true') {
+      const mask = (value: unknown) => {
+        const str = String(value ?? '');
+        if (!str) return '(empty)';
+        return str.length <= 4 ? '*'.repeat(str.length) : `${str.slice(0, 2)}***${str.slice(-2)}`;
+      };
+      const qaLike = (value: unknown) => /^qa-test/i.test(String(value ?? ''));
+
+      console.log(`  entry songs: ${entrySongTitles.join(' | ')}`);
+      console.log(
+        `  contestant emails (masked): ${contestants.docs
+          .map((c: any) => `${mask(c.email)}${qaLike(c.email) ? '[QA]' : ''}`)
+          .join(', ')}`,
+      );
+      console.log(
+        `  voter emails/keys (masked): ${votes.docs
+          .map((v: any) => {
+            const raw = v.voterEmail || v.voterKey || v.voterUserId;
+            return `${mask(raw)}${qaLike(raw) ? '[QA]' : ''}`;
+          })
+          .join(', ')}`,
+      );
+      console.log(`  write-ins: ${writeIns.docs.map((w: any) => w.writeIn).join(' | ')}`);
+    }
+  }
+
+  console.log('\nNo data was modified. Review the output above before writing a cleanup script.\n');
+
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('Inspection failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Closes chapter 19a's postmortem cleanup item: leftover synthetic QA rows (`qa-test%`-style emails, demo vote/write-in fixtures) landed on production alongside a real imported contest during a Neon connection-string incident.
- Adds `bin/migrations/inspectTop11Prod.ts` — read-only, identifies which `Top11Contests` row matches what's currently live on `ynotradio.net/top11` (by song-title overlap) vs. leftover seed data, with PII-masked verbose output.
- Adds `bin/migrations/cleanupSeedTop11Contest.ts` — deletes a given contest id and its dependent rows (Contestants, Votes, WriteIns, WinnerDraws), dry-run by default, requires `--confirm` to actually delete and `--contest-id` explicitly (no default target).
- **Already run against production**: removed contest id=2 (the seed contest — `qa-test` emails, a "QA Visible MySQL Band - Demo Song" write-in, only 3/11 songs matching live prod) — 3 contestants, 3 votes, 2 write-ins, 1 contest row deleted. Verified afterward: production now has exactly one `Top11Contests` row (id=3), matching the live page's 11-song list, with its 40 contestants and 125 votes (matching the postmortem's documented vote count) intact.

## Test plan
- [x] Dry run (`inspectTop11Prod.ts`) confirmed contest id/counts before any deletion
- [x] `cleanupSeedTop11Contest.ts --contest-id 2` (no `--confirm`) dry run matched inspection output exactly
- [x] Ran with `--confirm` against prod; re-ran `inspectTop11Prod.ts` afterward to verify only the real contest remains
- [x] `yarn eslint` / `yarn prettier --check` clean on both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2