### PR TITLE
fix: Contest Controls scoreboard reads full nominee pool, not last week's chart

### DIFF
--- a/payload/src/collections/Top11Contests.test.ts
+++ b/payload/src/collections/Top11Contests.test.ts
@@ -217,7 +217,7 @@ describe('Top11Contests', () => {
       const findByID = vi.fn().mockResolvedValue({
         id: 1,
         status: 'closed',
-        entries: [],
+        nominees: [],
       });
       return {
         req: {
@@ -255,10 +255,52 @@ describe('Top11Contests', () => {
     });
   });
 
-  describe('/:id/stats rankedSongs displayOrder', () => {
+  describe('/:id/stats rankedSongs', () => {
     const statsEndpoint = Top11Contests.endpoints?.find((e) => e.path === '/:id/stats');
 
-    it('derives displayOrder from entries array position, not the hidden field', async () => {
+    it('builds rankedSongs from the full nominees pool, not entries', async () => {
+      // Regression: rankedSongs used to be built from contest.entries (last
+      // week's frozen top-11 chart, capped at 11 rows), so any nominee
+      // outside that set had its votes counted but never surfaced here.
+      // song 3 is a nominee that was never on last week's chart.
+      const find = vi.fn().mockImplementation(async ({ collection }: { collection: string }) => {
+        if (collection === 'songs') {
+          return {
+            docs: [
+              { id: 7, title: 'Song Seven', artist: { name: 'Artist A' } },
+              { id: 3, title: 'Song Three', artist: { name: 'Artist B' } },
+            ],
+          };
+        }
+        if (collection === 'top11-votes') {
+          return {
+            docs: [
+              { id: 1, song: 3 },
+              { id: 2, song: 3 },
+            ],
+          };
+        }
+        return { docs: [] };
+      });
+      const findByID = vi.fn().mockResolvedValue({
+        id: 1,
+        status: 'open',
+        entries: [{ song: 7 }],
+        nominees: [{ song: 7 }, { song: 3 }],
+      });
+      const req = {
+        user: { role: 'admin' },
+        routeParams: { id: '1' },
+        payload: { find, findByID },
+      };
+
+      const response = await statsEndpoint?.handler(req as never);
+      const body = await (response as Response).json();
+
+      expect(body.rankedSongs.map((row: { song: number }) => row.song)).toEqual([3, 7]);
+    });
+
+    it('derives displayOrder from vote-count rank, not nominees array position', async () => {
       const find = vi.fn().mockImplementation(async ({ collection }: { collection: string }) => {
         if (collection === 'songs') {
           return {
@@ -269,14 +311,22 @@ describe('Top11Contests', () => {
             ],
           };
         }
+        if (collection === 'top11-votes') {
+          // song 9 (listed last in nominees) has the most votes.
+          return {
+            docs: [
+              { id: 1, song: 9 },
+              { id: 2, song: 9 },
+              { id: 3, song: 7 },
+            ],
+          };
+        }
         return { docs: [] };
       });
-      // displayOrder is a hidden field, so a real read never includes it —
-      // this mock matches that runtime shape.
       const findByID = vi.fn().mockResolvedValue({
         id: 1,
-        status: 'closed',
-        entries: [{ song: 7 }, { song: 3 }, { song: 9 }],
+        status: 'open',
+        nominees: [{ song: 7 }, { song: 3 }, { song: 9 }],
       });
       const req = {
         user: { role: 'admin' },
@@ -289,27 +339,56 @@ describe('Top11Contests', () => {
 
       expect(body.rankedSongs).toEqual([
         {
+          song: 9,
+          songTitle: 'Song Nine',
+          songArtist: 'Artist C',
+          votes: 2,
+          displayOrder: 1,
+        },
+        {
           song: 7,
           songTitle: 'Song Seven',
           songArtist: 'Artist A',
-          displayOrder: 1,
-          votes: 0,
+          votes: 1,
+          displayOrder: 2,
         },
         {
           song: 3,
           songTitle: 'Song Three',
           songArtist: 'Artist B',
-          displayOrder: 2,
           votes: 0,
-        },
-        {
-          song: 9,
-          songTitle: 'Song Nine',
-          songArtist: 'Artist C',
           displayOrder: 3,
-          votes: 0,
         },
       ]);
+    });
+
+    it('breaks ties by song id for a stable sort', async () => {
+      const find = vi.fn().mockImplementation(async ({ collection }: { collection: string }) => {
+        if (collection === 'songs') {
+          return {
+            docs: [
+              { id: 9, title: 'Song Nine', artist: { name: 'Artist C' } },
+              { id: 3, title: 'Song Three', artist: { name: 'Artist B' } },
+            ],
+          };
+        }
+        return { docs: [] };
+      });
+      const findByID = vi.fn().mockResolvedValue({
+        id: 1,
+        status: 'open',
+        nominees: [{ song: 9 }, { song: 3 }],
+      });
+      const req = {
+        user: { role: 'admin' },
+        routeParams: { id: '1' },
+        payload: { find, findByID },
+      };
+
+      const response = await statsEndpoint?.handler(req as never);
+      const body = await (response as Response).json();
+
+      expect(body.rankedSongs.map((row: { song: number }) => row.song)).toEqual([3, 9]);
     });
 
     it('falls back gracefully when a song cannot be found', async () => {
@@ -317,7 +396,7 @@ describe('Top11Contests', () => {
       const findByID = vi.fn().mockResolvedValue({
         id: 1,
         status: 'closed',
-        entries: [{ song: 42 }],
+        nominees: [{ song: 42 }],
       });
       const req = {
         user: { role: 'admin' },
@@ -333,8 +412,8 @@ describe('Top11Contests', () => {
           song: 42,
           songTitle: null,
           songArtist: null,
-          displayOrder: 1,
           votes: 0,
+          displayOrder: 1,
         },
       ]);
     });

--- a/payload/src/collections/Top11Contests.ts
+++ b/payload/src/collections/Top11Contests.ts
@@ -22,6 +22,11 @@ type ContestEntry = {
   weeklyNote?: unknown;
 };
 
+type ContestNominee = {
+  id?: string;
+  song: number;
+};
+
 type ContestDoc = {
   id: number;
   status: string;
@@ -31,6 +36,7 @@ type ContestDoc = {
     priorWinnerLookbackContests?: number;
   };
   entries?: ContestEntry[];
+  nominees?: ContestNominee[];
   messageSnapshot?: unknown;
 };
 
@@ -404,7 +410,13 @@ export const Top11Contests: CollectionConfig = {
           voterKeys.add(voterKey);
         });
 
-        const songIds = (contest.entries ?? []).map((entry) => entry.song);
+        // Built from the full nominees pool (this week's ballot), not
+        // entries (last week's frozen top-11 chart) -- entries only has
+        // room for 11 songs, so any nominee outside that set would have its
+        // votes correctly counted above but never appear here. This is the
+        // live, this-week leaderboard; entries becomes next week's chart
+        // only once the contest closes.
+        const songIds = (contest.nominees ?? []).map((nominee) => nominee.song);
         const songs = songIds.length > 0
           ? await findAllDocs<SongDoc>({
             payload: req.payload,
@@ -417,22 +429,22 @@ export const Top11Contests: CollectionConfig = {
           : [];
         const songsById = new Map(songs.map((song) => [song.id, song]));
 
-        // displayOrder is a hidden field (excluded from reads), so use the
-        // entries array's own position as the display order instead of
-        // relying on the stored value.
-        const rankedSongs = (contest.entries ?? [])
-          .map((entry, index) => {
-            const song = songsById.get(entry.song);
+        // Ranked purely by current vote count -- there's no "last position"
+        // concept for a nominee pool the way there is for entries, so ties
+        // break by song id for a stable sort instead of a prior displayOrder.
+        const rankedSongs = (contest.nominees ?? [])
+          .map((nominee) => {
+            const song = songsById.get(nominee.song);
             const artistName = song?.artist && typeof song.artist === 'object' ? song.artist.name : undefined;
             return {
-              song: entry.song,
+              song: nominee.song,
               songTitle: song?.title ?? null,
               songArtist: artistName ?? null,
-              displayOrder: index + 1,
-              votes: voteCounts.get(entry.song) ?? 0,
+              votes: voteCounts.get(nominee.song) ?? 0,
             };
           })
-          .sort((a, b) => b.votes - a.votes || a.displayOrder - b.displayOrder);
+          .sort((a, b) => b.votes - a.votes || a.song - b.song)
+          .map((row, index) => ({ ...row, displayOrder: index + 1 }));
 
         const newsletterOnlyCount = contestants.filter(
           (contestant) => contestant.newsletterOptIn,


### PR DESCRIPTION
## Summary
- `/:id/stats` (used by the admin Contest Controls tab) built `rankedSongs` from `contest.entries` — last week's frozen top-11 chart, capped at 11 rows — even though `voteCounts` was correctly aggregated across every vote, which references `contest.nominees` (this week's full ~50-60 song ballot). Any nominee not already on last week's chart had its vote count computed correctly but never shown anywhere in the admin UI.
- Found during PR #835's (Top11 votes-only import) parity verification: Death Cab For Cutie's "Riptides" had 14 real, correctly-counted votes that never appeared in the Contest Controls tab because it wasn't part of last week's chart.
- `rankedSongs` now builds from `contest.nominees`. `displayOrder` is now the actual votes-sorted rank (ties broken by song id) instead of carrying over `entries`' array-position semantics, which is more correct for a live, this-week leaderboard.

## Test plan
- [x] `yarn vitest run payload/src/collections/Top11Contests.test.ts` — 107 passing, including 3 new/rewritten tests: rankedSongs now sourced from nominees (regression test using a nominee outside `entries`), displayOrder derives from vote-count rank not array position, ties break by song id
- [x] `yarn vitest run payload/src/features/top11/Top11ContestControlsPanels.test.tsx` — 60 passing, unaffected (component only consumes the API response shape)
- [x] `yarn eslint` clean
- [x] **Verified on a live preview deploy** against a real production Neon snapshot with 144 real votes across 56 nominees: the fixed scoreboard shows all 56 songs ranked by vote count, with "Death Cab For Cutie — Riptides" (14 votes) correctly at #1 — the exact song that was previously invisible. Screenshots attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014f8RBMFtQZE7JRA7fJGDi2