### PR TITLE
feat: add votes-only incremental Top11 import for mid-contest cutover

### DIFF
--- a/bin/migrations/importTop11Votes.test.ts
+++ b/bin/migrations/importTop11Votes.test.ts
@@ -4,7 +4,7 @@ vi.mock('mysql2/promise', () => ({}));
 vi.mock('./shared/payloadClient', () => ({ getPayloadClient: vi.fn() }));
 vi.mock('../../config/databases', () => ({ getMySQLConfig: vi.fn() }));
 
-const { importVotesIncremental } = await import('./importTop11Votes');
+const { importVotesIncremental, mapNomineesToSongIds } = await import('./importTop11Votes');
 
 function makePayload(existingVoteDocs: Record<string, unknown>[] = []) {
   const create = vi.fn().mockResolvedValue({ id: 1 });
@@ -141,5 +141,110 @@ describe('importVotesIncremental', () => {
     await expect(importVotesIncremental(payload, 5, nominees, new Map(), voters)).rejects.toThrow(
       'No nominee resolved to a song',
     );
+  });
+
+  describe('per-song accuracy (headroom-aware real-voter assignment)', () => {
+    it('never assigns a real voter to a song that is already at its legacy target', async () => {
+      // Song A's target is 2 and already has 2 existing rows (full);
+      // Song B's target is 1 and has 0. A new real voter must land on Song B.
+      const payload = makePayload([
+        { voterUserId: 'legacy-import:1', song: 1 },
+        { voterUserId: 'legacy-import:2', song: 1 },
+      ]);
+      const voters = [{ user_email: 'real@example.com', user_auth0_id: null }];
+
+      const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+      const calls = payload.create.mock.calls.map((c: any[]) => c[0].data);
+      const realVoterCall = calls.find((c: any) => c.voterEmail === 'real@example.com');
+      expect(realVoterCall.song).toBe(2);
+      expect(result.overflowAssignments).toBe(0);
+    });
+
+    it('produces per-song totals that exactly match top11songs.value when voters fit within capacity', async () => {
+      // Total legacy target across both songs is 3; 2 real voters register.
+      const payload = makePayload([]);
+      const voters = [
+        { user_email: 'voter1@example.com', user_auth0_id: null },
+        { user_email: 'voter2@example.com', user_auth0_id: null },
+      ];
+
+      const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+      const calls = payload.create.mock.calls.map((c: any[]) => c[0].data);
+      const countBySong = new Map<number, number>();
+      calls.forEach((c: any) => countBySong.set(c.song, (countBySong.get(c.song) ?? 0) + 1));
+
+      expect(countBySong.get(1)).toBe(2); // Song A target
+      expect(countBySong.get(2)).toBe(1); // Song B target
+      expect(result.overflowAssignments).toBe(0);
+    });
+
+    it('reports overflowAssignments when more voters register than legacy counted votes in total', async () => {
+      // Total legacy target is 3 (2 + 1), but 5 voters register -- 2 must
+      // overflow past every song's target to still get a dedup-guard row.
+      const payload = makePayload([]);
+      const voters = [
+        { user_email: 'v1@example.com', user_auth0_id: null },
+        { user_email: 'v2@example.com', user_auth0_id: null },
+        { user_email: 'v3@example.com', user_auth0_id: null },
+        { user_email: 'v4@example.com', user_auth0_id: null },
+        { user_email: 'v5@example.com', user_auth0_id: null },
+      ];
+
+      const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+      expect(result.created).toBe(5);
+      expect(result.overflowAssignments).toBe(2);
+    });
+  });
+
+  describe('mapNomineesToSongIds', () => {
+    function makeContestPayload(nomineeSongs: { id: number; title: string; artist?: any }[]) {
+      return {
+        findByID: vi.fn().mockResolvedValue({
+          nominees: nomineeSongs.map((song) => ({ song })),
+        }),
+      } as any;
+    }
+
+    it('matches titles that differ only by trailing punctuation', async () => {
+      // Regression: a nominee stored in Payload as "MOST NORMAL AMERICAN
+      // VOTER:" (trailing colon) failed to match legacy's
+      // "MOST NORMAL AMERICAN VOTER" (no colon) before normalizeTitle()
+      // stripped trailing punctuation, silently dropping that song's votes.
+      const payload = makeContestPayload([
+        { id: 999, title: 'MOST NORMAL AMERICAN VOTER:' },
+      ]);
+      const legacyNominees = [
+        { id: 912, artist: 'Genesis Owusu', song: 'MOST NORMAL AMERICAN VOTER', value: 2 },
+      ];
+
+      const result = await mapNomineesToSongIds(payload, 3, legacyNominees);
+
+      expect(result.get(912)).toBe(999);
+    });
+
+    it('matches titles that differ only by case and whitespace', async () => {
+      const payload = makeContestPayload([{ id: 1, title: 'Chance to Bleed' }]);
+      const legacyNominees = [
+        { id: 852, artist: 'Kurt Vile', song: 'Chance To Bleed', value: 9 },
+      ];
+
+      const result = await mapNomineesToSongIds(payload, 3, legacyNominees);
+
+      expect(result.get(852)).toBe(1);
+    });
+
+    it('does not map a nominee with no matching song in the contest', async () => {
+      const payload = makeContestPayload([{ id: 1, title: 'Some Other Song' }]);
+      const legacyNominees = [
+        { id: 999, artist: 'Nobody', song: 'Completely Different Title', value: 3 },
+      ];
+
+      const result = await mapNomineesToSongIds(payload, 3, legacyNominees);
+
+      expect(result.has(999)).toBe(false);
+    });
   });
 });

--- a/bin/migrations/importTop11Votes.test.ts
+++ b/bin/migrations/importTop11Votes.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('mysql2/promise', () => ({}));
+vi.mock('./shared/payloadClient', () => ({ getPayloadClient: vi.fn() }));
+vi.mock('../../config/databases', () => ({ getMySQLConfig: vi.fn() }));
+
+const { importVotesIncremental } = await import('./importTop11Votes');
+
+function makePayload(existingVoteDocs: Record<string, unknown>[] = []) {
+  const create = vi.fn().mockResolvedValue({ id: 1 });
+  const find = vi
+    .fn()
+    .mockResolvedValue({ docs: existingVoteDocs, totalDocs: existingVoteDocs.length });
+  return { create, find } as any;
+}
+
+describe('importVotesIncremental', () => {
+  const nominees = [
+    { id: 101, artist: 'A', song: 'Song A', value: 2 },
+    { id: 102, artist: 'B', song: 'Song B', value: 1 },
+  ];
+  const songIdByLegacyId = new Map([
+    [101, 1],
+    [102, 2],
+  ]);
+
+  it('creates one vote row per counted slot on a fresh contest with no registered voters', async () => {
+    const payload = makePayload([]);
+    const voters: { user_email: string; user_auth0_id: string | null }[] = [];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    // 2 (Song A) + 1 (Song B) = 3 counted slots total, all synthetic
+    expect(result.created).toBe(3);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(payload.create).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives every registered voter a real-identity row, then tops up remaining counted total synthetically', async () => {
+    const payload = makePayload([]);
+    const voters = [{ user_email: 'real@example.com', user_auth0_id: 'auth0|abc' }];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    // 1 real-voter row + (3 counted total - 1 already covered by that row) = 3 total
+    expect(result.created).toBe(3);
+    const calls = payload.create.mock.calls.map((c: any[]) => c[0].data);
+    expect(calls[0]).toMatchObject({ voterEmail: 'real@example.com', voterAuth0Id: 'auth0|abc' });
+    expect(calls.slice(1).every((c: any) => typeof c.voterUserId === 'string')).toBe(true);
+  });
+
+  it('gives a write-in-only voter (zero counted checkbox votes) a dedup-guard row anyway', async () => {
+    // This voter registered in top11_user_votes but cast no checkbox picks --
+    // legacy's top11songs.value never reflects them, yet they must still get
+    // a row so hasUserVotedThisWeek() blocks a post-cutover re-vote.
+    const payload = makePayload([]);
+    const voters = [
+      { user_email: 'checkbox-voter@example.com', user_auth0_id: null },
+      { user_email: 'writein-only@example.com', user_auth0_id: null },
+      { user_email: 'another-checkbox-voter@example.com', user_auth0_id: null },
+      { user_email: 'yet-another@example.com', user_auth0_id: null },
+    ];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    const calls = payload.create.mock.calls.map((c: any[]) => c[0].data);
+    const coveredEmails = calls.map((c: any) => c.voterEmail).filter(Boolean);
+    expect(coveredEmails).toEqual(voters.map((v) => v.user_email));
+    expect(result.created).toBeGreaterThanOrEqual(voters.length);
+  });
+
+  it('skips a real voter already imported by voterAuth0Id on a re-run', async () => {
+    const payload = makePayload([
+      { voterAuth0Id: 'auth0|abc', voterEmail: 'real@example.com', song: 1 },
+    ]);
+    const voters = [{ user_email: 'real@example.com', user_auth0_id: 'auth0|abc' }];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    expect(result.skipped).toBe(1);
+    // 3 counted total - 1 already covered by the real voter's existing row = 2
+    expect(result.created).toBe(2);
+  });
+
+  it('skips a real voter already imported by voterEmail when no auth0Id was recorded', async () => {
+    const payload = makePayload([{ voterEmail: 'real@example.com', song: 1 }]);
+    const voters = [{ user_email: 'real@example.com', user_auth0_id: null }];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    expect(result.skipped).toBe(1);
+    expect(result.created).toBe(2);
+  });
+
+  it('is fully idempotent: a second run with the same inputs creates nothing new', async () => {
+    // First run's output, as importVotesIncremental would have created it:
+    // the real voter's row (arbitrary song) plus synthetic top-up rows for
+    // Song A (2 total) and Song B (1 total).
+    const firstRunDocs = [
+      { voterEmail: 'real@example.com', voterAuth0Id: 'auth0|abc', song: 1 },
+      { voterUserId: 'legacy-import:1', song: 1 },
+      { voterUserId: 'legacy-import:2', song: 2 },
+    ];
+    const payload = makePayload(firstRunDocs);
+    const voters = [{ user_email: 'real@example.com', user_auth0_id: 'auth0|abc' }];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(payload.create).not.toHaveBeenCalled();
+  });
+
+  it('does not double-count a synthetic row already imported for a song when topping up', async () => {
+    // Song A (target 2) already has 1 synthetic row; Song B (target 1) has 0.
+    const payload = makePayload([{ voterUserId: 'legacy-import:1', song: 1 }]);
+    const voters: { user_email: string; user_auth0_id: string | null }[] = [];
+
+    const result = await importVotesIncremental(payload, 5, nominees, songIdByLegacyId, voters);
+
+    // Song A needs 1 more, Song B needs 1 -- not 3 fresh rows
+    expect(result.created).toBe(2);
+  });
+
+  it('skips nominees with no mapped song id', async () => {
+    const payload = makePayload([]);
+    const partialMap = new Map([[101, 1]]);
+    const voters: { user_email: string; user_auth0_id: string | null }[] = [];
+
+    const result = await importVotesIncremental(payload, 5, nominees, partialMap, voters);
+
+    // Only Song A's 2 slots count; Song B's nominee has no mapped id
+    expect(result.created).toBe(2);
+  });
+
+  it('throws if no nominee resolves to a song but voters are registered', async () => {
+    const payload = makePayload([]);
+    const voters = [{ user_email: 'real@example.com', user_auth0_id: null }];
+
+    await expect(importVotesIncremental(payload, 5, nominees, new Map(), voters)).rejects.toThrow(
+      'No nominee resolved to a song',
+    );
+  });
+});

--- a/bin/migrations/importTop11Votes.ts
+++ b/bin/migrations/importTop11Votes.ts
@@ -18,18 +18,32 @@
  * voter-to-song mapping. This script preserves both properties the app
  * actually depends on:
  *   - Per-song tallies (Top11Contests' /stats endpoint, which counts
- *     top11-votes rows grouped by song) stay accurate: it creates exactly
- *     `top11songs.value` vote rows per nominee song, matching legacy's
- *     counter.
+ *     top11-votes rows grouped by song) match legacy's top11songs.value
+ *     exactly: real voters are only ever assigned to a song that still has
+ *     headroom under its legacy target (nextArbitrarySongId() checks
+ *     targetCountBySong before placing a row), so a dedup-guard row never
+ *     pushes a song's count past what legacy actually recorded. Verified
+ *     against a real production snapshot: 56/56 nominees matched exactly
+ *     after this fix (an earlier version assigned real voters round-robin
+ *     with no headroom check, which could and did overcount specific
+ *     songs -- caught during manual song-for-song parity verification).
  *   - Per-voter dedup (hasUserVotedThisWeek(), which checks for any
  *     top11-votes row matching the voter's email/auth0Id in this contest)
  *     stays correct: every real registered voter from top11_user_votes gets
  *     one of those counted rows under their real identity, so they cannot
- *     vote again after cutover. Which specific song their row references is
- *     arbitrary (legacy never recorded it) -- this only affects that one
- *     legacy-attributed row's song, not the total count for any song.
- *   - Remaining counted slots (value - real voters) get synthetic
- *     `legacy-import:<n>` identities, same as importTop11.ts.
+ *     vote again after cutover. Which specific song (among those with
+ *     headroom) their row references is arbitrary -- legacy never recorded
+ *     it -- but it never exceeds that song's legacy count.
+ *   - Remaining counted slots (value - real voters already placed there)
+ *     get synthetic `legacy-import:<n>` identities, same as importTop11.ts.
+ *   - Edge case: if more voters registered than legacy counted votes in
+ *     total (e.g. write-in-only voters, who show up in top11_user_votes
+ *     but never call addVote()), every song eventually runs out of
+ *     headroom. Remaining voters still get a dedup-guard row -- that
+ *     guarantee is non-negotiable -- but land on a song past its legacy
+ *     target. This is logged loudly (overflowAssignments) rather than
+ *     silently, since it means per-song accuracy is no longer exact for
+ *     whichever song absorbed the overflow.
  *
  * Incremental/idempotent: on each run, already-imported real voters (by
  * voterEmail/voterAuth0Id) and the synthetic slots already created for this
@@ -172,8 +186,19 @@ function stripHtmlTagsForComparison(text: string): string {
     .trim();
 }
 
+/**
+ * Normalizes a title/artist string for comparison: strips HTML tags,
+ * trailing punctuation (observed drift case: a nominee stored in Payload
+ * as "MOST NORMAL AMERICAN VOTER:" against legacy's "MOST NORMAL AMERICAN
+ * VOTER" -- same song, a colon apparently added or dropped between when
+ * the song doc was created and legacy's current text), and case.
+ */
 function normalizeTitle(text: string): string {
-  return stripHtmlTagsForComparison(text).trim().toLowerCase();
+  return stripHtmlTagsForComparison(text)
+    .trim()
+    .toLowerCase()
+    .replace(/[.,:;!?'"*]+$/, '')
+    .trim();
 }
 
 /**
@@ -190,7 +215,7 @@ function normalizeTitle(text: string): string {
  * up front), matching against that fixed set locally is both correct and
  * fast enough to re-run every few minutes before cutover.
  */
-async function mapNomineesToSongIds(
+export async function mapNomineesToSongIds(
   payload: Payload,
   contestId: number,
   nominees: NomineeRow[],
@@ -256,7 +281,7 @@ export async function importVotesIncremental(
   nominees: NomineeRow[],
   songIdByLegacyId: Map<number, number>,
   voters: UserVoteRow[],
-): Promise<{ created: number; skipped: number; errors: number }> {
+): Promise<{ created: number; skipped: number; errors: number; overflowAssignments: number }> {
   const nomineeSongIds = nominees
     .map((nominee) => songIdByLegacyId.get(nominee.id))
     .filter((id): id is number => id !== undefined);
@@ -311,13 +336,26 @@ export async function importVotesIncremental(
   let created = 0;
   let skipped = 0;
   let errors = 0;
-  let nextSongIndex = 0;
+  let overflowAssignments = 0;
   let nextSyntheticIndex = maxExistingSyntheticIndex + 1;
 
+  // Picks a song with remaining headroom under its legacy top11songs.value
+  // target, so a real voter's dedup-guard row never pushes a song's count
+  // past what legacy actually recorded. Falls back to the first nominee
+  // (and counts the overflow) only if every song is already at its target
+  // -- i.e. more registered voters exist than legacy's counted votes, which
+  // can happen for write-in-only voters. That fallback trades per-song
+  // accuracy for the non-negotiable guarantee that every registered voter
+  // gets a dedup row.
   const nextArbitrarySongId = (): number => {
-    const songId = nomineeSongIds[nextSongIndex % nomineeSongIds.length];
-    nextSongIndex += 1;
-    return songId;
+    const withHeadroom = nomineeSongIds.find((id) => {
+      const target = targetCountBySong.get(id) ?? 0;
+      const existing = existingCountBySong.get(id) ?? 0;
+      return existing < target;
+    });
+    if (withHeadroom !== undefined) return withHeadroom;
+    overflowAssignments += 1;
+    return nomineeSongIds[0];
   };
 
   const recordCreatedRow = (songId: number): void => {
@@ -374,7 +412,9 @@ export async function importVotesIncremental(
     }
   }
 
-  return { created, skipped, errors };
+  return {
+    created, skipped, errors, overflowAssignments,
+  };
 }
 
 async function main(): Promise<void> {
@@ -432,6 +472,15 @@ async function main(): Promise<void> {
       `Votes: ${result.created} created, ${result.skipped} already present (skipped), `
         + `${result.errors} failed`,
     );
+    if (result.overflowAssignments > 0) {
+      logger.warn(
+        `${result.overflowAssignments} registered voter(s) exceeded every song's `
+          + 'top11songs.value target and were assigned past their song\'s legacy count '
+          + '-- more voters registered than legacy counted votes (e.g. write-in-only '
+          + 'voters). Per-song tallies for the affected song(s) will run ahead of legacy '
+          + 'by that amount; every voter still has exactly one dedup-guard row.',
+      );
+    }
   } finally {
     await connection.end();
   }

--- a/bin/migrations/importTop11Votes.ts
+++ b/bin/migrations/importTop11Votes.ts
@@ -1,0 +1,445 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-await-in-loop */
+/**
+ * Import only the votes for the current Top 11 contest from legacy MySQL
+ * into an already-existing Top11Contests row in Payload/Postgres.
+ *
+ * Unlike importTop11.ts (which creates the contest, chart entries, nominee
+ * pool, contestants, and write-ins), this script touches only top11-votes.
+ * It's meant to run repeatedly in the hours/days before a mid-contest
+ * cutover -- each run tops up Postgres with whatever new votes have landed
+ * in legacy MySQL since the last run, so the gap at cutover time is as
+ * small as possible.
+ *
+ * Cutover safety: legacy's top11_user_votes table records "this voter cast
+ * a ballot this week" (unique per email+voting_period) but never recorded
+ * which song(s) they picked -- top11songs.value is a per-song counter with
+ * no voter attribution at all. So there is no way to recover real
+ * voter-to-song mapping. This script preserves both properties the app
+ * actually depends on:
+ *   - Per-song tallies (Top11Contests' /stats endpoint, which counts
+ *     top11-votes rows grouped by song) stay accurate: it creates exactly
+ *     `top11songs.value` vote rows per nominee song, matching legacy's
+ *     counter.
+ *   - Per-voter dedup (hasUserVotedThisWeek(), which checks for any
+ *     top11-votes row matching the voter's email/auth0Id in this contest)
+ *     stays correct: every real registered voter from top11_user_votes gets
+ *     one of those counted rows under their real identity, so they cannot
+ *     vote again after cutover. Which specific song their row references is
+ *     arbitrary (legacy never recorded it) -- this only affects that one
+ *     legacy-attributed row's song, not the total count for any song.
+ *   - Remaining counted slots (value - real voters) get synthetic
+ *     `legacy-import:<n>` identities, same as importTop11.ts.
+ *
+ * Incremental/idempotent: on each run, already-imported real voters (by
+ * voterEmail/voterAuth0Id) and the synthetic slots already created for this
+ * contest are skipped -- only the difference is inserted. Safe to run many
+ * times before cutover.
+ *
+ * Usage:
+ *   yarn import:top11-votes [--from local-mysql|prod-mysql]
+ *     [--to local-postgres|dev-neon|prod-neon] [--contest-id <id>]
+ *
+ * Defaults: --from local-mysql --to local-postgres. Prod targets require
+ * the explicit confirmation env enforced by getPayloadClient.
+ *
+ * --contest-id is optional; if omitted, the script finds the Top11Contests
+ * row whose weekOf matches legacy's current placement-99 date row (same
+ * week-matching importTop11.ts uses) and requires exactly one match.
+ */
+
+import * as mysql from 'mysql2/promise';
+import type { Payload } from 'payload';
+import { getPayloadClient } from './shared/payloadClient';
+import type { PostgresTarget } from './shared/payloadClient';
+import { createLogger } from './shared/logger';
+import { getMySQLConfig, type MySQLSource } from '../../config/databases';
+
+const logger = createLogger('Top11VotesImport');
+
+interface ChartRow {
+  placement: number;
+  artist: string;
+  song: string;
+  note: string | null;
+}
+
+interface NomineeRow {
+  id: number;
+  artist: string;
+  song: string;
+  value: number;
+}
+
+interface UserVoteRow {
+  user_email: string;
+  user_auth0_id: string | null;
+}
+
+interface ImportOptions {
+  from: MySQLSource;
+  to: PostgresTarget;
+  contestId: number | null;
+}
+
+function parseArgs(): ImportOptions {
+  const args = process.argv.slice(2);
+  const options: ImportOptions = { from: 'local-mysql', to: 'local-postgres', contestId: null };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--from') {
+      const value = args[i + 1];
+      if (value !== 'local-mysql' && value !== 'prod-mysql') {
+        throw new Error('--from must be "local-mysql" or "prod-mysql"');
+      }
+      options.from = value;
+      i += 1;
+    } else if (arg === '--to') {
+      const value = args[i + 1];
+      if (value !== 'local-postgres' && value !== 'prod-neon' && value !== 'dev-neon') {
+        throw new Error('--to must be "local-postgres", "prod-neon", or "dev-neon"');
+      }
+      options.to = value;
+      i += 1;
+    } else if (arg === '--contest-id') {
+      options.contestId = Number(args[i + 1]);
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: yarn import:top11-votes [--from local-mysql|prod-mysql]'
+          + ' [--to local-postgres|dev-neon|prod-neon] [--contest-id <id>]',
+      );
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+/** Parse the legacy display date ("July 2, 2026") into a UTC-midnight ISO string. */
+function parseWeekOf(dateStr: string): string {
+  const parsed = new Date(dateStr);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Cannot parse legacy Top 11 date "${dateStr}"`);
+  }
+  return new Date(
+    Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()),
+  ).toISOString();
+}
+
+async function findContestId(
+  payload: Payload,
+  weekOf: string,
+  explicitContestId: number | null,
+): Promise<number> {
+  if (explicitContestId !== null) {
+    const contest = await payload.findByID({
+      collection: 'top11-contests',
+      id: explicitContestId,
+      depth: 0,
+    });
+    if (!contest) {
+      throw new Error(`No top11-contests row with id=${explicitContestId}`);
+    }
+    return explicitContestId;
+  }
+
+  const existing = await payload.find({
+    collection: 'top11-contests',
+    where: { weekOf: { equals: weekOf } },
+    limit: 1,
+    depth: 0,
+  });
+
+  if (existing.docs.length === 0) {
+    throw new Error(
+      `No top11-contests row found for week of ${weekOf}. This script only imports votes into `
+        + 'an existing contest -- run importTop11.ts first to create it.',
+    );
+  }
+
+  return existing.docs[0].id as number;
+}
+
+/** Strips HTML tags for comparison purposes only -- same rules as importUtils' stripHtmlTags. */
+function stripHtmlTagsForComparison(text: string): string {
+  return text
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/(p|div|h[1-6]|li|td|th|tr)>/gi, ' ')
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeTitle(text: string): string {
+  return stripHtmlTagsForComparison(text).trim().toLowerCase();
+}
+
+/**
+ * Maps legacy nominee-pool song rows to their canonical Payload song ids
+ * by matching against the contest's own nominees array (title + artist
+ * name, case/whitespace/HTML-tag-insensitive).
+ *
+ * Deliberately does NOT call findOrCreateArtist/findOrCreateSong (which
+ * importSongPool() in importTop11.ts uses to build the pool in the first
+ * place) -- those make network calls (MusicBrainz lookups) per song, which
+ * made an early version of this script take 15+ seconds per nominee and
+ * effectively hang on the ~57-song pool. Since the contest's nominees
+ * already exist by the time this script runs (importTop11.ts creates them
+ * up front), matching against that fixed set locally is both correct and
+ * fast enough to re-run every few minutes before cutover.
+ */
+async function mapNomineesToSongIds(
+  payload: Payload,
+  contestId: number,
+  nominees: NomineeRow[],
+): Promise<Map<number, number>> {
+  const contest = (await payload.findByID({
+    collection: 'top11-contests',
+    id: contestId,
+    depth: 1,
+  })) as {
+    nominees?: {
+      song: number | { id: number; title?: string; artist?: number | { name?: string } };
+    }[];
+  };
+
+  const contestSongs = (contest.nominees ?? [])
+    .map((n) => (typeof n.song === 'object' ? n.song : null))
+    .filter((s): s is { id: number; title?: string; artist?: number | { name?: string } } => (
+      s !== null
+    ));
+
+  const songIdByLegacyId = new Map<number, number>();
+  for (const nominee of nominees) {
+    const normalizedTitle = normalizeTitle(nominee.song);
+    const normalizedArtist = normalizeTitle(nominee.artist);
+
+    const match = contestSongs.find((s) => {
+      if (normalizeTitle(s.title ?? '') !== normalizedTitle) return false;
+      const artistName = typeof s.artist === 'object' ? s.artist?.name : undefined;
+      return artistName ? normalizeTitle(artistName) === normalizedArtist : true;
+    });
+
+    if (match) {
+      songIdByLegacyId.set(nominee.id, match.id);
+    } else {
+      logger.warn(
+        `Nominee "${nominee.artist} - ${nominee.song}" (legacy id ${nominee.id}) has no `
+          + "matching song in the contest's nominees array -- its votes will be skipped. "
+          + 'Re-run importTop11.ts if the nominee pool is stale.',
+      );
+    }
+  }
+  return songIdByLegacyId;
+}
+
+/**
+ * Every registered voter (top11_user_votes) gets exactly one dedup-guard
+ * vote row under their real identity, unconditionally -- including voters
+ * who only submitted a write-in with no checkbox picks, who would
+ * otherwise have zero rows in top11songs.value's counted total and so be
+ * invisible to hasUserVotedThisWeek() after cutover. Song attribution for
+ * these rows is arbitrary: legacy never recorded voter-to-song mapping.
+ *
+ * Per-song tallies stay accurate separately: after every voter's row is
+ * placed, synthetic legacy-import:<n> rows top up each song to its
+ * top11songs.value count. A voter's row already counts toward whichever
+ * song it was arbitrarily assigned, so that song needs one fewer synthetic
+ * fill than its raw counter -- this only shifts which specific row
+ * "represents" a given count, never double-counts or under-counts a song.
+ */
+export async function importVotesIncremental(
+  payload: Payload,
+  contestId: number,
+  nominees: NomineeRow[],
+  songIdByLegacyId: Map<number, number>,
+  voters: UserVoteRow[],
+): Promise<{ created: number; skipped: number; errors: number }> {
+  const nomineeSongIds = nominees
+    .map((nominee) => songIdByLegacyId.get(nominee.id))
+    .filter((id): id is number => id !== undefined);
+
+  if (nomineeSongIds.length === 0 && voters.length > 0) {
+    throw new Error(
+      'No nominee resolved to a song on this contest -- cannot attach dedup-guard vote rows. '
+        + 'Re-run importTop11.ts to refresh the nominee pool before importing votes.',
+    );
+  }
+
+  // Target counted total per song, from legacy's top11songs.value.
+  const targetCountBySong = new Map<number, number>();
+  nominees.forEach((nominee) => {
+    const songId = songIdByLegacyId.get(nominee.id);
+    if (songId === undefined) return;
+    targetCountBySong.set(songId, (targetCountBySong.get(songId) ?? 0) + nominee.value);
+  });
+
+  const existingVotes = await payload.find({
+    collection: 'top11-votes',
+    where: { contest: { equals: contestId }, voteSource: { equals: 'legacy-import' } },
+    limit: 0,
+    depth: 0,
+  });
+
+  const existingRealIdentities = new Set<string>();
+  // How many rows (real or synthetic) already exist per song -- this is
+  // all that's needed to decide how many synthetic top-up rows a song
+  // still needs; synthetic labels themselves don't need to be stable
+  // across runs, only unique per row created.
+  const existingCountBySong = new Map<number, number>();
+  let maxExistingSyntheticIndex = 0;
+
+  existingVotes.docs.forEach((vote: any) => {
+    const identity = vote.voterAuth0Id || vote.voterEmail;
+    if (identity) existingRealIdentities.add(identity);
+
+    if (typeof vote.voterUserId === 'string' && vote.voterUserId.startsWith('legacy-import:')) {
+      const index = Number(vote.voterUserId.slice('legacy-import:'.length));
+      if (Number.isInteger(index)) {
+        maxExistingSyntheticIndex = Math.max(maxExistingSyntheticIndex, index);
+      }
+    }
+
+    const songId = typeof vote.song === 'object' ? vote.song?.id : vote.song;
+    if (songId !== undefined) {
+      existingCountBySong.set(songId, (existingCountBySong.get(songId) ?? 0) + 1);
+    }
+  });
+
+  let created = 0;
+  let skipped = 0;
+  let errors = 0;
+  let nextSongIndex = 0;
+  let nextSyntheticIndex = maxExistingSyntheticIndex + 1;
+
+  const nextArbitrarySongId = (): number => {
+    const songId = nomineeSongIds[nextSongIndex % nomineeSongIds.length];
+    nextSongIndex += 1;
+    return songId;
+  };
+
+  const recordCreatedRow = (songId: number): void => {
+    existingCountBySong.set(songId, (existingCountBySong.get(songId) ?? 0) + 1);
+  };
+
+  const createVote = async (
+    identity: Record<string, string>,
+    songId: number,
+    label: string,
+  ): Promise<void> => {
+    try {
+      await payload.create({
+        collection: 'top11-votes',
+        data: {
+          contest: contestId,
+          song: songId,
+          voteSource: 'legacy-import',
+          ...identity,
+        },
+      });
+      created += 1;
+      recordCreatedRow(songId);
+    } catch (err) {
+      errors += 1;
+      logger.warn(`Vote for ${label} failed: ${(err as Error).message}`);
+    }
+  };
+
+  // Every registered voter gets one dedup-guard row, unconditionally --
+  // including voters who only wrote in a song with no checkbox picks.
+  for (const voter of voters) {
+    const voterEmail = voter.user_email.trim().toLowerCase();
+    const voterAuth0Id = voter.user_auth0_id?.trim() || undefined;
+    const identity = { voterEmail, ...(voterAuth0Id ? { voterAuth0Id } : {}) };
+
+    if (existingRealIdentities.has(voterAuth0Id || voterEmail)) {
+      skipped += 1;
+    } else {
+      const songId = nextArbitrarySongId();
+      await createVote(identity, songId, voterEmail);
+    }
+  }
+
+  // Top up each song's row count to match its target from top11songs.value.
+  for (const [songId, target] of targetCountBySong) {
+    const existingCount = existingCountBySong.get(songId) ?? 0;
+    const stillNeeded = Math.max(target - existingCount, 0);
+
+    for (let i = 0; i < stillNeeded; i += 1) {
+      const syntheticId = `legacy-import:${nextSyntheticIndex}`;
+      nextSyntheticIndex += 1;
+      await createVote({ voterUserId: syntheticId }, songId, syntheticId);
+    }
+  }
+
+  return { created, skipped, errors };
+}
+
+async function main(): Promise<void> {
+  process.env.PAYLOAD_MIGRATING = 'true';
+
+  const options = parseArgs();
+  logger.info(`Importing Top 11 votes from ${options.from} to ${options.to}`);
+
+  const connection = await mysql.createConnection(getMySQLConfig(options.from));
+
+  try {
+    const [chartRows] = await connection.execute<mysql.RowDataPacket[]>(
+      'SELECT placement, artist, song, note FROM top11 ORDER BY placement',
+    );
+    const [nomineeRows] = await connection.execute<mysql.RowDataPacket[]>(
+      "SELECT id, artist, song, value FROM top11songs WHERE deleted = 'n' ORDER BY id",
+    );
+
+    const dateRow = (chartRows as ChartRow[]).find((row) => row.placement === 99);
+    if (!dateRow?.artist) {
+      throw new Error('Legacy top11 table has no date row (placement 99)');
+    }
+
+    const [voterRows] = await connection.execute<mysql.RowDataPacket[]>(
+      'SELECT user_email, user_auth0_id FROM top11_user_votes WHERE voting_period = ? ORDER BY id',
+      [dateRow.artist],
+    );
+
+    const weekOf = parseWeekOf(dateRow.artist);
+    logger.info(
+      `Legacy contest: week of ${dateRow.artist}, ${nomineeRows.length} nominees, `
+        + `${voterRows.length} registered voters`,
+    );
+
+    const payload = await getPayloadClient(options.to);
+
+    const contestId = await findContestId(payload, weekOf, options.contestId);
+    logger.info(`Target contest: id=${contestId}`);
+
+    const songIdByLegacyId = await mapNomineesToSongIds(
+      payload,
+      contestId,
+      nomineeRows as NomineeRow[],
+    );
+
+    const result = await importVotesIncremental(
+      payload,
+      contestId,
+      nomineeRows as NomineeRow[],
+      songIdByLegacyId,
+      voterRows as UserVoteRow[],
+    );
+
+    logger.info(
+      `Votes: ${result.created} created, ${result.skipped} already present (skipped), `
+        + `${result.errors} failed`,
+    );
+  } finally {
+    await connection.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    logger.error(`Import failed: ${(error as Error).message}`);
+    process.exit(1);
+  });
+}

--- a/docs/payload-migration/19a-top11-readiness.md
+++ b/docs/payload-migration/19a-top11-readiness.md
@@ -183,6 +183,22 @@ true`, no row cap (legacy pool runs ~57). Backfilled by re-running
 8. **The image+link Lexical block** and **weekly re-import cadence** from
    "What's next" above are both open, ongoing items — not one-time PRs.
 
+9. **Contest Controls tab's `/stats` scoreboard only shows this week's chart
+   `entries` (≤11 songs), not the full `nominees` pool (~56 songs).**
+   Verified during preview-branch parity testing: `/stats`
+   (`Top11Contests.ts`'s handler) correctly aggregates `voteCounts` across
+   _every_ nominee's votes, but `rankedSongs` — what the tab actually
+   renders — is built by mapping over `contest.entries` only, so any
+   nominee not already on last week's frozen top-11 chart has its vote
+   count computed but never displayed anywhere in the admin UI. A song like
+   this week's current leader can be sitting at zero visibility if it
+   wasn't in last week's top 11. The underlying vote data is correct — this
+   is a display gap, not a data-integrity bug — but it means nobody
+   (including Josh) can see this week's actual leaderboard while voting is
+   open, only after it becomes next week's `entries` snapshot. Fix: build
+   `rankedSongs` from `contest.nominees` instead of (or in addition to)
+   `contest.entries`.
+
 ## Decisions locked
 
 | Question                  | Decision                                                                                                                                                                                                                                                                             |

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "seed:mrm": "tsx --import ./bin/preload-nextenv-fix.mjs bin/seed-mrm.ts",
     "seed:mrm:fresh": "tsx --import ./bin/preload-nextenv-fix.mjs bin/seed-mrm-fresh.ts",
     "import:top11": "tsx --import ./bin/preload-nextenv-fix.mjs bin/migrations/importTop11.ts",
+    "import:top11-votes": "tsx --import ./bin/preload-nextenv-fix.mjs bin/migrations/importTop11Votes.ts",
     "seed:payload": "tsx bin/seed-payload.ts",
     "seed:legacy": "./bin/seed-legacy.sh",
     "seed": "yarn seed:payload && yarn seed:legacy",


### PR DESCRIPTION
## Summary
- Adds `bin/migrations/importTop11Votes.ts` (`yarn import:top11-votes`): imports only `top11-votes` rows for an already-existing Top11 contest, so `use_postgres_top11` can flip mid-contest without letting anyone who already voted this week vote again.
- **Cutover safety guarantee**: every row in legacy's `top11_user_votes` (the "this voter cast a ballot this week" registry) gets exactly one dedup-guard row under their real identity in `top11-votes` — including voters who only submitted a write-in with no checkbox picks. Legacy's `addVote()` (which feeds `top11songs.value`, the per-song counter) only runs when checkboxes are present, so a write-in-only voter has zero counted votes and would otherwise be invisible to `hasUserVotedThisWeek()` after cutover.
- **Exact per-song tally parity** (added in a follow-up fix after initial review): real-voter dedup rows are only ever assigned to a song with remaining headroom under its legacy `top11songs.value` target (`nextArbitrarySongId()` checks `targetCountBySong` before placing a row). An earlier version assigned voters round-robin with no headroom check, which could and did overcount specific songs — caught via manual song-for-song parity verification against a real production snapshot (4 of 56 songs off by a combined 7 votes). Also fixed a title-normalization gap (`"MOST NORMAL AMERICAN VOTER:"` vs. legacy's `"MOST NORMAL AMERICAN VOTER"` — trailing punctuation) that silently dropped one song's votes every run.
- **Verified end to end against real production data**: ran against a live prod MySQL snapshot (via SSH tunnel) into a disposable Neon preview branch forked from production. Final result: **56/56 nominees match exactly, 144 = 144 total votes.** Full comparison table available on request.
- Overflow case (more registered voters than legacy counted votes in total, e.g. all-write-in voters) is now logged loudly via `overflowAssignments` rather than silently — per-song accuracy is no longer guaranteed exact only in that edge case, and every run reports it if it happens.
- Idempotent by construction: on each run, existing row counts (not label matching) determine what's still needed, so it's safe to re-run every few minutes right up to the flag flip to minimize the cutover gap.
- Maps legacy nominees to Payload song ids by comparing against the contest's own `nominees` array (normalized title/artist text) rather than calling `findOrCreateArtist`/`findOrCreateSong` — those make MusicBrainz network calls per song and made an early version of this take 15+ seconds per nominee across the ~57-song pool, defeating the "run frequently" goal.

## Test plan
- [x] `yarn vitest run bin/migrations/importTop11Votes.test.ts` — 15 passing: every-voter-gets-a-row, write-in-only-voter coverage, idempotent re-run creates nothing new, no double-counting synthetic top-up rows, headroom-aware real-voter assignment never exceeds a song's legacy target, overflow reporting when voters exceed capacity, trailing-punctuation/case-insensitive title matching
- [x] `yarn eslint` clean
- [x] Ran against local Docker MySQL/Postgres end-to-end (idempotent skip verified)
- [x] Ran against real production MySQL (SSH tunnel) into a disposable preview Neon branch (forked from prod, verified isolated — writes confirmed not to affect prod). Song-for-song comparison script joined both datasets by normalized artist+song text: **56/56 exact match**, legacy `sum(value)` = preview total vote rows = 144.

## Also updates
- `docs/payload-migration/19a-top11-readiness.md`: logs a new fast-follow item — the Contest Controls tab's `/stats` scoreboard only renders `contest.entries` (last week's frozen top-11 chart), not the full `contest.nominees` pool, so a song's real vote count can be computed correctly but never shown anywhere in the admin UI if it wasn't already on last week's chart. Found during this PR's parity verification; display-only, not a data bug, but worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2